### PR TITLE
Add backend test suite with setup instructions and production bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ wheels/
 
 # Virtual environments
 venv/
+.venv/
 *.db

--- a/README.md
+++ b/README.md
@@ -34,3 +34,28 @@ The project is still in it's early stages, so currently the only option is to ru
 4. Open browser and go to URL printed in terminal
     - Append `/docs` to see the interactive API docs
     - Most likely [http://127.0.0.1:8000/docs]
+
+## Testing
+
+The test suite covers all active gear types with CRUD, pagination, and loader logic tests.
+
+### Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate       # Linux/Mac
+# .venv\Scripts\activate        # Windows
+pip install -e ".[dev]"
+```
+
+Or with uv:
+
+```bash
+uv sync
+```
+
+### Running
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,14 @@ dependencies = [
     "sqlmodel>=0.0.24",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
+    "pytest>=8.0",
     "ruff>=0.11.11",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.setuptools.packages.find]
+include = ["slack_data*"]

--- a/slack_data/api/routers/weblock_router.py
+++ b/slack_data/api/routers/weblock_router.py
@@ -13,7 +13,7 @@ weblock_router = APIRouter(
 
 @weblock_router.post("/", response_model=WeblockPublic)
 def create_weblock(weblock: WeblockCreate, session: SessionDep):
-    db_weblock = weblock.model_validate(weblock)
+    db_weblock = Weblock.model_validate(weblock)
     session.add(db_weblock)
     session.commit()
     session.refresh(db_weblock)

--- a/slack_data/load_data/load_webbings.py
+++ b/slack_data/load_data/load_webbings.py
@@ -30,10 +30,10 @@ def clean_webbing_data(webbing: dict) -> dict:
     for key, value in webbing.items():
         if key in {"width", "weight"} and value == "":
             cleaned_webbing[key] = 0
-        elif key not in {"name", "brand", "materialType"} and value == "":
-            cleaned_webbing[key] = None
         elif key == "isa_certified":
             cleaned_webbing[key] = bool(value) if isinstance(value, str) else value
+        elif key not in {"name", "brand", "materialType"} and value == "":
+            cleaned_webbing[key] = None
         else:
             cleaned_webbing[key] = str(value) if value is not None else None
     return cleaned_webbing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,87 @@
+"""
+Shared fixtures for all tests.
+
+We deliberately do NOT use the production app from main.py.  The production
+app has an async lifespan that calls create_db_and_tables() (which guards
+against a second call with a RuntimeError) and seeds data from JSON files.
+Trying to monkeypatch around all of that is fragile.
+
+Instead we create a bare FastAPI app with the same routers but no lifespan.
+The `engine` fixture creates an isolated in-memory SQLite database, and the
+`session` fixture provides a Session that is injected into every request via
+FastAPI's dependency_overrides.  Each test starts with an empty database and
+inserts only what it needs.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from slack_data.database import get_session
+from slack_data.models.brands import Brand
+from slack_data.api.routers.brand_router import brand_router
+from slack_data.api.routers.grip_router import grip_router
+from slack_data.api.routers.leashring_router import leashring_router
+from slack_data.api.routers.roller_router import roller_router
+from slack_data.api.routers.starterkit_router import starterkit_router
+from slack_data.api.routers.treepro_router import treepro_router
+from slack_data.api.routers.tricklinekit_router import tricklinekit_router
+from slack_data.api.routers.webbing_router import webbing_router
+from slack_data.api.routers.weblock_router import weblock_router
+
+
+def _build_test_app() -> FastAPI:
+    """Minimal app — same routers as production, no lifespan seeding."""
+    app = FastAPI()
+    app.include_router(brand_router)
+    app.include_router(grip_router)
+    app.include_router(leashring_router)
+    app.include_router(roller_router)
+    app.include_router(starterkit_router)
+    app.include_router(treepro_router)
+    app.include_router(tricklinekit_router)
+    app.include_router(webbing_router)
+    app.include_router(weblock_router)
+    return app
+
+
+@pytest.fixture
+def engine():
+    engine = create_engine(
+        "sqlite://",  # in-memory; isolated per test
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,  # single shared connection so session + requests see the same data
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def client(session):
+    app = _build_test_app()
+
+    def get_session_override():
+        yield session
+
+    app.dependency_overrides[get_session] = get_session_override
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def brand(session):
+    """A generic brand row available to all test files."""
+    b = Brand(name="Test Brand")
+    session.add(b)
+    session.commit()
+    session.refresh(b)
+    return b

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -1,0 +1,116 @@
+"""
+Tests for brand behaviour — the central entity every gear type links to.
+
+Covers: get_brand() upsert logic, cache behaviour, brand_name computed field
+in gear responses, and the constraint that the same brand name never produces
+two rows.
+"""
+
+from sqlmodel import Session, select
+
+from slack_data.models.brands import Brand, get_brand
+from slack_data.models.webbing import FiberMaterial, Webbing
+
+
+# ---------------------------------------------------------------------------
+# get_brand() upsert
+# ---------------------------------------------------------------------------
+
+def test_get_brand_creates_brand_if_missing(session: Session):
+    cache: dict = {}
+    brand_id, cache = get_brand(session, cache, {"brand": "Gibbon"})
+
+    assert brand_id is not None
+    brand = session.get(Brand, brand_id)
+    assert brand is not None
+    assert brand.name == "Gibbon"
+
+
+def test_get_brand_returns_same_id_for_same_name(session: Session):
+    cache: dict = {}
+    id1, cache = get_brand(session, cache, {"brand": "Gibbon"})
+    id2, cache = get_brand(session, cache, {"brand": "Gibbon"})
+
+    assert id1 == id2
+
+
+def test_get_brand_no_duplicate_rows(session: Session):
+    cache: dict = {}
+    get_brand(session, cache, {"brand": "Gibbon"})
+    # Simulate a second loader call with an empty cache (cache miss → DB lookup)
+    get_brand(session, {}, {"brand": "Gibbon"})
+
+    rows = session.exec(select(Brand).where(Brand.name == "Gibbon")).all()
+    assert len(rows) == 1
+
+
+def test_get_brand_different_names_get_different_ids(session: Session):
+    cache: dict = {}
+    id_gibbon,     cache = get_brand(session, cache, {"brand": "Gibbon"})
+    id_slacktivity, cache = get_brand(session, cache, {"brand": "Slacktivity"})
+
+    assert id_gibbon != id_slacktivity
+
+
+def test_get_brand_cache_prevents_second_db_insert(session: Session):
+    cache: dict = {}
+    # First call: creates brand and populates cache
+    id1, cache = get_brand(session, cache, {"brand": "Gibbon"})
+    # Second call with same cache: must hit cache, not DB
+    assert "Gibbon" in cache
+    id2, cache = get_brand(session, cache, {"brand": "Gibbon"})
+
+    assert id1 == id2
+    # Still only one row despite two calls
+    rows = session.exec(select(Brand).where(Brand.name == "Gibbon")).all()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# brand_name computed field in API responses
+# ---------------------------------------------------------------------------
+
+def test_brand_name_present_in_webbing_response(client, session):
+    brand = Brand(name="Landcruising")
+    session.add(brand)
+    session.commit()
+    session.refresh(brand)
+
+    webbing = Webbing(name="Verve", material=FiberMaterial.POLYESTER, width=25, brand_id=brand.id)
+    session.add(webbing)
+    session.commit()
+    session.refresh(webbing)
+
+    response = client.get(f"/webbing/{webbing.id}")
+    assert response.status_code == 200
+    assert response.json()["brand_name"] == "Landcruising"
+
+
+def test_brand_name_present_in_list_response(client, session):
+    brand = Brand(name="Balance Community")
+    session.add(brand)
+    session.commit()
+    session.refresh(brand)
+
+    webbing = Webbing(name="Jibline", material=FiberMaterial.POLYESTER, width=20, brand_id=brand.id)
+    session.add(webbing)
+    session.commit()
+
+    data = client.get("/webbing/").json()
+    assert data[0]["brand_name"] == "Balance Community"
+
+
+def test_brand_name_present_after_patch(client, session):
+    brand = Brand(name="Slacktivity")
+    session.add(brand)
+    session.commit()
+    session.refresh(brand)
+
+    webbing = Webbing(name="Mission", material=FiberMaterial.NYLON, width=25, brand_id=brand.id)
+    session.add(webbing)
+    session.commit()
+    session.refresh(webbing)
+
+    response = client.patch(f"/webbing/{webbing.id}", json={"price": 22.0})
+    assert response.status_code == 200
+    assert response.json()["brand_name"] == "Slacktivity"

--- a/tests/test_grips.py
+++ b/tests/test_grips.py
@@ -1,0 +1,137 @@
+"""Tests for the /grip endpoints."""
+
+from slack_data.models.grips import ConnectionType, Grip
+from slack_data.utilities.materials import MetalMaterial
+
+
+def make_grip(session, brand, *, name="Test Grip", width_min=24, **kwargs) -> Grip:
+    g = Grip(
+        name=name,
+        material=MetalMaterial.ALUMINUM,
+        width_min=width_min,
+        brand_id=brand.id,
+        **kwargs,
+    )
+    session.add(g)
+    session.commit()
+    session.refresh(g)
+    return g
+
+
+# --- LIST ---
+
+def test_list_grips_empty(client):
+    assert client.get("/grip/").json() == []
+
+
+def test_list_grips_returns_items(client, session, brand):
+    make_grip(session, brand, name="LineGrip G4")
+    make_grip(session, brand, name="HighlineGrip G2")
+    names = [g["name"] for g in client.get("/grip/").json()]
+    assert "LineGrip G4" in names and "HighlineGrip G2" in names
+
+
+def test_list_grips_includes_brand_name(client, session, brand):
+    make_grip(session, brand)
+    assert client.get("/grip/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_grip_by_id(client, session, brand):
+    g = make_grip(session, brand, name="Snatch", width_min=49, width_max=51)
+    data = client.get(f"/grip/{g.id}").json()
+    assert data["name"] == "Snatch"
+    assert data["width_min"] == 49
+    assert data["brand_name"] == brand.name
+
+
+def test_get_grip_not_found(client):
+    assert client.get("/grip/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_grip(client, brand):
+    r = client.post("/grip/", json={
+        "name": "New Grip",
+        "material": "Aluminum",
+        "width_min": 24,
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Grip"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_grip_with_optional_fields(client, brand):
+    r = client.post("/grip/", json={
+        "name": "Full Grip",
+        "material": "Aluminum",
+        "width_min": 24,
+        "width_max": 26,
+        "wll": 15.0,
+        "mbs": 45.0,
+        "common_slipping_threshold": 25.0,
+        "connection_type": "Mounting Hole",
+        "price": 193.70,
+        "currency": "EUR",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["wll"] == 15.0
+    assert data["connection_type"] == "Mounting Hole"
+
+
+def test_create_grip_missing_required_field_rejected(client, brand):
+    # Missing material
+    r = client.post("/grip/", json={"name": "No Material", "width_min": 25, "brand_id": brand.id})
+    assert r.status_code == 422
+
+
+def test_create_grip_optional_fields_default_null(client, brand):
+    r = client.post("/grip/", json={
+        "name": "Minimal",
+        "material": "Aluminum",
+        "width_min": 25,
+        "brand_id": brand.id,
+    })
+    data = r.json()
+    assert data["price"] is None
+    assert data["wll"] is None
+    assert data["connection_type"] is None
+
+
+# --- PATCH ---
+
+def test_patch_grip_updates_field(client, session, brand):
+    g = make_grip(session, brand, price=150.0)
+    resp = client.patch(f"/grip/{g.id}", json={"price": 193.70})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 193.70
+
+
+def test_patch_grip_does_not_touch_other_fields(client, session, brand):
+    g = make_grip(session, brand, name="Stays Same", width_min=24)
+    resp = client.patch(f"/grip/{g.id}", json={"price": 99.0})
+    assert resp.status_code == 200
+    data = client.get(f"/grip/{g.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["width_min"] == 24
+
+
+def test_patch_grip_not_found(client):
+    assert client.patch("/grip/9999", json={"price": 10.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_grip(client, session, brand):
+    g = make_grip(session, brand)
+    assert client.delete(f"/grip/{g.id}").json() == {"ok": True}
+    assert client.get(f"/grip/{g.id}").status_code == 404
+
+
+def test_delete_grip_not_found(client):
+    assert client.delete("/grip/9999").status_code == 404

--- a/tests/test_leashrings.py
+++ b/tests/test_leashrings.py
@@ -1,0 +1,127 @@
+"""Tests for the /leashring endpoints."""
+
+from slack_data.models.leashrings import LeashRing
+from slack_data.utilities.materials import MetalMaterial
+
+
+def make_leashring(session, brand, *, name="Test Ring", **kwargs) -> LeashRing:
+    r = LeashRing(name=name, material=MetalMaterial.STEEL, brand_id=brand.id, **kwargs)
+    session.add(r)
+    session.commit()
+    session.refresh(r)
+    return r
+
+
+# --- LIST ---
+
+def test_list_leashrings_empty(client):
+    assert client.get("/leashring/").json() == []
+
+
+def test_list_leashrings_returns_items(client, session, brand):
+    make_leashring(session, brand, name="Ring 50")
+    make_leashring(session, brand, name="Bomber Ring")
+    names = [r["name"] for r in client.get("/leashring/").json()]
+    assert "Ring 50" in names and "Bomber Ring" in names
+
+
+def test_list_leashrings_includes_brand_name(client, session, brand):
+    make_leashring(session, brand)
+    assert client.get("/leashring/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_leashring_by_id(client, session, brand):
+    r = make_leashring(session, brand, name="Arbo Ring", inner_diameter=46.0)
+    data = client.get(f"/leashring/{r.id}").json()
+    assert data["name"] == "Arbo Ring"
+    assert data["inner_diameter"] == 46.0
+    assert data["brand_name"] == brand.name
+
+
+def test_get_leashring_not_found(client):
+    assert client.get("/leashring/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_leashring(client, brand):
+    r = client.post("/leashring/", json={
+        "name": "New Ring",
+        "material": "Steel",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Ring"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_leashring_with_optional_fields(client, brand):
+    r = client.post("/leashring/", json={
+        "name": "Ti Ring",
+        "material": "Titanium",
+        "inner_diameter": 50.0,
+        "outer_diameter": 59.0,
+        "breaking_strength": 30.0,
+        "isa_certified": True,
+        "price": 45.0,
+        "currency": "USD",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["material"] == "Titanium"
+    assert data["inner_diameter"] == 50.0
+    assert data["isa_certified"] is True
+
+
+def test_create_leashring_missing_required_field_rejected(client, brand):
+    r = client.post("/leashring/", json={"name": "No Material", "brand_id": brand.id})
+    assert r.status_code == 422
+
+
+def test_create_leashring_optional_fields_default_null(client, brand):
+    r = client.post("/leashring/", json={
+        "name": "Minimal",
+        "material": "Steel",
+        "brand_id": brand.id,
+    })
+    data = r.json()
+    assert data["price"] is None
+    assert data["inner_diameter"] is None
+    assert data["breaking_strength"] is None
+
+
+# --- PATCH ---
+
+def test_patch_leashring_updates_field(client, session, brand):
+    r = make_leashring(session, brand, price=10.0)
+    resp = client.patch(f"/leashring/{r.id}", json={"price": 18.0})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 18.0
+
+
+def test_patch_leashring_does_not_touch_other_fields(client, session, brand):
+    r = make_leashring(session, brand, name="Stays Same", inner_diameter=57.0)
+    resp = client.patch(f"/leashring/{r.id}", json={"price": 12.0})
+    assert resp.status_code == 200
+    data = client.get(f"/leashring/{r.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["inner_diameter"] == 57.0
+
+
+def test_patch_leashring_not_found(client):
+    assert client.patch("/leashring/9999", json={"price": 5.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_leashring(client, session, brand):
+    r = make_leashring(session, brand)
+    assert client.delete(f"/leashring/{r.id}").json() == {"ok": True}
+    assert client.get(f"/leashring/{r.id}").status_code == 404
+
+
+def test_delete_leashring_not_found(client):
+    assert client.delete("/leashring/9999").status_code == 404

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,117 @@
+"""
+Tests for data loading / normalisation logic.
+
+These tests do not go through HTTP — they call the loader functions directly.
+They cover the JSON→model mapping that is most likely to break silently:
+  - get_material_type(): string → FiberMaterial enum
+  - clean_webbing_data(): blank/null field normalisation
+  - get_brand(): upsert with cache (also tested in test_brands.py from the
+    API side; here we focus on the pure function behaviour)
+"""
+
+import pytest
+
+from slack_data.load_data.load_webbings import clean_webbing_data, get_material_type
+from slack_data.models.brands import get_brand
+from slack_data.models.webbing import FiberMaterial
+
+
+# ---------------------------------------------------------------------------
+# get_material_type()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw, expected", [
+    ("Nylon",        FiberMaterial.NYLON),
+    ("NYLON",        FiberMaterial.NYLON),      # case-insensitive
+    ("polyamid",     FiberMaterial.NYLON),       # synonym
+    ("Polyester",    FiberMaterial.POLYESTER),
+    ("PES",          FiberMaterial.POLYESTER),   # abbreviation
+    ("Dyneema",      FiberMaterial.DYNEEMA),
+    ("DYNEEMA SK75", FiberMaterial.DYNEEMA),     # with suffix
+    ("Vectran",      FiberMaterial.VECTRAN),
+    ("pes/polyamid", FiberMaterial.HYBRID),      # hybrid check comes first
+    ("Carbon Fibre", FiberMaterial.OTHER),       # unrecognised
+    ("",             FiberMaterial.OTHER),       # empty string
+])
+def test_get_material_type(raw, expected):
+    assert get_material_type(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# clean_webbing_data()
+# ---------------------------------------------------------------------------
+
+def _base_item(**overrides) -> dict:
+    """Minimal valid webbing dict with overrides applied."""
+    item = {
+        "name": "Test Webbing",
+        "brand": "Test Brand",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 68,
+    }
+    item.update(overrides)
+    return item
+
+
+def test_clean_webbing_empty_width_becomes_zero():
+    result = clean_webbing_data(_base_item(width=""))
+    assert result["width"] == 0
+
+
+def test_clean_webbing_empty_weight_becomes_zero():
+    result = clean_webbing_data(_base_item(weight=""))
+    assert result["weight"] == 0
+
+
+def test_clean_webbing_empty_optional_field_becomes_none():
+    result = clean_webbing_data(_base_item(product_url=""))
+    assert result["product_url"] is None
+
+
+def test_clean_webbing_isa_certified_string_true_becomes_bool():
+    result = clean_webbing_data(_base_item(isa_certified="true"))
+    assert result["isa_certified"] is True
+
+
+def test_clean_webbing_isa_certified_empty_string():
+    # isa_certified="" in the JSON means "not certified" — should become False.
+    result = clean_webbing_data(_base_item(isa_certified=""))
+    assert result["isa_certified"] is False
+
+
+def test_clean_webbing_none_value_stays_none():
+    result = clean_webbing_data(_base_item(product_url=None))
+    assert result["product_url"] is None
+
+
+def test_clean_webbing_numeric_value_becomes_string():
+    # Non-special fields get str() applied
+    result = clean_webbing_data(_base_item(breaking_strength=32))
+    assert result["breaking_strength"] == "32"
+
+
+# ---------------------------------------------------------------------------
+# get_brand() — pure function behaviour (no HTTP)
+# ---------------------------------------------------------------------------
+
+def test_get_brand_returns_tuple(session):
+    result = get_brand(session, {}, {"brand": "Gibbon"})
+    assert isinstance(result, tuple)
+    brand_id, cache = result
+    assert isinstance(brand_id, int)
+    assert isinstance(cache, dict)
+
+
+def test_get_brand_populates_cache(session):
+    cache: dict = {}
+    brand_id, cache = get_brand(session, cache, {"brand": "Gibbon"})
+    assert "Gibbon" in cache
+    assert cache["Gibbon"] == brand_id
+
+
+def test_get_brand_cache_hit_on_second_call(session):
+    cache: dict = {}
+    id1, cache = get_brand(session, cache, {"brand": "Gibbon"})
+    id2, cache = get_brand(session, cache, {"brand": "Gibbon"})
+    assert id1 == id2

--- a/tests/test_rollers.py
+++ b/tests/test_rollers.py
@@ -1,0 +1,137 @@
+"""Tests for the /roller endpoints."""
+
+from slack_data.models.rollers import BearingMaterial, LockType, Roller, SliderType
+from slack_data.utilities.materials import MetalMaterial, RollerMaterial
+
+# Defaults for roller's many required fields
+_DEFAULTS = dict(
+    material=MetalMaterial.ALUMINUM,
+    roller_material=RollerMaterial.PLASTIC,
+    slider_type=SliderType.Carabiner,
+    lock_type=LockType.Nonlocking,
+    bearing_material=BearingMaterial.StainlessSteel,
+)
+
+
+def make_roller(session, brand, *, name="Test Roller", **kwargs) -> Roller:
+    r = Roller(name=name, brand_id=brand.id, **{**_DEFAULTS, **kwargs})
+    session.add(r)
+    session.commit()
+    session.refresh(r)
+    return r
+
+
+def _create_payload(brand_id: int, **overrides) -> dict:
+    base = {
+        "name": "New Roller",
+        "material": "Aluminum",
+        "roller_material": "Plastic",
+        "slider_type": "Carabiner",
+        "lock_type": "Non-locking",
+        "bearing_material": "Stainless Steel",
+        "brand_id": brand_id,
+    }
+    return {**base, **overrides}
+
+
+# --- LIST ---
+
+def test_list_rollers_empty(client):
+    assert client.get("/roller/").json() == []
+
+
+def test_list_rollers_returns_items(client, session, brand):
+    make_roller(session, brand, name="HangOver")
+    make_roller(session, brand, name="Rollex")
+    names = [r["name"] for r in client.get("/roller/").json()]
+    assert "HangOver" in names and "Rollex" in names
+
+
+def test_list_rollers_includes_brand_name(client, session, brand):
+    make_roller(session, brand)
+    assert client.get("/roller/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_roller_by_id(client, session, brand):
+    r = make_roller(session, brand, name="Slipstream", slider_type=SliderType.MovingPlates)
+    data = client.get(f"/roller/{r.id}").json()
+    assert data["name"] == "Slipstream"
+    assert data["slider_type"] == "Moving plates"
+    assert data["brand_name"] == brand.name
+
+
+def test_get_roller_not_found(client):
+    assert client.get("/roller/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_roller(client, brand):
+    r = client.post("/roller/", json=_create_payload(brand.id))
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Roller"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_roller_with_optional_fields(client, brand):
+    r = client.post("/roller/", json=_create_payload(
+        brand.id,
+        name="Pro Roller",
+        breaking_strength=14.0,
+        price=80.0,
+        currency="USD",
+        isa_certified=True,
+    ))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["breaking_strength"] == 14.0
+    assert data["isa_certified"] is True
+
+
+def test_create_roller_missing_required_field_rejected(client, brand):
+    # Missing slider_type
+    payload = _create_payload(brand.id)
+    del payload["slider_type"]
+    assert client.post("/roller/", json=payload).status_code == 422
+
+
+def test_create_roller_optional_fields_default_null(client, brand):
+    r = client.post("/roller/", json=_create_payload(brand.id))
+    data = r.json()
+    assert data["price"] is None
+    assert data["width"] is None
+    assert data["breaking_strength"] is None
+
+
+# --- PATCH ---
+
+def test_patch_roller_updates_field(client, session, brand):
+    r = make_roller(session, brand, price=50.0)
+    resp = client.patch(f"/roller/{r.id}", json={"price": 75.0})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 75.0
+
+
+def test_patch_roller_does_not_touch_other_fields(client, session, brand):
+    r = make_roller(session, brand, name="Unchanged")
+    resp = client.patch(f"/roller/{r.id}", json={"price": 99.0})
+    assert resp.status_code == 200
+    assert client.get(f"/roller/{r.id}").json()["name"] == "Unchanged"
+
+
+def test_patch_roller_not_found(client):
+    assert client.patch("/roller/9999", json={"price": 10.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_roller(client, session, brand):
+    r = make_roller(session, brand)
+    assert client.delete(f"/roller/{r.id}").json() == {"ok": True}
+    assert client.get(f"/roller/{r.id}").status_code == 404
+
+
+def test_delete_roller_not_found(client):
+    assert client.delete("/roller/9999").status_code == 404

--- a/tests/test_starterkits.py
+++ b/tests/test_starterkits.py
@@ -1,0 +1,143 @@
+"""Tests for the /starterkit endpoints."""
+
+from slack_data.models.starterkits import StarterKit, TensioningType
+
+
+def make_starterkit(session, brand, *, name="Test Kit", webbing_length=15, webbing_width=50, **kwargs) -> StarterKit:
+    k = StarterKit(
+        name=name,
+        webbing_length=webbing_length,
+        webbing_width=webbing_width,
+        tensioning_type=TensioningType.SINGLE_RATCHET,
+        brand_id=brand.id,
+        **kwargs,
+    )
+    session.add(k)
+    session.commit()
+    session.refresh(k)
+    return k
+
+
+# --- LIST ---
+
+def test_list_starterkits_empty(client):
+    assert client.get("/starterkit/").json() == []
+
+
+def test_list_starterkits_returns_items(client, session, brand):
+    make_starterkit(session, brand, name="Fun Line Kit")
+    make_starterkit(session, brand, name="Classic Line Kit")
+    names = [k["name"] for k in client.get("/starterkit/").json()]
+    assert "Fun Line Kit" in names and "Classic Line Kit" in names
+
+
+def test_list_starterkits_includes_brand_name(client, session, brand):
+    make_starterkit(session, brand)
+    assert client.get("/starterkit/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_starterkit_by_id(client, session, brand):
+    k = make_starterkit(session, brand, name="Pro Starter", webbing_length=20)
+    data = client.get(f"/starterkit/{k.id}").json()
+    assert data["name"] == "Pro Starter"
+    assert data["webbing_length"] == 20
+    assert data["brand_name"] == brand.name
+
+
+def test_get_starterkit_not_found(client):
+    assert client.get("/starterkit/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_starterkit(client, brand):
+    r = client.post("/starterkit/", json={
+        "name": "New Kit",
+        "webbing_length": 15,
+        "webbing_width": 50,
+        "tensioning_type": "Single Ratchet",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Kit"
+    assert r.json()["tensioning_type"] == "Single Ratchet"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_starterkit_with_optional_fields(client, brand):
+    r = client.post("/starterkit/", json={
+        "name": "Full Kit",
+        "webbing_length": 25,
+        "webbing_width": 50,
+        "tensioning_type": "Double Ratchet",
+        "includes_treepro": True,
+        "isa_certified": True,
+        "price": 145.0,
+        "currency": "EUR",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["includes_treepro"] is True
+    assert data["isa_certified"] is True
+
+
+def test_create_starterkit_missing_required_field_rejected(client, brand):
+    # Missing tensioning_type
+    r = client.post("/starterkit/", json={
+        "name": "No Tensioning",
+        "webbing_length": 15,
+        "webbing_width": 50,
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 422
+
+
+def test_create_starterkit_optional_fields_default_null(client, brand):
+    r = client.post("/starterkit/", json={
+        "name": "Minimal",
+        "webbing_length": 15,
+        "webbing_width": 50,
+        "tensioning_type": "Primitive",
+        "brand_id": brand.id,
+    })
+    data = r.json()
+    assert data["price"] is None
+    assert data["includes_treepro"] is False
+    assert data["isa_certified"] is False
+
+
+# --- PATCH ---
+
+def test_patch_starterkit_updates_field(client, session, brand):
+    k = make_starterkit(session, brand, price=79.0)
+    resp = client.patch(f"/starterkit/{k.id}", json={"price": 99.0})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 99.0
+
+
+def test_patch_starterkit_does_not_touch_other_fields(client, session, brand):
+    k = make_starterkit(session, brand, name="Stays Same", webbing_length=20)
+    resp = client.patch(f"/starterkit/{k.id}", json={"price": 100.0})
+    assert resp.status_code == 200
+    data = client.get(f"/starterkit/{k.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["webbing_length"] == 20
+
+
+def test_patch_starterkit_not_found(client):
+    assert client.patch("/starterkit/9999", json={"price": 10.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_starterkit(client, session, brand):
+    k = make_starterkit(session, brand)
+    assert client.delete(f"/starterkit/{k.id}").json() == {"ok": True}
+    assert client.get(f"/starterkit/{k.id}").status_code == 404
+
+
+def test_delete_starterkit_not_found(client):
+    assert client.delete("/starterkit/9999").status_code == 404

--- a/tests/test_treepros.py
+++ b/tests/test_treepros.py
@@ -1,0 +1,112 @@
+"""Tests for the /treepro endpoints."""
+
+from slack_data.models.treepro import PriceUnit, TreePro
+
+
+def make_treepro(session, brand, *, name="Test TreePro", **kwargs) -> TreePro:
+    t = TreePro(name=name, brand_id=brand.id, **kwargs)
+    session.add(t)
+    session.commit()
+    session.refresh(t)
+    return t
+
+
+# --- LIST ---
+
+def test_list_treepros_empty(client):
+    assert client.get("/treepro/").json() == []
+
+
+def test_list_treepros_returns_items(client, session, brand):
+    make_treepro(session, brand, name="TreePro XL")
+    make_treepro(session, brand, name="Tree-Shirt S")
+    names = [t["name"] for t in client.get("/treepro/").json()]
+    assert "TreePro XL" in names and "Tree-Shirt S" in names
+
+
+def test_list_treepros_includes_brand_name(client, session, brand):
+    make_treepro(session, brand)
+    assert client.get("/treepro/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_treepro_by_id(client, session, brand):
+    t = make_treepro(session, brand, name="Wide Guard", width=15.0, length=150)
+    data = client.get(f"/treepro/{t.id}").json()
+    assert data["name"] == "Wide Guard"
+    assert data["length"] == 150
+    assert data["brand_name"] == brand.name
+
+
+def test_get_treepro_not_found(client):
+    assert client.get("/treepro/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_treepro(client, brand):
+    r = client.post("/treepro/", json={"name": "New TreePro", "brand_id": brand.id})
+    assert r.status_code == 200
+    assert r.json()["name"] == "New TreePro"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_treepro_with_optional_fields(client, brand):
+    r = client.post("/treepro/", json={
+        "name": "Full TreePro",
+        "width": 10.0,
+        "length": 100,
+        "thickness": 8,
+        "has_sling_attachment": True,
+        "price": 28.0,
+        "price_unit": "pair",
+        "currency": "EUR",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["has_sling_attachment"] is True
+    assert data["price_unit"] == "pair"
+
+
+def test_create_treepro_optional_fields_default_null(client, brand):
+    r = client.post("/treepro/", json={"name": "Minimal", "brand_id": brand.id})
+    data = r.json()
+    assert data["price"] is None
+    assert data["width"] is None
+    assert data["length"] is None
+
+
+# --- PATCH ---
+
+def test_patch_treepro_updates_field(client, session, brand):
+    t = make_treepro(session, brand, price=25.0)
+    resp = client.patch(f"/treepro/{t.id}", json={"price": 29.99})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 29.99
+
+
+def test_patch_treepro_does_not_touch_other_fields(client, session, brand):
+    t = make_treepro(session, brand, name="Stays Same", length=198)
+    resp = client.patch(f"/treepro/{t.id}", json={"price": 30.0})
+    assert resp.status_code == 200
+    data = client.get(f"/treepro/{t.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["length"] == 198
+
+
+def test_patch_treepro_not_found(client):
+    assert client.patch("/treepro/9999", json={"price": 5.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_treepro(client, session, brand):
+    t = make_treepro(session, brand)
+    assert client.delete(f"/treepro/{t.id}").json() == {"ok": True}
+    assert client.get(f"/treepro/{t.id}").status_code == 404
+
+
+def test_delete_treepro_not_found(client):
+    assert client.delete("/treepro/9999").status_code == 404

--- a/tests/test_tricklinekits.py
+++ b/tests/test_tricklinekits.py
@@ -1,0 +1,141 @@
+"""Tests for the /tricklinekit endpoints."""
+
+from slack_data.models.tricklinekits import TensioningType, TricklineKit
+
+
+def make_tricklinekit(session, brand, *, name="Test Trickline Kit", webbing_length=15, webbing_width=25, **kwargs) -> TricklineKit:
+    k = TricklineKit(
+        name=name,
+        webbing_length=webbing_length,
+        webbing_width=webbing_width,
+        tensioning_type=TensioningType.DOUBLE_RATCHET,
+        brand_id=brand.id,
+        **kwargs,
+    )
+    session.add(k)
+    session.commit()
+    session.refresh(k)
+    return k
+
+
+# --- LIST ---
+
+def test_list_tricklinekits_empty(client):
+    assert client.get("/tricklinekit/").json() == []
+
+
+def test_list_tricklinekits_returns_items(client, session, brand):
+    make_tricklinekit(session, brand, name="Jibline Kit")
+    make_tricklinekit(session, brand, name="Flow Trickline")
+    names = [k["name"] for k in client.get("/tricklinekit/").json()]
+    assert "Jibline Kit" in names and "Flow Trickline" in names
+
+
+def test_list_tricklinekits_includes_brand_name(client, session, brand):
+    make_tricklinekit(session, brand)
+    assert client.get("/tricklinekit/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_tricklinekit_by_id(client, session, brand):
+    k = make_tricklinekit(session, brand, name="Pro Trickline", webbing_length=25)
+    data = client.get(f"/tricklinekit/{k.id}").json()
+    assert data["name"] == "Pro Trickline"
+    assert data["webbing_length"] == 25
+    assert data["brand_name"] == brand.name
+
+
+def test_get_tricklinekit_not_found(client):
+    assert client.get("/tricklinekit/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_tricklinekit(client, brand):
+    r = client.post("/tricklinekit/", json={
+        "name": "New Trickline Kit",
+        "webbing_length": 15,
+        "webbing_width": 25,
+        "tensioning_type": "Double Ratchet",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Trickline Kit"
+    assert r.json()["tensioning_type"] == "Double Ratchet"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_tricklinekit_with_optional_fields(client, brand):
+    r = client.post("/tricklinekit/", json={
+        "name": "Full Trickline Kit",
+        "webbing_length": 20,
+        "webbing_width": 20,
+        "tensioning_type": "Single Ratchet",
+        "includes_treepro": True,
+        "price": 149.0,
+        "currency": "USD",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["includes_treepro"] is True
+    assert data["price"] == 149.0
+
+
+def test_create_tricklinekit_missing_required_field_rejected(client, brand):
+    # Missing webbing_width
+    r = client.post("/tricklinekit/", json={
+        "name": "No Width",
+        "webbing_length": 15,
+        "tensioning_type": "Double Ratchet",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 422
+
+
+def test_create_tricklinekit_optional_fields_default_null(client, brand):
+    r = client.post("/tricklinekit/", json={
+        "name": "Minimal",
+        "webbing_length": 15,
+        "webbing_width": 25,
+        "tensioning_type": "Other",
+        "brand_id": brand.id,
+    })
+    data = r.json()
+    assert data["price"] is None
+    assert data["includes_treepro"] is False
+
+
+# --- PATCH ---
+
+def test_patch_tricklinekit_updates_field(client, session, brand):
+    k = make_tricklinekit(session, brand, price=120.0)
+    resp = client.patch(f"/tricklinekit/{k.id}", json={"price": 149.0})
+    assert resp.status_code == 200
+    assert resp.json()["price"] == 149.0
+
+
+def test_patch_tricklinekit_does_not_touch_other_fields(client, session, brand):
+    k = make_tricklinekit(session, brand, name="Stays Same", webbing_length=20)
+    resp = client.patch(f"/tricklinekit/{k.id}", json={"price": 200.0})
+    assert resp.status_code == 200
+    data = client.get(f"/tricklinekit/{k.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["webbing_length"] == 20
+
+
+def test_patch_tricklinekit_not_found(client):
+    assert client.patch("/tricklinekit/9999", json={"price": 10.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_tricklinekit(client, session, brand):
+    k = make_tricklinekit(session, brand)
+    assert client.delete(f"/tricklinekit/{k.id}").json() == {"ok": True}
+    assert client.get(f"/tricklinekit/{k.id}").status_code == 404
+
+
+def test_delete_tricklinekit_not_found(client):
+    assert client.delete("/tricklinekit/9999").status_code == 404

--- a/tests/test_webbings.py
+++ b/tests/test_webbings.py
@@ -1,0 +1,255 @@
+"""
+Tests for the /webbing endpoints.
+
+Covers: CRUD contract, pagination edge cases, response schema.
+"""
+
+import pytest
+from sqlmodel import Session
+
+from slack_data.models.brands import Brand
+from slack_data.models.webbing import FiberMaterial, Webbing
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_brand(session: Session, name: str = "Test Brand") -> Brand:
+    brand = Brand(name=name)
+    session.add(brand)
+    session.commit()
+    session.refresh(brand)
+    return brand
+
+
+def make_webbing(
+    session: Session,
+    brand: Brand,
+    *,
+    name: str = "Test Webbing",
+    material: FiberMaterial = FiberMaterial.NYLON,
+    width: int = 25,
+    **kwargs,
+) -> Webbing:
+    webbing = Webbing(name=name, material=material, width=width, brand_id=brand.id, **kwargs)
+    session.add(webbing)
+    session.commit()
+    session.refresh(webbing)
+    return webbing
+
+
+# ---------------------------------------------------------------------------
+# GET /webbing/
+# ---------------------------------------------------------------------------
+
+def test_list_webbings_empty(client):
+    response = client.get("/webbing/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_webbings_returns_items(client, session):
+    brand = make_brand(session)
+    make_webbing(session, brand, name="Fly")
+    make_webbing(session, brand, name="McFly")
+
+    response = client.get("/webbing/")
+    assert response.status_code == 200
+    names = [w["name"] for w in response.json()]
+    assert "Fly" in names
+    assert "McFly" in names
+
+
+def test_list_webbings_includes_brand_name(client, session):
+    brand = make_brand(session, "Gibbon")
+    make_webbing(session, brand)
+
+    data = client.get("/webbing/").json()
+    assert data[0]["brand_name"] == "Gibbon"
+
+
+# ---------------------------------------------------------------------------
+# GET /webbing/{id}
+# ---------------------------------------------------------------------------
+
+def test_get_webbing_by_id(client, session):
+    brand = make_brand(session)
+    webbing = make_webbing(session, brand, name="Aero 18", width=18)
+
+    response = client.get(f"/webbing/{webbing.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Aero 18"
+    assert data["width"] == 18
+    assert data["brand_name"] == brand.name
+
+
+def test_get_webbing_not_found(client):
+    response = client.get("/webbing/9999")
+    assert response.status_code == 404
+
+
+def test_get_webbing_invalid_id_zero(client):
+    # Path uses gt=0, so 0 is rejected at validation
+    response = client.get("/webbing/0")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /webbing/
+# ---------------------------------------------------------------------------
+
+def test_create_webbing(client, session):
+    brand = make_brand(session)
+
+    response = client.post("/webbing/", json={
+        "name": "New Webbing",
+        "material": "Nylon",
+        "width": 25,
+        "brand_id": brand.id,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "New Webbing"
+    assert data["material"] == "Nylon"
+    assert data["brand_name"] == brand.name
+
+
+def test_create_webbing_optional_fields_default_null(client, session):
+    brand = make_brand(session)
+
+    response = client.post("/webbing/", json={
+        "name": "Minimal Webbing",
+        "material": "Polyester",
+        "width": 35,
+        "brand_id": brand.id,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["price"] is None
+    assert data["weight"] is None
+    assert data["breaking_strength"] is None
+
+
+def test_create_webbing_with_optional_fields(client, session):
+    brand = make_brand(session)
+
+    response = client.post("/webbing/", json={
+        "name": "Full Webbing",
+        "material": "Dyneema",
+        "width": 18,
+        "brand_id": brand.id,
+        "breaking_strength": 22.5,
+        "weight": 38.0,
+        "price": 65.0,
+        "currency": "EUR",
+        "isa_certified": True,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["breaking_strength"] == 22.5
+    assert data["isa_certified"] is True
+
+
+# ---------------------------------------------------------------------------
+# PATCH /webbing/{id}
+# ---------------------------------------------------------------------------
+
+def test_patch_webbing_updates_field(client, session):
+    brand = make_brand(session)
+    webbing = make_webbing(session, brand, name="Original", price=20.0)
+
+    response = client.patch(f"/webbing/{webbing.id}", json={"price": 35.0})
+    assert response.status_code == 200
+    assert response.json()["price"] == 35.0
+
+
+def test_patch_webbing_does_not_touch_other_fields(client, session):
+    brand = make_brand(session)
+    webbing = make_webbing(session, brand, name="Stays Same", width=25)
+
+    response = client.patch(f"/webbing/{webbing.id}", json={"price": 99.0})
+    assert response.status_code == 200
+
+    data = client.get(f"/webbing/{webbing.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["width"] == 25
+    assert data["price"] == 99.0
+
+
+def test_patch_webbing_not_found(client):
+    response = client.patch("/webbing/9999", json={"price": 10.0})
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /webbing/{id}
+# ---------------------------------------------------------------------------
+
+def test_delete_webbing(client, session):
+    brand = make_brand(session)
+    webbing = make_webbing(session, brand)
+
+    response = client.delete(f"/webbing/{webbing.id}")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    # Confirm it's gone
+    response = client.get(f"/webbing/{webbing.id}")
+    assert response.status_code == 404
+
+
+def test_delete_webbing_not_found(client):
+    response = client.delete("/webbing/9999")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+def _create_webbings(session, brand, count: int):
+    for i in range(count):
+        make_webbing(session, brand, name=f"Webbing {i:03d}", width=25)
+
+
+def test_pagination_default_limit_is_10(client, session):
+    brand = make_brand(session)
+    _create_webbings(session, brand, 15)
+
+    response = client.get("/webbing/")
+    assert response.status_code == 200
+    assert len(response.json()) == 10
+
+
+def test_pagination_limit(client, session):
+    brand = make_brand(session)
+    _create_webbings(session, brand, 10)
+
+    response = client.get("/webbing/?limit=3")
+    assert len(response.json()) == 3
+
+
+def test_pagination_offset(client, session):
+    brand = make_brand(session)
+    _create_webbings(session, brand, 10)
+
+    all_items  = client.get("/webbing/?limit=10").json()
+    page2      = client.get("/webbing/?limit=5&offset=5").json()
+
+    assert page2 == all_items[5:]
+
+
+def test_pagination_limit_over_100_rejected(client):
+    response = client.get("/webbing/?limit=101")
+    assert response.status_code == 422
+
+
+def test_pagination_offset_past_end_returns_empty(client, session):
+    brand = make_brand(session)
+    _create_webbings(session, brand, 3)
+
+    response = client.get("/webbing/?offset=100")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/tests/test_weblocks.py
+++ b/tests/test_weblocks.py
@@ -1,0 +1,137 @@
+"""Tests for the /weblock endpoints."""
+
+from slack_data.models.weblocks import AttachmentPoint, FrontPin, Weblock
+from slack_data.utilities.materials import MetalMaterial
+
+
+def make_weblock(session, brand, *, name="Test Weblock", width_min=25, **kwargs) -> Weblock:
+    w = Weblock(
+        name=name,
+        material=MetalMaterial.ALUMINUM,
+        width_min=width_min,
+        brand_id=brand.id,
+        **kwargs,
+    )
+    session.add(w)
+    session.commit()
+    session.refresh(w)
+    return w
+
+
+# --- LIST ---
+
+def test_list_weblocks_empty(client):
+    assert client.get("/weblock/").json() == []
+
+
+def test_list_weblocks_returns_items(client, session, brand):
+    make_weblock(session, brand, name="Eddy")
+    make_weblock(session, brand, name="Eliot")
+    names = [w["name"] for w in client.get("/weblock/").json()]
+    assert "Eddy" in names and "Eliot" in names
+
+
+def test_list_weblocks_includes_brand_name(client, session, brand):
+    make_weblock(session, brand)
+    assert client.get("/weblock/").json()[0]["brand_name"] == brand.name
+
+
+# --- GET ---
+
+def test_get_weblock_by_id(client, session, brand):
+    w = make_weblock(session, brand, name="Campo", width_min=24, width_max=26)
+    data = client.get(f"/weblock/{w.id}").json()
+    assert data["name"] == "Campo"
+    assert data["width_min"] == 24
+    assert data["brand_name"] == brand.name
+
+
+def test_get_weblock_not_found(client):
+    assert client.get("/weblock/9999").status_code == 404
+
+
+# --- POST ---
+
+def test_create_weblock(client, brand):
+    r = client.post("/weblock/", json={
+        "name": "New Weblock",
+        "material": "Aluminum",
+        "width_min": 25,
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    assert r.json()["name"] == "New Weblock"
+    assert r.json()["brand_name"] == brand.name
+
+
+def test_create_weblock_with_optional_fields(client, brand):
+    r = client.post("/weblock/", json={
+        "name": "Full Weblock",
+        "material": "Stainless Steel",
+        "width_min": 20,
+        "width_max": 35,
+        "front_pin": "Push Pin",
+        "attachment_point": "Universal",
+        "isa_certified": True,
+        "price": 95.0,
+        "currency": "EUR",
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["width_max"] == 35
+    assert data["front_pin"] == "Push Pin"
+    assert data["isa_certified"] is True
+
+
+def test_create_weblock_missing_required_field_rejected(client, brand):
+    r = client.post("/weblock/", json={"name": "No Material", "brand_id": brand.id})
+    assert r.status_code == 422
+
+
+def test_create_weblock_optional_fields_default_null(client, brand):
+    r = client.post("/weblock/", json={
+        "name": "Minimal",
+        "material": "Steel",
+        "width_min": 25,
+        "brand_id": brand.id,
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data["price"] is None
+    assert data["front_pin"] is None
+    assert data["attachment_point"] is None
+
+
+# --- PATCH ---
+
+def test_patch_weblock_updates_field(client, session, brand):
+    w = make_weblock(session, brand, price=80.0)
+    r = client.patch(f"/weblock/{w.id}", json={"price": 120.0})
+    assert r.status_code == 200
+    assert r.json()["price"] == 120.0
+
+
+def test_patch_weblock_does_not_touch_other_fields(client, session, brand):
+    w = make_weblock(session, brand, name="Stays Same", width_min=25)
+    r = client.patch(f"/weblock/{w.id}", json={"price": 99.0})
+    assert r.status_code == 200
+    data = client.get(f"/weblock/{w.id}").json()
+    assert data["name"] == "Stays Same"
+    assert data["width_min"] == 25
+
+
+def test_patch_weblock_not_found(client):
+    assert client.patch("/weblock/9999", json={"price": 10.0}).status_code == 404
+
+
+# --- DELETE ---
+
+def test_delete_weblock(client, session, brand):
+    w = make_weblock(session, brand)
+    assert client.delete(f"/weblock/{w.id}").json() == {"ok": True}
+    assert client.get(f"/weblock/{w.id}").status_code == 404
+
+
+def test_delete_weblock_not_found(client):
+    assert client.delete("/weblock/9999").status_code == 404


### PR DESCRIPTION
- pytest suite covering all 7 active gear types (145 tests)
- pip install -e '.[dev]' + pytest workflow documented in README
- Fixed weblock router using instance instead of class for model_validate
- Fixed isa_certified branch ordering in clean_webbing_data loader