### PR TITLE
Enrich and clean up webbing dataset from SlackDB

### DIFF
--- a/ropes.json
+++ b/ropes.json
@@ -1,0 +1,382 @@
+[
+    {
+        "name": "9mm static",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.5,
+                "percent": 2
+            },
+            {
+                "kn": 1,
+                "percent": 3.5
+            },
+            {
+                "kn": 5,
+                "percent": 12
+            },
+            {
+                "kn": 10,
+                "percent": 16.1
+            },
+            {
+                "kn": 15,
+                "percent": 20.3
+            },
+            {
+                "kn": 20,
+                "percent": 27.6
+            }
+        ],
+        "materialType": "static rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "10mm static",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.5,
+                "percent": 2.6
+            },
+            {
+                "kn": 1.5,
+                "percent": 4.7
+            },
+            {
+                "kn": 5,
+                "percent": 12.4
+            },
+            {
+                "kn": 10,
+                "percent": 17.1
+            },
+            {
+                "kn": 15,
+                "percent": 20.1
+            },
+            {
+                "kn": 20,
+                "percent": 22.5
+            },
+            {
+                "kn": 25,
+                "percent": 25.6
+            }
+        ],
+        "materialType": "static rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "11mm static",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.8,
+                "percent": 3.9
+            },
+            {
+                "kn": 5,
+                "percent": 12.4
+            },
+            {
+                "kn": 10,
+                "percent": 16.7
+            },
+            {
+                "kn": 15,
+                "percent": 19.1
+            }
+        ],
+        "materialType": "static rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "12mm static",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.8,
+                "percent": 5.5
+            },
+            {
+                "kn": 5,
+                "percent": 15.3
+            },
+            {
+                "kn": 10,
+                "percent": 20.7
+            },
+            {
+                "kn": 15,
+                "percent": 23.7
+            }
+        ],
+        "materialType": "static rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "8.2",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.15,
+                "percent": 2.1
+            },
+            {
+                "kn": 0.2,
+                "percent": 2.8
+            },
+            {
+                "kn": 0.25,
+                "percent": 3.3
+            },
+            {
+                "kn": 0.5,
+                "percent": 5.2
+            },
+            {
+                "kn": 0.75,
+                "percent": 7
+            },
+            {
+                "kn": 1,
+                "percent": 9
+            },
+            {
+                "kn": 2.5,
+                "percent": 19.6
+            },
+            {
+                "kn": 5,
+                "percent": 29.8
+            },
+            {
+                "kn": 7.5,
+                "percent": 37.4
+            },
+            {
+                "kn": 10,
+                "percent": 43.44
+            },
+            {
+                "kn": 12.5,
+                "percent": 47.93
+            }
+        ],
+        "materialType": "climbing rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "8.9",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.15,
+                "percent": 1.5
+            },
+            {
+                "kn": 0.2,
+                "percent": 2
+            },
+            {
+                "kn": 0.25,
+                "percent": 2.3
+            },
+            {
+                "kn": 0.5,
+                "percent": 3.8
+            },
+            {
+                "kn": 0.75,
+                "percent": 5
+            },
+            {
+                "kn": 1,
+                "percent": 6.2
+            },
+            {
+                "kn": 2.5,
+                "percent": 16.3
+            },
+            {
+                "kn": 5,
+                "percent": 25.9
+            },
+            {
+                "kn": 7.5,
+                "percent": 32.9
+            },
+            {
+                "kn": 10,
+                "percent": 38.85
+            },
+            {
+                "kn": 12.5,
+                "percent": 44.06
+            }
+        ],
+        "materialType": "climbing rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "10",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.15,
+                "percent": 1.2
+            },
+            {
+                "kn": 0.2,
+                "percent": 1.7
+            },
+            {
+                "kn": 0.25,
+                "percent": 2.1
+            },
+            {
+                "kn": 0.5,
+                "percent": 3.8
+            },
+            {
+                "kn": 0.75,
+                "percent": 5.5
+            },
+            {
+                "kn": 1,
+                "percent": 7.2
+            },
+            {
+                "kn": 2.5,
+                "percent": 15.7
+            },
+            {
+                "kn": 5,
+                "percent": 24.2
+            },
+            {
+                "kn": 7.5,
+                "percent": 29.8
+            },
+            {
+                "kn": 10,
+                "percent": 34.55
+            },
+            {
+                "kn": 12.5,
+                "percent": 38.28
+            }
+        ],
+        "materialType": "climbing rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "12",
+        "brand": "Edelrid",
+        "stretch": [
+            {
+                "kn": 0,
+                "percent": 0
+            },
+            {
+                "kn": 0.15,
+                "percent": 1.3
+            },
+            {
+                "kn": 0.2,
+                "percent": 1.8
+            },
+            {
+                "kn": 0.25,
+                "percent": 2.1
+            },
+            {
+                "kn": 0.5,
+                "percent": 3.6
+            },
+            {
+                "kn": 0.75,
+                "percent": 4.7
+            },
+            {
+                "kn": 1,
+                "percent": 5.8
+            },
+            {
+                "kn": 2.5,
+                "percent": 13.2
+            },
+            {
+                "kn": 5,
+                "percent": 21
+            },
+            {
+                "kn": 7.5,
+                "percent": 26.4
+            },
+            {
+                "kn": 10,
+                "percent": 30.75
+            },
+            {
+                "kn": 12.5,
+                "percent": 34.78
+            }
+        ],
+        "materialType": "climbing rope",
+        "weight": "",
+        "breakingStrength": "",
+        "date_introduced": null,
+        "product_url": null
+    }
+]

--- a/slack_data/load_data/load_webbings.py
+++ b/slack_data/load_data/load_webbings.py
@@ -1,3 +1,4 @@
+import ast
 import json
 from pathlib import Path
 
@@ -5,7 +6,8 @@ from sqlmodel import select
 
 from slack_data.database import SessionDep
 from slack_data.models.brands import Brand, BrandCreate, get_brand
-from slack_data.models.webbing import FiberMaterial, Webbing, WebbingCreate
+from slack_data.models.webbing import FiberMaterial, Webbing, WebbingConstruction, WebbingCreate
+from slack_data.utilities.currencies import Currency
 
 
 WEBBING_FILE = Path(__file__).parent.parent.parent / "webbings.json"
@@ -30,10 +32,15 @@ def clean_webbing_data(webbing: dict) -> dict:
     for key, value in webbing.items():
         if key in {"width", "weight"} and value == "":
             cleaned_webbing[key] = 0
-        elif key not in {"name", "brand", "materialType"} and value == "":
-            cleaned_webbing[key] = None
         elif key == "isa_certified":
             cleaned_webbing[key] = bool(value) if isinstance(value, str) else value
+        elif key == "stretch":
+            # stretch is a list of {kn, percent} dicts; store it as valid JSON
+            # (the generic str() branch below would emit a Python repr with
+            # single quotes, which is not JSON-parseable on the client).
+            cleaned_webbing[key] = json.dumps(value) if value else None
+        elif key not in {"name", "brand", "materialType"} and value == "":
+            cleaned_webbing[key] = None
         else:
             cleaned_webbing[key] = str(value) if value is not None else None
     return cleaned_webbing
@@ -55,10 +62,20 @@ def add_webbings_to_db(webbings: list[dict], session: SessionDep) -> None:
             release_date=webbing.get("date_introduced"),
             product_url=webbing.get("product_url"),
             material=material,
-            width=int(webbing.get("width", 0)),
-            weight=float(webbing.get("weight", 0)),
+            # width is `int` mm in the model, but the enriched dataset carries
+            # some decimal widths (e.g. "25.4"); coerce via float so int() won't
+            # crash on them.
+            width=int(float(webbing.get("width") or 0)),
+            # weight is `float | None` in the model; the enriched dataset has
+            # some null weights, so pass None through instead of float(None).
+            weight=float(webbing.get("weight")) if webbing.get("weight") not in (None, "") else None,
             breaking_strength=webbing.get("breakingStrength"),
             stretch=webbing.get("stretch"),
+            thickness=float(webbing.get("thickness")) if webbing.get("thickness") not in (None, "") else None,
+            webbing_construction=get_webbing_construction(webbing.get("webbing_construction")),
+            isa_certified=webbing.get("isa_certified", False),
+            price=parse_price(webbing.get("priceMeter")),
+            currency=parse_currency(webbing.get("currency")),
         )
         db_webbing = Webbing.model_validate(webbing_create)
         db_webbing.brand = session.get(Brand, brand_id)
@@ -67,6 +84,44 @@ def add_webbings_to_db(webbings: list[dict], session: SessionDep) -> None:
 
     session.commit()
     session.refresh(db_webbing)
+
+def parse_currency(value) -> Currency | None:
+    """Map a currency code to the enum; unknown codes -> None (don't crash seeding)."""
+    if not value:
+        return None
+    try:
+        return Currency(str(value).upper())
+    except ValueError:
+        return None
+
+def parse_price(raw) -> float | None:
+    """priceMeter may be a number, a numeric string, or a stringified dict like
+    "{'value': 1.69, 'currency': 'euro'}" left over from the original scrape."""
+    if raw in (None, ""):
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    s = str(raw).strip()
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    try:
+        parsed = ast.literal_eval(s)
+    except (ValueError, SyntaxError):
+        return None
+    if isinstance(parsed, dict) and parsed.get("value") is not None:
+        return float(parsed["value"])
+    return None
+
+def get_webbing_construction(value: str | None) -> WebbingConstruction | None:
+    """Map a webbing_construction label (e.g. "Core/Sheath") to the enum."""
+    if not value:
+        return None
+    try:
+        return WebbingConstruction(str(value))
+    except ValueError:
+        return WebbingConstruction.OTHER
 
 def get_material_type(material: str) -> FiberMaterial:
     """

--- a/slack_data/load_data/load_weblocks.py
+++ b/slack_data/load_data/load_weblocks.py
@@ -211,7 +211,7 @@ def parse_currency_from_weblock(weblock_data: dict) -> Currency | None:
         try:
             currency = get_currency(tooltip)
         except ValueError:
-            pass
+            currency = None
         if currency: return currency
         
         # Check main text
@@ -219,7 +219,7 @@ def parse_currency_from_weblock(weblock_data: dict) -> Currency | None:
         try:
             currency = get_currency(text)
         except ValueError:
-            pass
+            currency = None
         if currency: return currency
     
     # Try specifications as fallback
@@ -228,7 +228,7 @@ def parse_currency_from_weblock(weblock_data: dict) -> Currency | None:
     try:
         currency = get_currency(price_text)
     except ValueError:
-        pass
+        currency = None
     if currency: return currency
     
     return Currency.EUR

--- a/slack_data/models/brands.py
+++ b/slack_data/models/brands.py
@@ -2,6 +2,7 @@ from pydantic import computed_field
 from sqlmodel import select, Field, Relationship, SQLModel
 
 from slack_data.database import SessionDep
+from slack_data.utilities.brand_aliases import canonical_brand
 from slack_data.utilities.countries import Country
 
 class BaseBrands(SQLModel):
@@ -87,7 +88,7 @@ class Brand(BaseBrands, table=True):
         return [tricklinekit.name for tricklinekit in self._tricklinekits]
     
 def get_brand(session: SessionDep, brand_cache: dict[str, int] | None, item: dict) -> tuple[int,dict]:
-    brand_name = str(item.get("brand"))
+    brand_name = canonical_brand(str(item.get("brand")))
     if brand_name not in brand_cache:
         # get brand_id from the database or create it if it doesn't exist
         statement = select(Brand.id).where(Brand.name == brand_name)

--- a/slack_data/models/webbing.py
+++ b/slack_data/models/webbing.py
@@ -21,6 +21,12 @@ class Classification(str, Enum):
     C = "C"
     OTHER = "Other"
 
+class WebbingConstruction(str, Enum):
+    FLAT = "Flat"
+    TUBULAR = "Tubular"
+    CORE_SHEATH = "Core/Sheath"
+    OTHER = "Other"
+
 class BaseWebbing(SQLModel):
     """
     Base class for webbing. All fields optional so adding a new field is one line.
@@ -28,7 +34,9 @@ class BaseWebbing(SQLModel):
     """
     name: str | None = Field(default=None, index=True)
     material: FiberMaterial | None = None
+    webbing_construction: WebbingConstruction | None = None # Flat / Tubular / Core-Sheath
     width: int | None = None              # mm
+    thickness: float | None = None        # mm
     release_date: int | None = None       # Unix timestamp
     product_url: str | None = None
     weight: float | None = None           # g/m

--- a/slack_data/utilities/brand_aliases.py
+++ b/slack_data/utilities/brand_aliases.py
@@ -1,0 +1,26 @@
+"""
+Canonical brand names. The gear datasets spell some manufacturers several ways
+(e.g. "BalanceCommunity" vs "Balance Community: Slackline Outfitters"), which
+would create duplicate Brand rows. `get_brand()` runs each brand string through
+`canonical_brand()` so every variant resolves to one row.
+
+Add new variants here (variant -> canonical) as they turn up.
+"""
+
+BRAND_ALIASES: dict[str, str] = {
+    "Aki Slackline": "Aki Slacklines",
+    "Balance Community: Slackline Outfitters": "Balance Community",
+    "BalanceCommunity": "Balance Community",
+    "Elephant": "Elephant Slacklines",
+    "Equilibrium": "Equilibrium Slacklines (EQB)",
+    "slackliner.de": "Slackliner.de",
+    "SlackMountain": "Slack Mountain",
+    "slackPro": "Slack Pro!",
+    "Spider slacklines": "Spider Slacklines",
+    "yogaslackers": "Yoga Slackers",
+}
+
+
+def canonical_brand(name: str) -> str:
+    """Map a brand-name variant to its canonical spelling (unchanged if unknown)."""
+    return BRAND_ALIASES.get(name.strip(), name.strip())

--- a/slack_data/utilities/currencies.py
+++ b/slack_data/utilities/currencies.py
@@ -25,6 +25,7 @@ class Currency(str, Enum):
     JPY = "JPY"  # Japanese Yen
     KRW = "KRW"  # South Korean Won
     MXN = "MXN"  # Mexican Peso
+    NZD = "NZD"  # New Zealand Dollar
     PEN = "PEN"  # Peruvian Sol
     PLN = "PLN"  # Polish Zloty
     RUB = "RUB"  # Russian Ruble

--- a/webbings.json
+++ b/webbings.json
@@ -633,7 +633,8 @@
         "weight": 80,
         "breakingStrength": 38,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Sonic 2",
@@ -859,7 +860,8 @@
         "weight": 58,
         "breakingStrength": 32.5,
         "date_introduced": null,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyester/4/aki-white-magic-webbing?c=6"
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/4/aki-white-magic-webbing?c=6",
+        "width": 25
     },
     {
         "name": "Verve red",
@@ -981,7 +983,8 @@
         "weight": 61.5,
         "breakingStrength": 32,
         "date_introduced": 1489363200000,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Wizard",
@@ -1048,7 +1051,8 @@
         "weight": 55,
         "breakingStrength": 33,
         "date_introduced": 1518991200000,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Aero",
@@ -1143,7 +1147,8 @@
         "weight": 62,
         "breakingStrength": 33.4,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Aero 2",
@@ -1238,7 +1243,8 @@
         "weight": 62,
         "breakingStrength": 33.4,
         "date_introduced": 1449273600000,
-        "product_url": "http://www.balancecommunity.com/aero-2"
+        "product_url": "http://www.balancecommunity.com/aero-2",
+        "width": 25.4
     },
     {
         "name": "Feather",
@@ -1293,7 +1299,8 @@
         "weight": 47,
         "breakingStrength": 27,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Feather Pro",
@@ -1388,7 +1395,8 @@
         "weight": 47,
         "breakingStrength": 27,
         "date_introduced": 1459900800000,
-        "product_url": "http://www.balancecommunity.com/feather-pro"
+        "product_url": "http://www.balancecommunity.com/feather-pro",
+        "width": 25
     },
     {
         "name": "Mantra MK1",
@@ -1749,10 +1757,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 76,
+        "breakingStrength": 42,
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://www.balancecommunity.com/mantra-mk4-flight",
+        "width": 25
     },
     {
         "name": "type-18 MK1",
@@ -1981,7 +1990,8 @@
         "weight": "58",
         "breakingStrength": "28",
         "date_introduced": 1507150800000,
-        "product_url": "http://www.balancecommunity.com/lift"
+        "product_url": "http://www.balancecommunity.com/lift",
+        "width": 25
     },
     {
         "name": "SpiderSilk MK2",
@@ -2130,7 +2140,8 @@
         "weight": 33.4,
         "breakingStrength": 35,
         "date_introduced": null,
-        "product_url": "https://laboutique.slack.fr/en/slackline-webbings/41-moonwalk-flat-hybride.html"
+        "product_url": "https://laboutique.slack.fr/en/slackline-webbings/41-moonwalk-flat-hybride.html",
+        "width": 25
     },
     {
         "name": "McFly",
@@ -2157,7 +2168,8 @@
         "weight": 65,
         "breakingStrength": 31,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Spring",
@@ -2279,7 +2291,8 @@
         "weight": 63,
         "breakingStrength": 30,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Passion",
@@ -2469,10 +2482,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 48,
+        "breakingStrength": 20,
         "date_introduced": null,
-        "product_url": "https://www.slackshop.cz/en/webbing/30-eqb-neon.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/30-eqb-neon.html",
+        "width": 25
     },
     {
         "name": "Sigma N",
@@ -2531,7 +2545,8 @@
         "weight": 55,
         "breakingStrength": 26,
         "date_introduced": null,
-        "product_url": "http://www.slackliner.de/Webbing/Nylon/Sigma-N-jormungand-270.html"
+        "product_url": "http://www.slackliner.de/Webbing/Nylon/Sigma-N-jormungand-270.html",
+        "width": 25
     },
     {
         "name": "Sigma X",
@@ -2688,7 +2703,8 @@
         "weight": "64",
         "breakingStrength": "35",
         "date_introduced": null,
-        "product_url": "http://www.slackliner.de/Webbing/Flat-Webbing/Sigma-Impact.html"
+        "product_url": "http://www.slackliner.de/Webbing/Flat-Webbing/Sigma-Impact.html",
+        "width": 25
     },
     {
         "name": "Sigma LG",
@@ -2731,7 +2747,8 @@
         "weight": 66,
         "breakingStrength": 38,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Dragon",
@@ -2766,7 +2783,8 @@
         "weight": 64,
         "breakingStrength": 31,
         "date_introduced": null,
-        "product_url": "https://www.slackshop.cz/en/webbing/31-eqb-dragon.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/31-eqb-dragon.html",
+        "width": 25
     },
     {
         "name": "Sumo",
@@ -2801,7 +2819,8 @@
         "weight": 82,
         "breakingStrength": 40,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Bounce",
@@ -2832,7 +2851,8 @@
         "weight": "38",
         "breakingStrength": "16",
         "date_introduced": null,
-        "product_url": "https://www.slackshop.cz/en/for-advanced/142-eqb-bounce.html"
+        "product_url": "https://www.slackshop.cz/en/for-advanced/142-eqb-bounce.html",
+        "width": 19
     },
     {
         "name": "Flash",
@@ -2867,7 +2887,8 @@
         "weight": 61,
         "breakingStrength": 31,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Element",
@@ -2898,7 +2919,8 @@
         "weight": 42,
         "breakingStrength": 20,
         "date_introduced": null,
-        "product_url": "http://www.eqb.cz/element-en.html"
+        "product_url": "http://www.eqb.cz/element-en.html",
+        "width": 25
     },
     {
         "name": "Skye",
@@ -2961,7 +2983,8 @@
         "weight": 62,
         "breakingStrength": 36,
         "date_introduced": 1492041600000,
-        "product_url": "https://www.slackshop.cz/en/webbing/78-eqb-skye.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/78-eqb-skye.html",
+        "width": 25
     },
     {
         "name": "Fresh",
@@ -2996,7 +3019,8 @@
         "weight": 67,
         "breakingStrength": 32,
         "date_introduced": 1496188800000,
-        "product_url": "https://www.slackshop.cz/en/webbing/76-157-eqb-fresh.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/76-157-eqb-fresh.html",
+        "width": 25
     },
     {
         "name": "eLine",
@@ -3054,7 +3078,8 @@
         "weight": "53",
         "breakingStrength": "29",
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/1-cobalt.html"
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/1-cobalt.html",
+        "width": 25
     },
     {
         "name": "Windu",
@@ -3082,10 +3107,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 65,
+        "breakingStrength": 25,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "Snake",
@@ -3198,10 +3224,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 52,
+        "breakingStrength": 21,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "flax",
@@ -3252,10 +3279,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 57,
+        "breakingStrength": 25,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "spectre",
@@ -3283,10 +3311,11 @@
             }
         ],
         "materialType": "polyamid/nylon",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 70,
+        "breakingStrength": 30,
         "date_introduced": 1486425600000,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/168-spectre.html"
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/168-spectre.html",
+        "width": 25
     },
     {
         "name": "rubalise",
@@ -3306,10 +3335,11 @@
             }
         ],
         "materialType": "50mm pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 80,
+        "breakingStrength": 30,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 50
     },
     {
         "name": "wallaby",
@@ -3332,7 +3362,8 @@
         "weight": "118",
         "breakingStrength": "30",
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/jumplines/6-wallaby.html"
+        "product_url": "http://slack-mountain.com/en/jumplines/6-wallaby.html",
+        "width": 48
     },
     {
         "name": "Storm",
@@ -3352,10 +3383,11 @@
             }
         ],
         "materialType": "50mm pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 80,
+        "breakingStrength": 30,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 50
     },
     {
         "name": "plum",
@@ -3375,10 +3407,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
+        "weight": 25,
         "breakingStrength": "10",
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/7-plum.html"
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/7-plum.html",
+        "width": 25
     },
     {
         "name": "Cosmic",
@@ -3453,7 +3486,8 @@
         "weight": "50",
         "breakingStrength": "31",
         "date_introduced": 1470528000000,
-        "product_url": "http://slack-inov.com/gb/webbing/69-cosmic"
+        "product_url": "http://slack-inov.com/gb/webbing/69-cosmic",
+        "width": 25
     },
     {
         "name": "Flame3",
@@ -3559,7 +3593,8 @@
         "weight": "66",
         "breakingStrength": "32",
         "date_introduced": null,
-        "product_url": "https://slack-inov.com/gb/longline/144-donkey"
+        "product_url": "https://slack-inov.com/gb/longline/144-donkey",
+        "width": 25.4
     },
     {
         "name": "Nova",
@@ -3590,7 +3625,8 @@
         "weight": "56",
         "breakingStrength": "27",
         "date_introduced": null,
-        "product_url": "https://slack-inov.com/gb/longline/145-nova"
+        "product_url": "https://slack-inov.com/gb/longline/145-nova",
+        "width": 25.4
     },
     {
         "name": "(pes)",
@@ -3764,7 +3800,8 @@
         "weight": "62",
         "breakingStrength": "36",
         "date_introduced": 1539118800000,
-        "product_url": "https://raed-slacklines.com/rainbow-polyester-highline-webbing"
+        "product_url": "https://raed-slacklines.com/rainbow-polyester-highline-webbing",
+        "width": 25.4
     },
     {
         "name": "Parsec",
@@ -3859,7 +3896,8 @@
         "weight": "59",
         "breakingStrength": "33",
         "date_introduced": null,
-        "product_url": "https://raed-slacklines.com/parsec-longline-webbing"
+        "product_url": "https://raed-slacklines.com/parsec-longline-webbing",
+        "width": 25
     },
     {
         "name": "MOTM",
@@ -3954,7 +3992,8 @@
         "weight": "56",
         "breakingStrength": "27",
         "date_introduced": null,
-        "product_url": "https://raed-slacklines.com/motm-tubular-nylon-slackline-webbing"
+        "product_url": "https://raed-slacklines.com/motm-tubular-nylon-slackline-webbing",
+        "width": 25
     },
     {
         "name": "Helium",
@@ -4049,7 +4088,8 @@
         "weight": "38",
         "breakingStrength": "24",
         "date_introduced": null,
-        "product_url": "https://raed-slacklines.com/helium-lightweight-polyester-slackline-webbing"
+        "product_url": "https://raed-slacklines.com/helium-lightweight-polyester-slackline-webbing",
+        "width": 25
     },
     {
         "name": "Cumulus",
@@ -4124,7 +4164,8 @@
         "weight": "66",
         "breakingStrength": "35",
         "date_introduced": 1563919200000,
-        "product_url": "https://raed-slacklines.com/cumulus-nylon-highline-webbing"
+        "product_url": "https://raed-slacklines.com/cumulus-nylon-highline-webbing",
+        "width": 25
     },
     {
         "name": "pinkTube",
@@ -4235,7 +4276,8 @@
         "weight": "48",
         "breakingStrength": "20.6",
         "date_introduced": 1503349200000,
-        "product_url": "https://www.slacktivity.com/pinktube-25m-200m"
+        "product_url": "https://www.slacktivity.com/pinktube-25m-200m",
+        "width": 25.5
     },
     {
         "name": "redTube",
@@ -4398,7 +4440,8 @@
         "weight": 76,
         "breakingStrength": 36,
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/redtube-30m-200m"
+        "product_url": "https://www.slacktivity.com/redtube-30m-200m",
+        "width": 25
     },
     {
         "name": "Marathon",
@@ -4557,7 +4600,8 @@
         "weight": "61.5",
         "breakingStrength": "37",
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/marathon-50m-500m"
+        "product_url": "https://www.slacktivity.com/marathon-50m-500m",
+        "width": 25
     },
     {
         "name": "Marathon Play",
@@ -4713,10 +4757,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 65,
+        "breakingStrength": 37,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25
     },
     {
         "name": "halfMarathon 20mm",
@@ -4919,10 +4964,11 @@
             }
         ],
         "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "weight": 45,
+        "breakingStrength": 16,
         "date_introduced": null,
-        "product_url": "https://www.balanceur.ro/slackshop/benzi/pana-corbului/"
+        "product_url": "https://www.balanceur.ro/slackshop/benzi/pana-corbului/",
+        "width": 25
     },
     {
         "name": "Milky Way",
@@ -5065,7 +5111,8 @@
         "weight": "63",
         "breakingStrength": "32",
         "date_introduced": 1562706000000,
-        "product_url": "https://www.balanceur.ro/slackshop/benzi/milky-way/"
+        "product_url": "https://www.balanceur.ro/slackshop/benzi/milky-way/",
+        "width": 25
     },
     {
         "name": "Tender",
@@ -5317,7 +5364,8 @@
         "weight": "62",
         "breakingStrength": "35",
         "date_introduced": null,
-        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/74-edge-line.html"
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/74-edge-line.html",
+        "width": 25.4
     },
     {
         "name": "Jumbo",
@@ -5380,7 +5428,8 @@
         "weight": "83",
         "breakingStrength": "35",
         "date_introduced": null,
-        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/73-jumbo-line.html"
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/73-jumbo-line.html",
+        "width": 25.4
     },
     {
         "name": "Nylove",
@@ -5443,7 +5492,8 @@
         "weight": "62",
         "breakingStrength": "31",
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/245-nylove-longline-price-per-meter.html"
+        "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/245-nylove-longline-price-per-meter.html",
+        "width": 25
     },
     {
         "name": "Y2k",
@@ -5458,7 +5508,8 @@
         "breakingStrength": 34,
         "materialType": "dyneema",
         "date_introduced": 1534744800000,
-        "product_url": "https://www.slacktivity.com/y2k"
+        "product_url": "https://www.slacktivity.com/y2k",
+        "width": 25.4
     },
     {
         "name": "Voyage",
@@ -5510,5 +5561,2372 @@
         "materialType": "pes",
         "date_introduced": null,
         "product_url": null
+    },
+    {
+        "name": "Ribera",
+        "brand": "Pump Slackline",
+        "materialType": "Polyester",
+        "width": 26,
+        "weight": 80,
+        "breakingStrength": 42,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Bloodline",
+        "brand": "Pure Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Tape",
+        "brand": "Singing rock",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 59,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 8
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.singingrock.com/slackline-webbing-yellowblack"
+    },
+    {
+        "name": "Ninja",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Nylon",
+        "width": 35,
+        "weight": 86,
+        "breakingStrength": 45,
+        "stretch": [
+            {
+                "percent": 11,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.eqb.cz/ninja-en.html"
+    },
+    {
+        "name": "Nitro",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Polyester",
+        "width": 50,
+        "weight": 99,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 11,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Slim Green",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 26,
+        "breakingStrength": 11,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 3
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.slackshop.cz/en/webbing/29-eqb-slim.html"
+    },
+    {
+        "name": "Chartreuse",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 30,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Dibona",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Elia",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Etna II",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 90,
+        "breakingStrength": 50,
+        "stretch": [
+            {
+                "percent": 2,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Fuji",
+        "brand": "Line Spirit",
+        "materialType": "Dyneema",
+        "width": 25,
+        "weight": 37,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Krakatoa",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 45,
+        "weight": 96,
+        "breakingStrength": 45,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Mauna Kea",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 26,
+        "weight": 116,
+        "breakingStrength": 42,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Pierra Menta",
+        "brand": "Line Spirit",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 54,
+        "breakingStrength": 22,
+        "stretch": [
+            {
+                "percent": 15,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Vercors",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Vesuve",
+        "brand": "Line Spirit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 56,
+        "breakingStrength": 24,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Sat'Elite",
+        "brand": "Dakas",
+        "materialType": "Nylon",
+        "width": 50,
+        "weight": 145,
+        "breakingStrength": 75,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Red Zebra",
+        "brand": "Dakas",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 30.9,
+        "stretch": [
+            {
+                "percent": 16.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Slack Swan",
+        "brand": "Dakas",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 78,
+        "breakingStrength": 36.5,
+        "stretch": [
+            {
+                "percent": 5.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Flamme II",
+        "brand": "Slack Inov",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 76,
+        "breakingStrength": 43,
+        "stretch": [
+            {
+                "percent": 3.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Emeraude",
+        "brand": "Slack Inov",
+        "materialType": "Polyester",
+        "width": 50,
+        "weight": 95,
+        "breakingStrength": 40,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "http://slack-inov.com/gb/webbing/9-emeraude"
+    },
+    {
+        "name": "Diablo2",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 96,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 3.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/132-diablo2.html"
+    },
+    {
+        "name": "Flax NY",
+        "brand": "Slack Mountain",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 38,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 13,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Goku",
+        "brand": "Slack Mountain",
+        "materialType": "Hybrid",
+        "width": 25,
+        "weight": 32,
+        "breakingStrength": 35,
+        "stretch": [
+            {
+                "percent": 3.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Goku 2",
+        "brand": "Slack Mountain",
+        "materialType": "Hybrid",
+        "width": 25,
+        "weight": 41,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 3.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/136-goku2.html"
+    },
+    {
+        "name": "Snake Tub",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 52,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/5-snake-tub.html"
+    },
+    {
+        "name": "Club S",
+        "brand": "Slack.fr",
+        "materialType": "Other",
+        "width": 25,
+        "weight": 75,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Dark Blue",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 28,
+        "stretch": [
+            {
+                "percent": 4.7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "MILF",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 73,
+        "breakingStrength": 37,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Neon Light",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 35,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "SuperFL Kill Bill",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 146,
+        "breakingStrength": 54,
+        "stretch": [
+            {
+                "percent": 2.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "SuperFL Maverick V2",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Supertube Norway",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 54,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Jumpline",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 30,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Jumpline Pro Series",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 40,
+        "weight": 74,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Jumpline AntiPop",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 40,
+        "weight": 101,
+        "breakingStrength": 45,
+        "stretch": [
+            {
+                "percent": 8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Passion red",
+        "brand": "Elephant",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 69,
+        "breakingStrength": 33,
+        "stretch": [
+            {
+                "percent": 12.3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Flash'line",
+        "brand": "Elephant",
+        "materialType": "Polyester",
+        "width": 50,
+        "weight": 86,
+        "breakingStrength": null,
+        "stretch": [
+            {
+                "percent": 2,
+                "kn": 7.5
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://elephant-slacklines.com"
+    },
+    {
+        "name": "EcoLine",
+        "brand": "Elephant",
+        "materialType": "Polyester",
+        "width": 50,
+        "weight": 86,
+        "breakingStrength": 45,
+        "stretch": [
+            {
+                "percent": 2,
+                "kn": 7
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://elephant-slacklines.com"
+    },
+    {
+        "name": "Wing 3.5",
+        "brand": "Elephant",
+        "materialType": "Polyester",
+        "width": 35,
+        "weight": 54,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 5.9,
+                "kn": 7.5
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Skillshot HS",
+        "brand": "Gambit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Skillshot LS",
+        "brand": "Gambit",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 59,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Flow Line",
+        "brand": "Gibbon",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 64,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.gibbon-slacklines.com/en/products/longline-modules/flowline/index.html"
+    },
+    {
+        "name": "Tube Line",
+        "brand": "Gibbon",
+        "materialType": "Other",
+        "width": 25,
+        "weight": 64,
+        "breakingStrength": 30,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Verve 35mm",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 35,
+        "weight": 69,
+        "breakingStrength": 35,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Core 1",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 76,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 2.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Core 2 HS",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 71.5,
+        "breakingStrength": 44,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Core 2 LS",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 69.9,
+        "breakingStrength": 44,
+        "stretch": [
+            {
+                "percent": 2,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Matrix",
+        "brand": "Landcruising",
+        "materialType": "Nylon",
+        "width": 32,
+        "weight": 102,
+        "breakingStrength": 43,
+        "stretch": [
+            {
+                "percent": 14.5,
+                "kn": 12
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Matrix Outer",
+        "brand": "Landcruising",
+        "materialType": "Nylon",
+        "width": 32,
+        "weight": 58,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 9
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Sonic 2.0",
+        "brand": "Aki Slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 68,
+        "breakingStrength": 34,
+        "stretch": [
+            {
+                "percent": 15,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/137/aki-sonic-2-slackline-webbing?c=12&fbclid=IwAR1eTq7La_8P4pp3HW0hq4rE2LNuzA2ZAbm-Vyx4gXORVdZU1EmhrtBbLAo"
+    },
+    {
+        "name": "Wave Tube",
+        "brand": "Landcruising",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 42,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 17,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Wave Tape 19",
+        "brand": "Landcruising",
+        "materialType": "Nylon",
+        "width": 19,
+        "weight": 38,
+        "breakingStrength": 18,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 6
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Wave Tube 19",
+        "brand": "Landcruising",
+        "materialType": "Nylon",
+        "width": 19,
+        "weight": 36,
+        "breakingStrength": 16,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 6
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Sigma Impact LS",
+        "brand": "Slackliner.de",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 64,
+        "breakingStrength": 37,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.slackliner.de/Slackline-Band/Flachband/Sigma-Impact-lowstretch.html"
+    },
+    {
+        "name": "Sigma X (HeliX)",
+        "brand": "Slackliner.de",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 44,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 15.5,
+                "kn": 8
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.slackliner.de/Slackline-Band/Schlauchband/Sigma-X.html"
+    },
+    {
+        "name": "Strong II",
+        "brand": "Slackline tools",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 67,
+        "breakingStrength": 36,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 6
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.slack-shop.de/baender-schlingen/bander/strong/slacklineband-strong-ii.html"
+    },
+    {
+        "name": "FLY Line",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 58,
+        "breakingStrength": 33,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/77-fly-line.html"
+    },
+    {
+        "name": "Tender Line",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 23,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 8
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/76-tender-line.html"
+    },
+    {
+        "name": "Zao Line",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 9,
+                "kn": 12
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/69-zao-line.html"
+    },
+    {
+        "name": "Octopussy MKV",
+        "brand": "Slack house",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slackhouseshop.pl/en/produkt/octopussy-en"
+    },
+    {
+        "name": "Rubber Band MKIII BLU",
+        "brand": "Slack house",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-blu"
+    },
+    {
+        "name": "Rubber Band MKIII SOL",
+        "brand": "Slack house",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slackhouseshop.pl/en/produkt/slackhouse-rubber-band-25mm-sol/"
+    },
+    {
+        "name": "Blue Mile",
+        "brand": "Slack house",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 59.7,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 3.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://slackline.pl/bluemile"
+    },
+    {
+        "name": "Sin Más",
+        "brand": "Ambaradam",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 52,
+        "breakingStrength": 36,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://ambaradam.net/product/sin-mas/"
+    },
+    {
+        "name": "Black-White",
+        "brand": "Slacktivity",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 88,
+        "breakingStrength": 43,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Mantra MKIII",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 83,
+        "breakingStrength": 42,
+        "stretch": [
+            {
+                "percent": 8.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Slack-Spec Tubelar",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 40,
+        "breakingStrength": 20,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "http://www.balancecommunity.com/1-slack-spec-tubular"
+    },
+    {
+        "name": "Slack-Spec 11/16\"",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 17.5,
+        "weight": 28,
+        "breakingStrength": 13.3,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "http://www.balancecommunity.com/11-16-slack-spec-tubular"
+    },
+    {
+        "name": "Slack-Spec Threaded Tubular",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 70,
+        "breakingStrength": 33.4,
+        "stretch": [
+            {
+                "percent": 11.1,
+                "kn": 6.7
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Spider Silk 7/8\"",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Vectran",
+        "width": 22.2,
+        "weight": 44,
+        "breakingStrength": 51.2,
+        "stretch": [
+            {
+                "percent": 1.6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Spider Silk MKII",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Vectran",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 67,
+        "stretch": [
+            {
+                "percent": 1.22,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.balancecommunity.com/spider-silk-mkii"
+    },
+    {
+        "name": "Type 18 MKII",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 35.6,
+        "stretch": [
+            {
+                "percent": 14.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.balancecommunity.com/type-18-mkii"
+    },
+    {
+        "name": "RAGEline",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Hybrid",
+        "width": 31,
+        "weight": 104,
+        "breakingStrength": 42,
+        "stretch": [
+            {
+                "percent": 8.3,
+                "kn": 12
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.balancecommunity.com/rageline"
+    },
+    {
+        "name": "CoreTek",
+        "brand": "Slackline Industries",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 56,
+        "breakingStrength": 27.5,
+        "stretch": [
+            {
+                "percent": 2.5,
+                "kn": 5.34
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slacklineindustries.com/collections/1-inch/products/coretek"
+    },
+    {
+        "name": "Sugoi",
+        "brand": "Slackline Industries",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 34.32,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 6.67
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slacklineindustries.com/collections/all-products/products/sugoi"
+    },
+    {
+        "name": "Great White",
+        "brand": "SlackGear",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 6.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.slackgear.co.za/product/great-white/"
+    },
+    {
+        "name": "Tantalus",
+        "brand": "Slacklife BC",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 53,
+        "breakingStrength": 34.7,
+        "stretch": [
+            {
+                "percent": 8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Sky Pilot (Green/Orange)",
+        "brand": "Slacklife BC",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 65,
+        "breakingStrength": 36.4,
+        "stretch": [
+            {
+                "percent": 9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "HighTech",
+        "brand": "Slacklife BC",
+        "materialType": "Dyneema",
+        "width": 25.4,
+        "weight": 48,
+        "breakingStrength": 39.2,
+        "stretch": [
+            {
+                "percent": 4.6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Type 18 CG4",
+        "brand": "Balancing Earth Slacklines",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 60,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 6
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.balancingearthslacklines.com/slackline_webbing_flat_nylon_type_18_cg4_slackline_p/cg4.htm"
+    },
+    {
+        "name": "Rasta Tubelar",
+        "brand": "Balancing Earth Slacklines",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": null,
+        "breakingStrength": 20,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "http://www.balancingearthslacklines.com/webbing_tubular_rasta_slackline_balancing_earth_p/rtw.htm"
+    },
+    {
+        "name": "Chi",
+        "brand": "Middle Way Slacklines",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 60,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1454371200000,
+        "product_url": "https://www.middlewayslacklines.com"
+    },
+    {
+        "name": "Zen",
+        "brand": "Middle Way Slacklines",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 62,
+        "breakingStrength": 37,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1454371200000,
+        "product_url": "http://www.middlewayslacklines.com/?gclid=CNuN-J2FrssCFS8z0wodUssKNQ#!product-page/q2heq/175dcc60-c3b2-604d-301a-41aa51e3fc68"
+    },
+    {
+        "name": "Flat",
+        "brand": "Slackline Shop NZ",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 50,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.slacklineshop.co.nz/product/25mm-flat-slackline-webbing/"
+    },
+    {
+        "name": "Sky Pilot (Black/White)",
+        "brand": "Slacklife BC",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 53,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 12,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.slacklifebc.com/product/skypilot-nylon"
+    },
+    {
+        "name": "Lion Line",
+        "brand": "Slacklife BC",
+        "materialType": "Dyneema",
+        "width": 25.4,
+        "weight": 35,
+        "breakingStrength": 35.6,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "https://www.slacklifebc.com/product/lions-line-hightech-webbing/"
+    },
+    {
+        "name": "Tube #1",
+        "brand": "Slackline Shop NZ",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": null,
+        "breakingStrength": 18,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "http://www.slacklineshop.co.nz/product/25-mm-tubular-nylon-slackline-webbing-assorted-colors-order-by-the-metre/"
+    },
+    {
+        "name": "Mirage",
+        "brand": "Absolute Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Alfa",
+        "brand": "Slacklining Canada",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 10.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.slacklining.ca/shop/alfa/"
+    },
+    {
+        "name": "Mamba",
+        "brand": "Spider slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 22,
+        "stretch": [
+            {
+                "percent": 13.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Flamme III",
+        "brand": "Slack Inov",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 76,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 5.4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Abysses",
+        "brand": "Slack Inov",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 63,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 11,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Verve 25mm",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 59,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 11,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/11/landcruising-verve-25-mm-slackline-30m?c=6"
+    },
+    {
+        "name": "Wave Tube  32",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 58,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 16,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "#FFF",
+        "brand": "Raed Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 61,
+        "breakingStrength": 34,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 11
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "SlackPro 42kN",
+        "brand": "Slack Pro!",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 72,
+        "breakingStrength": 42,
+        "stretch": [
+            {
+                "percent": 3.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://www.slackpro.de/en/products/2542slackline.shtml"
+    },
+    {
+        "name": "Neon Light",
+        "brand": "Slack Pro!",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 57,
+        "breakingStrength": 33,
+        "stretch": [
+            {
+                "percent": 3.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Reggae",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 54,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/143-reggae-tubular.html"
+    },
+    {
+        "name": "RVD",
+        "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 21,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/146-rvd-tubular.html"
+    },
+    {
+        "name": "Half-Marathon",
+        "brand": "Slacktivity",
+        "materialType": "Polyester",
+        "width": 20,
+        "weight": 48.5,
+        "breakingStrength": 28,
+        "stretch": [
+            {
+                "percent": 4.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.slacktivity.com/halfmarathon-50m-500m"
+    },
+    {
+        "name": "Low stretch Webbing",
+        "brand": "Slacktivity",
+        "materialType": "Polyester",
+        "width": 37,
+        "weight": 64,
+        "breakingStrength": null,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "SuperMOTM",
+        "brand": "Raed Slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 77,
+        "breakingStrength": 36,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 12
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Plasma",
+        "brand": "Slack Inov",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 73,
+        "breakingStrength": 40,
+        "stretch": [
+            {
+                "percent": 6.2,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "http://slack-inov.com/gb/webbing/92-flamme3-webbing"
+    },
+    {
+        "name": "Mammut",
+        "brand": "Mammut",
+        "materialType": "Polyester",
+        "width": 25.8,
+        "weight": 76.8,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 9.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": null
+    },
+    {
+        "name": "Firefly (phosphorescent)",
+        "brand": "Slack Mountain",
+        "materialType": "Hybrid",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 7.8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1510700400000,
+        "product_url": "https://slack-mountain.com/fr/sangle-hybride/185-firefly.html"
+    },
+    {
+        "name": "French Line",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 52,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 8,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1512946800000,
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/189-french-line.html"
+    },
+    {
+        "name": "Pop-Art",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 50,
+        "weight": 71,
+        "breakingStrength": 30,
+        "stretch": null,
+        "date_introduced": 1513465200000,
+        "product_url": "https://slack-mountain.com/fr/jumplines/191-pop-art.html"
+    },
+    {
+        "name": "Project 44",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 54,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 9.2,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1519340400000,
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/194-project-44.html"
+    },
+    {
+        "name": "Aloha (Aka Aki Tidal)",
+        "brand": "Landcruising",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1511128800000,
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/99/aki-tidal-webbing?c=6"
+    },
+    {
+        "name": "Panda",
+        "brand": "Slackline Industries",
+        "materialType": "Hybrid",
+        "width": 25,
+        "weight": 34.3,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 6.4
+            }
+        ],
+        "date_introduced": 1493758800000,
+        "product_url": "https://slacklineindustries.com/collections/1-inch/products/panda"
+    },
+    {
+        "name": "Joker",
+        "brand": "Slack Inov",
+        "materialType": "Hybrid",
+        "width": 25.4,
+        "weight": 54,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1533934800000,
+        "product_url": "http://slack-inov.com/gb/webbing/110-joker-sold-by-meter"
+    },
+    {
+        "name": "Y.a.w",
+        "brand": "Slackliner.de",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 38,
+        "breakingStrength": 24,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 8
+            }
+        ],
+        "date_introduced": 1541368800000,
+        "product_url": "https://www.slackliner.de/Webbing/Flat-Webbing/yaw.html?language=en"
+    },
+    {
+        "name": "Coelum",
+        "brand": "Petram Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 61.5,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 10,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1539118800000,
+        "product_url": "https://petramslacklines.site123.me/shop-1/coelum-webbing-1"
+    },
+    {
+        "name": "Skyway",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 56.2,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 11,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1542232800000,
+        "product_url": "https://slack-mountain.com/en/webbing-slackline/213-skyway.html"
+    },
+    {
+        "name": "Totally Tubular",
+        "brand": "Slacklife BC",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 40,
+        "breakingStrength": 17.7,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "https://www.slacklifebc.com/product/totally-tubular/"
+    },
+    {
+        "name": "FIREFOX",
+        "brand": "Slack Mountain",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 52,
+        "breakingStrength": 26,
+        "stretch": [
+            {
+                "percent": 17,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1543618800000,
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/214-firefox.html"
+    },
+    {
+        "name": "Spice",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 3.9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1541026800000,
+        "product_url": null
+    },
+    {
+        "name": "Orange",
+        "brand": "Souz Slackline",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 62,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://souzslackline.com/product/violet"
+    },
+    {
+        "name": "S.O.S - Sunset Over Seas",
+        "brand": "Slack Mountain",
+        "materialType": "Hybrid",
+        "width": 22,
+        "weight": 33.6,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 3.4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1554152400000,
+        "product_url": "https://slack-mountain.com/en/hybrid-webbing/221-cloud.html#/242-swen_loop-with/65-longueur-55_m"
+    },
+    {
+        "name": "Blue",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 55,
+        "breakingStrength": 28,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1567976400000,
+        "product_url": "https://www.balancecommunity.com/products/blue"
+    },
+    {
+        "name": "Green",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 53,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 11.72,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1567976400000,
+        "product_url": "https://www.balancecommunity.com/products/green"
+    },
+    {
+        "name": "Polar",
+        "brand": "Aki Slacklines",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 56,
+        "breakingStrength": 28,
+        "stretch": [
+            {
+                "percent": 8.5,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1582668000000,
+        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/162"
+    },
+    {
+        "name": "Jybn",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 51,
+        "breakingStrength": 26,
+        "stretch": [
+            {
+                "percent": 19.6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1583272800000,
+        "product_url": "https://www.balancecommunity.com/products/jybn"
+    },
+    {
+        "name": "SuperTape 19mm",
+        "brand": "Edelrid",
+        "materialType": "Nylon",
+        "width": 18,
+        "weight": 35,
+        "breakingStrength": 15,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "https://www.edelrid.de/en/sports/flat-webbings1/flachband-supertape-19mm.html"
+    },
+    {
+        "name": "X-Tuble 16mm",
+        "brand": "Edelrid",
+        "materialType": "Nylon",
+        "width": 16,
+        "weight": 34,
+        "breakingStrength": 15,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-16mm.html"
+    },
+    {
+        "name": "X-Tube 25mm",
+        "brand": "Edelrid",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 43,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 15.5,
+                "kn": 8
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-25mm.html"
+    },
+    {
+        "name": "Abysses Bounce",
+        "brand": "Slack Inov",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 63,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 15.2,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slack-inov.com/gb/longline/106-abysses-bounce-sold-by-meter"
+    },
+    {
+        "name": "Photon",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 50,
+        "breakingStrength": 29,
+        "stretch": [
+            {
+                "percent": 4.1,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slack-mountain.com/en/webbing-slackline/233-photon.html"
+    },
+    {
+        "name": "Rubber Band PUR",
+        "brand": "Slack house",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 14,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-pur/"
+    },
+    {
+        "name": "Levitation",
+        "brand": "Slack house",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 22,
+        "stretch": [
+            {
+                "percent": 7,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://slackhouseshop.pl/en/produkt/levitation/"
+    },
+    {
+        "name": "MOTM light",
+        "brand": "Raed Slacklines",
+        "materialType": "Nylon",
+        "width": 19,
+        "weight": 33,
+        "breakingStrength": null,
+        "stretch": null,
+        "date_introduced": null,
+        "product_url": "https://raed-slacklines.com/motm-light"
+    },
+    {
+        "name": "Ocean",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 53,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 12,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1590008400000,
+        "product_url": "https://www.slackshop.cz/en/webbing/176-eqb-ocean.html"
+    },
+    {
+        "name": "Skye2",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 59,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1590008400000,
+        "product_url": "https://www.slackshop.cz/en/webbing/175-eqb-skye2.html"
+    },
+    {
+        "name": "LSDTube",
+        "brand": "Slacktivity",
+        "materialType": "Nylon",
+        "width": 25.5,
+        "weight": 49.5,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 18,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1597006800000,
+        "product_url": "https://www.slacktivity.com/lsdtube"
+    },
+    {
+        "name": "Spider Silk MK3",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Dyneema",
+        "width": 20,
+        "weight": 31,
+        "breakingStrength": 38,
+        "stretch": [
+            {
+                "percent": 1.8,
+                "kn": 6
+            }
+        ],
+        "date_introduced": 1592341200000,
+        "product_url": "https://www.balancecommunity.com/products/spider-silk-mk3"
+    },
+    {
+        "name": "Dyneemite",
+        "brand": "Raed Slacklines",
+        "materialType": "Hybrid",
+        "width": 25,
+        "weight": 22,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 1,
+                "kn": 5
+            }
+        ],
+        "date_introduced": 1598734800000,
+        "product_url": "https://raed-slacklines.com/dyneemite-ultralight-highline-project-webbing"
+    },
+    {
+        "name": "Aurora",
+        "brand": "Raed Slacklines",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 61,
+        "breakingStrength": 31,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 5
+            }
+        ],
+        "date_introduced": 1602190800000,
+        "product_url": "https://raed-slacklines.com/aurora-polyester-highline-webbing"
+    },
+    {
+        "name": "ReBL",
+        "brand": "Slackliner.de",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 56,
+        "breakingStrength": 36,
+        "stretch": null,
+        "date_introduced": 1603490400000,
+        "product_url": "https://www.slackliner.de/en/Sigma-ReBL.html"
+    },
+    {
+        "name": "Zen 2",
+        "brand": "Middle Way Slacklines",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 64,
+        "breakingStrength": 32,
+        "stretch": [
+            {
+                "percent": 9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1604181600000,
+        "product_url": "https://middlewayslacklines.com/product/zen25mm/"
+    },
+    {
+        "name": "Lift 2be",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25.4,
+        "weight": 48,
+        "breakingStrength": 21.5,
+        "stretch": [
+            {
+                "percent": 16.9,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1596834000000,
+        "product_url": "https://www.balancecommunity.com/products/lift-2be"
+    },
+    {
+        "name": "Candy",
+        "brand": "Equilibrium Slacklines (EQB)",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 61,
+        "breakingStrength": 36,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1604354400000,
+        "product_url": "https://www.slackshop.cz/en/polyester/195-eqb-candy.html"
+    },
+    {
+        "name": "Eclipse",
+        "brand": "Raed Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 30,
+        "breakingStrength": 16,
+        "stretch": [
+            {
+                "percent": 5,
+                "kn": 5
+            }
+        ],
+        "date_introduced": 1617051600000,
+        "product_url": "https://raed-slacklines.com/eclipse-lightweight-polyester-webbing"
+    },
+    {
+        "name": "Jelly",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Polyester",
+        "width": 25.4,
+        "weight": 45,
+        "breakingStrength": 20,
+        "stretch": [
+            {
+                "percent": 7.01,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1616450400000,
+        "product_url": "https://www.balancecommunity.com/products/jelly-webbing"
+    },
+    {
+        "name": "Blue 20",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Polyester",
+        "width": 20,
+        "weight": 53,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 7.51,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1614290400000,
+        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/blue-20"
+    },
+    {
+        "name": "Green 20",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 20,
+        "weight": 53,
+        "breakingStrength": 25,
+        "stretch": [
+            {
+                "percent": 11.72,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1614290400000,
+        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/green-20?variant"
+    },
+    {
+        "name": "Green Magic",
+        "brand": "Acrobat Slackline",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 60,
+        "breakingStrength": 30,
+        "stretch": [
+            {
+                "percent": 6,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://www.acrobatslackline.com/slackline1inch-1"
+    },
+    {
+        "name": "Purple Gold",
+        "brand": "Aki Slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 65.5,
+        "breakingStrength": 30.5,
+        "stretch": [
+            {
+                "percent": 17,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1605132000000,
+        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/188/sCategory/6"
+    },
+    {
+        "name": "Nomad",
+        "brand": "Aki Slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 38,
+        "breakingStrength": 23.5,
+        "stretch": [
+            {
+                "percent": 4,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1605391200000,
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/187/aki-nomad-webbing"
+    },
+    {
+        "name": "Sonic Light",
+        "brand": "Aki Slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 53,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 13,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1600030800000,
+        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/176/aki-sonic-light-webbing"
+    },
+    {
+        "name": "Sky Diamond",
+        "brand": "Spider slacklines",
+        "materialType": "Dyneema",
+        "width": 17,
+        "weight": 33,
+        "breakingStrength": 35,
+        "stretch": [
+            {
+                "percent": 3,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://spider-slacklines.com/shop/en/highline-webbing/426-2764-sky-diamond-longline-presale.html#/306-select_model-price_by_meter"
+    },
+    {
+        "name": "Rodeo",
+        "brand": "Spider slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": null,
+        "breakingStrength": 27,
+        "stretch": [
+            {
+                "percent": 23.1,
+                "kn": 10
+            }
+        ],
+        "date_introduced": null,
+        "product_url": "https://spider-slacklines.com/shop/en/products/344-3723-rodeo-line.html"
+    },
+    {
+        "name": "Heavy",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 100,
+        "breakingStrength": 45,
+        "stretch": [
+            {
+                "percent": 13.12,
+                "kn": 10
+            }
+        ],
+        "date_introduced": 1623358800000,
+        "product_url": "https://www.balancecommunity.com/products/heavy"
     }
 ]

--- a/webbings.json
+++ b/webbings.json
@@ -1,385 +1,5 @@
 [
     {
-        "name": "9mm static",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.5,
-                "percent": 2
-            },
-            {
-                "kn": 1,
-                "percent": 3.5
-            },
-            {
-                "kn": 5,
-                "percent": 12
-            },
-            {
-                "kn": 10,
-                "percent": 16.1
-            },
-            {
-                "kn": 15,
-                "percent": 20.3
-            },
-            {
-                "kn": 20,
-                "percent": 27.6
-            }
-        ],
-        "materialType": "static rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "10mm static",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.5,
-                "percent": 2.6
-            },
-            {
-                "kn": 1.5,
-                "percent": 4.7
-            },
-            {
-                "kn": 5,
-                "percent": 12.4
-            },
-            {
-                "kn": 10,
-                "percent": 17.1
-            },
-            {
-                "kn": 15,
-                "percent": 20.1
-            },
-            {
-                "kn": 20,
-                "percent": 22.5
-            },
-            {
-                "kn": 25,
-                "percent": 25.6
-            }
-        ],
-        "materialType": "static rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "11mm static",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.8,
-                "percent": 3.9
-            },
-            {
-                "kn": 5,
-                "percent": 12.4
-            },
-            {
-                "kn": 10,
-                "percent": 16.7
-            },
-            {
-                "kn": 15,
-                "percent": 19.1
-            }
-        ],
-        "materialType": "static rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "12mm static",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.8,
-                "percent": 5.5
-            },
-            {
-                "kn": 5,
-                "percent": 15.3
-            },
-            {
-                "kn": 10,
-                "percent": 20.7
-            },
-            {
-                "kn": 15,
-                "percent": 23.7
-            }
-        ],
-        "materialType": "static rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "8.2",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.15,
-                "percent": 2.1
-            },
-            {
-                "kn": 0.2,
-                "percent": 2.8
-            },
-            {
-                "kn": 0.25,
-                "percent": 3.3
-            },
-            {
-                "kn": 0.5,
-                "percent": 5.2
-            },
-            {
-                "kn": 0.75,
-                "percent": 7
-            },
-            {
-                "kn": 1,
-                "percent": 9
-            },
-            {
-                "kn": 2.5,
-                "percent": 19.6
-            },
-            {
-                "kn": 5,
-                "percent": 29.8
-            },
-            {
-                "kn": 7.5,
-                "percent": 37.4
-            },
-            {
-                "kn": 10,
-                "percent": 43.44
-            },
-            {
-                "kn": 12.5,
-                "percent": 47.93
-            }
-        ],
-        "materialType": "climbing rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "8.9",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.15,
-                "percent": 1.5
-            },
-            {
-                "kn": 0.2,
-                "percent": 2
-            },
-            {
-                "kn": 0.25,
-                "percent": 2.3
-            },
-            {
-                "kn": 0.5,
-                "percent": 3.8
-            },
-            {
-                "kn": 0.75,
-                "percent": 5
-            },
-            {
-                "kn": 1,
-                "percent": 6.2
-            },
-            {
-                "kn": 2.5,
-                "percent": 16.3
-            },
-            {
-                "kn": 5,
-                "percent": 25.9
-            },
-            {
-                "kn": 7.5,
-                "percent": 32.9
-            },
-            {
-                "kn": 10,
-                "percent": 38.85
-            },
-            {
-                "kn": 12.5,
-                "percent": 44.06
-            }
-        ],
-        "materialType": "climbing rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "10",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.15,
-                "percent": 1.2
-            },
-            {
-                "kn": 0.2,
-                "percent": 1.7
-            },
-            {
-                "kn": 0.25,
-                "percent": 2.1
-            },
-            {
-                "kn": 0.5,
-                "percent": 3.8
-            },
-            {
-                "kn": 0.75,
-                "percent": 5.5
-            },
-            {
-                "kn": 1,
-                "percent": 7.2
-            },
-            {
-                "kn": 2.5,
-                "percent": 15.7
-            },
-            {
-                "kn": 5,
-                "percent": 24.2
-            },
-            {
-                "kn": 7.5,
-                "percent": 29.8
-            },
-            {
-                "kn": 10,
-                "percent": 34.55
-            },
-            {
-                "kn": 12.5,
-                "percent": 38.28
-            }
-        ],
-        "materialType": "climbing rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "12",
-        "brand": "Edelrid",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 0.15,
-                "percent": 1.3
-            },
-            {
-                "kn": 0.2,
-                "percent": 1.8
-            },
-            {
-                "kn": 0.25,
-                "percent": 2.1
-            },
-            {
-                "kn": 0.5,
-                "percent": 3.6
-            },
-            {
-                "kn": 0.75,
-                "percent": 4.7
-            },
-            {
-                "kn": 1,
-                "percent": 5.8
-            },
-            {
-                "kn": 2.5,
-                "percent": 13.2
-            },
-            {
-                "kn": 5,
-                "percent": 21
-            },
-            {
-                "kn": 7.5,
-                "percent": 26.4
-            },
-            {
-                "kn": 10,
-                "percent": 30.75
-            },
-            {
-                "kn": 12.5,
-                "percent": 34.78
-            }
-        ],
-        "materialType": "climbing rope",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
-    },
-    {
         "name": "Core2 HS",
         "brand": "Landcruising",
         "stretch": [
@@ -436,11 +56,15 @@
                 "percent": 8.1
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 71.5,
         "breakingStrength": 44,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25,
+        "thickness": 3.5,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Core2 LS",
@@ -499,11 +123,15 @@
                 "percent": 3.7
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 69.9,
         "breakingStrength": 44,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25,
+        "thickness": 3.2,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Core1",
@@ -562,11 +190,15 @@
                 "percent": 7
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 76,
-        "breakingStrength": 43,
+        "breakingStrength": 40,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25,
+        "thickness": 3.9,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "T-Wave",
@@ -629,16 +261,25 @@
                 "percent": 18.4
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 80,
         "breakingStrength": 38,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 4.5,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 3.33,
+        "currency": "EUR"
     },
     {
         "name": "Sonic 2",
-        "brand": "Landcruising",
+        "brand": "Aki Slacklines",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 68,
+        "breakingStrength": 34,
         "stretch": [
             {
                 "kn": 0,
@@ -789,11 +430,12 @@
                 "percent": 33.78
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": 68,
-        "breakingStrength": 35,
         "date_introduced": null,
-        "product_url": null
+        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/137/aki-sonic-2-slackline-webbing?c=12&fbclid=IwAR1eTq7La_8P4pp3HW0hq4rE2LNuzA2ZAbm-Vyx4gXORVdZU1EmhrtBbLAo",
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.99,
+        "currency": "EUR"
     },
     {
         "name": "White Magic",
@@ -856,71 +498,16 @@
                 "percent": 15
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 58,
         "breakingStrength": 32.5,
         "date_introduced": null,
         "product_url": "https://aki-slacklines.de/en/webbing/polyester/4/aki-white-magic-webbing?c=6",
-        "width": 25
-    },
-    {
-        "name": "Verve red",
-        "brand": "Landcruising",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 1,
-                "percent": 0.5
-            },
-            {
-                "kn": 2,
-                "percent": 0.9
-            },
-            {
-                "kn": 4,
-                "percent": 1.8
-            },
-            {
-                "kn": 6,
-                "percent": 3.1
-            },
-            {
-                "kn": 8,
-                "percent": 5
-            },
-            {
-                "kn": 10,
-                "percent": 7
-            },
-            {
-                "kn": 12,
-                "percent": 8.9
-            },
-            {
-                "kn": 14,
-                "percent": 10.25
-            },
-            {
-                "kn": 16,
-                "percent": 11.5
-            },
-            {
-                "kn": 18,
-                "percent": 12.4
-            },
-            {
-                "kn": 20,
-                "percent": 13.2
-            }
-        ],
-        "materialType": "pes",
-        "weight": "58",
-        "breakingStrength": "33",
-        "date_introduced": null,
-        "product_url": null
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.3,
+        "currency": "EUR"
     },
     {
         "name": "Unicorn",
@@ -979,12 +566,17 @@
                 "percent": 13
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 61.5,
         "breakingStrength": 32,
         "date_introduced": 1489363200000,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.7,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.79,
+        "currency": "EUR"
     },
     {
         "name": "Wizard",
@@ -1047,12 +639,17 @@
                 "percent": 15
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 55,
         "breakingStrength": 33,
         "date_introduced": 1518991200000,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.5,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.79,
+        "currency": "EUR"
     },
     {
         "name": "Aero",
@@ -1143,12 +740,15 @@
                 "percent": 14.24
             }
         ],
-        "materialType": "pes/polyamid/nylon",
-        "weight": 62,
+        "materialType": "Polyester",
+        "weight": 59,
         "breakingStrength": 33.4,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Aero 2",
@@ -1244,7 +844,12 @@
         "breakingStrength": 33.4,
         "date_introduced": 1449273600000,
         "product_url": "http://www.balancecommunity.com/aero-2",
-        "width": 25.4
+        "width": 25.4,
+        "thickness": 3.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.96,
+        "currency": "USD"
     },
     {
         "name": "Feather",
@@ -1295,12 +900,17 @@
                 "percent": 10.36
             }
         ],
-        "materialType": "pes",
-        "weight": 47,
-        "breakingStrength": 27,
+        "materialType": "Polyester",
+        "weight": 34,
+        "breakingStrength": 20,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 1.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.61,
+        "currency": "USD"
     },
     {
         "name": "Feather Pro",
@@ -1391,12 +1001,17 @@
                 "percent": 14.03
             }
         ],
-        "materialType": "pes/polyamid/nylon",
-        "weight": 47,
+        "materialType": "Polyester",
+        "weight": 51,
         "breakingStrength": 27,
         "date_introduced": 1459900800000,
         "product_url": "http://www.balancecommunity.com/feather-pro",
-        "width": 25
+        "width": 25,
+        "thickness": 2.46,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.36,
+        "currency": "USD"
     },
     {
         "name": "Mantra MK1",
@@ -1590,7 +1205,11 @@
     },
     {
         "name": "Mantra MK3",
-        "brand": "BalanceCommunity",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 83,
+        "breakingStrength": 42,
         "stretch": [
             {
                 "kn": 0,
@@ -1661,11 +1280,11 @@
                 "percent": 13.79
             }
         ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 4.1,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Mantra MK4 Flight",
@@ -1756,12 +1375,17 @@
                 "percent": 7.65
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 76,
         "breakingStrength": 42,
         "date_introduced": null,
         "product_url": "http://www.balancecommunity.com/mantra-mk4-flight",
-        "width": 25
+        "width": 25,
+        "thickness": 3.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.46,
+        "currency": "USD"
     },
     {
         "name": "type-18 MK1",
@@ -1831,8 +1455,12 @@
         "product_url": null
     },
     {
-        "name": "type-18 MK2",
-        "brand": "BalanceCommunity",
+        "name": "Type 18 MKII",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 35.6,
         "stretch": [
             {
                 "kn": 0,
@@ -1891,11 +1519,13 @@
                 "percent": 17.4
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": 62,
-        "breakingStrength": 35.6,
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/type-18-mkii"
+        "product_url": "http://www.balancecommunity.com/type-18-mkii",
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.36,
+        "currency": "USD"
     },
     {
         "name": "Lift",
@@ -1986,15 +1616,25 @@
                 "percent": 23.83
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "58",
-        "breakingStrength": "28",
+        "materialType": "Nylon",
+        "weight": 58,
+        "breakingStrength": 28,
         "date_introduced": 1507150800000,
         "product_url": "http://www.balancecommunity.com/lift",
-        "width": 25
+        "width": 25,
+        "thickness": 3.18,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.46,
+        "currency": "USD"
     },
     {
-        "name": "SpiderSilk MK2",
+        "name": "Spider Silk MK2",
+        "brand": "Balance Community: Slackline Outfitters",
+        "materialType": "Vectran",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 67,
         "stretch": [
             {
                 "kn": 0,
@@ -2081,16 +1721,21 @@
                 "percent": 1.88
             }
         ],
-        "brand": "BalanceCommunity",
-        "materialType": "vectran",
-        "weight": 48,
-        "breakingStrength": 67,
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/spider-silk-mkii"
+        "product_url": "http://www.balancecommunity.com/spider-silk-mkii",
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 9.68,
+        "currency": "USD"
     },
     {
         "name": "Maverick",
         "brand": "Slack.fr",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 62,
+        "breakingStrength": 31,
         "stretch": [
             {
                 "kn": 0,
@@ -2105,11 +1750,12 @@
                 "percent": 4.7
             }
         ],
-        "materialType": "pes",
-        "weight": 62,
-        "breakingStrength": 31,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.4,
+        "currency": "EUR"
     },
     {
         "name": "Moonwalk",
@@ -2136,12 +1782,17 @@
                 "percent": 5
             }
         ],
-        "materialType": "hybrid",
-        "weight": 33.4,
+        "materialType": "Hybrid",
+        "weight": 34,
         "breakingStrength": 35,
         "date_introduced": null,
         "product_url": "https://laboutique.slack.fr/en/slackline-webbings/41-moonwalk-flat-hybride.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 3.2,
+        "currency": "EUR"
     },
     {
         "name": "McFly",
@@ -2164,39 +1815,17 @@
                 "percent": 14.5
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 65,
         "breakingStrength": 31,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
-    },
-    {
-        "name": "Spring",
-        "brand": "Slack.fr",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 5,
-                "percent": 1.8
-            },
-            {
-                "kn": 10,
-                "percent": 4.7
-            },
-            {
-                "kn": 15,
-                "percent": 6.9
-            }
-        ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
+        "width": 25,
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.29,
+        "currency": "EUR"
     },
     {
         "name": "Bluewing",
@@ -2287,16 +1916,24 @@
                 "percent": 16.5
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 63,
         "breakingStrength": 30,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
-        "name": "Passion",
-        "brand": "Elephant Slacklines",
+        "name": "Passion Red",
+        "brand": "Elephant",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 69,
+        "breakingStrength": 33,
         "stretch": [
             {
                 "kn": 0,
@@ -2343,15 +1980,21 @@
                 "percent": 16.9
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": 69,
-        "breakingStrength": 33,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 3,
+        "currency": "CAD"
     },
     {
-        "name": "42kN",
-        "brand": "slackPro",
+        "name": "SlackPro 42kN",
+        "brand": "Slack Pro!",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 72,
+        "breakingStrength": 42,
         "stretch": [
             {
                 "kn": 0,
@@ -2422,11 +2065,11 @@
                 "percent": 6.5
             }
         ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://www.slackpro.de/en/products/2542slackline.shtml",
+        "thickness": 2.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Neon ",
@@ -2481,12 +2124,17 @@
                 "percent": 7.2
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 48,
         "breakingStrength": 20,
         "date_introduced": null,
         "product_url": "https://www.slackshop.cz/en/webbing/30-eqb-neon.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 27,
+        "currency": "CZK"
     },
     {
         "name": "Sigma N",
@@ -2541,16 +2189,24 @@
                 "percent": 23.5
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 55,
         "breakingStrength": 26,
         "date_introduced": null,
         "product_url": "http://www.slackliner.de/Webbing/Nylon/Sigma-N-jormungand-270.html",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
         "name": "Sigma X",
-        "brand": "slackliner.de",
+        "brand": "Slackliner.de",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 44,
+        "breakingStrength": 21,
         "stretch": [
             {
                 "kn": 0,
@@ -2601,54 +2257,12 @@
                 "percent": 25.1
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": 44,
-        "breakingStrength": 21,
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "Sigma P",
-        "brand": "slackliner.de",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 3,
-                "percent": 0.9
-            },
-            {
-                "kn": 6,
-                "percent": 2.1
-            },
-            {
-                "kn": 9,
-                "percent": 4.5
-            },
-            {
-                "kn": 12,
-                "percent": 6.1
-            },
-            {
-                "kn": 15,
-                "percent": 7.2
-            },
-            {
-                "kn": 18,
-                "percent": 8
-            },
-            {
-                "kn": 20,
-                "percent": 8.9
-            }
-        ],
-        "materialType": "",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
+        "product_url": "http://www.slackliner.de/Slackline-Band/Schlauchband/Sigma-X.html",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
         "name": "Sigma Impact",
@@ -2699,12 +2313,17 @@
                 "percent": 16.6
             }
         ],
-        "materialType": "pes",
-        "weight": "64",
-        "breakingStrength": "35",
+        "materialType": "Polyester",
+        "weight": 64,
+        "breakingStrength": 35,
         "date_introduced": null,
         "product_url": "http://www.slackliner.de/Webbing/Flat-Webbing/Sigma-Impact.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.05,
+        "currency": "EUR"
     },
     {
         "name": "Sigma LG",
@@ -2743,12 +2362,17 @@
                 "percent": 9.2
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 66,
         "breakingStrength": 38,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.05,
+        "currency": "EUR"
     },
     {
         "name": "Dragon",
@@ -2779,12 +2403,17 @@
                 "percent": 12
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 64,
         "breakingStrength": 31,
         "date_introduced": null,
         "product_url": "https://www.slackshop.cz/en/webbing/31-eqb-dragon.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 33,
+        "currency": "CZK"
     },
     {
         "name": "Sumo",
@@ -2815,12 +2444,17 @@
                 "percent": 10
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 82,
         "breakingStrength": 40,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 3.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 39,
+        "currency": "CZK"
     },
     {
         "name": "Bounce",
@@ -2847,12 +2481,17 @@
                 "percent": 20
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "38",
-        "breakingStrength": "16",
+        "materialType": "Nylon",
+        "weight": 38,
+        "breakingStrength": 16,
         "date_introduced": null,
         "product_url": "https://www.slackshop.cz/en/for-advanced/142-eqb-bounce.html",
-        "width": 19
+        "width": 19,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 25,
+        "currency": "CZK"
     },
     {
         "name": "Flash",
@@ -2883,12 +2522,15 @@
                 "percent": 17
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 61,
         "breakingStrength": 31,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Element",
@@ -2915,12 +2557,17 @@
                 "percent": 19
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 42,
         "breakingStrength": 20,
         "date_introduced": null,
         "product_url": "http://www.eqb.cz/element-en.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 29,
+        "currency": "CZK"
     },
     {
         "name": "Skye",
@@ -2979,12 +2626,17 @@
                 "percent": 9.79
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 62,
-        "breakingStrength": 36,
+        "breakingStrength": 31,
         "date_introduced": 1492041600000,
         "product_url": "https://www.slackshop.cz/en/webbing/78-eqb-skye.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 45,
+        "currency": "CZK"
     },
     {
         "name": "Fresh",
@@ -3015,12 +2667,17 @@
                 "percent": 25
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 67,
         "breakingStrength": 32,
         "date_introduced": 1496188800000,
         "product_url": "https://www.slackshop.cz/en/webbing/76-157-eqb-fresh.html",
-        "width": 25
+        "width": 25,
+        "thickness": 4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 42,
+        "currency": "CZK"
     },
     {
         "name": "eLine",
@@ -3043,11 +2700,14 @@
                 "percent": 16.5
             }
         ],
-        "materialType": "pes",
-        "weight": 48.18,
+        "materialType": "Polyester",
+        "weight": 52.24,
         "breakingStrength": 21.5,
         "date_introduced": null,
-        "product_url": null
+        "product_url": "https://yogaslackers.com/shop/slackline/eline-webbing/",
+        "width": 25.4,
+        "thickness": 2.08,
+        "webbing_construction": "Tubular"
     },
     {
         "name": "Cobalt",
@@ -3074,12 +2734,17 @@
                 "percent": 6
             }
         ],
-        "materialType": "pes",
-        "weight": "53",
-        "breakingStrength": "29",
+        "materialType": "Polyester",
+        "weight": 60,
+        "breakingStrength": 30,
         "date_introduced": null,
         "product_url": "http://slack-mountain.com/en/webbing-slackline/1-cobalt.html",
-        "width": 25
+        "width": 25,
+        "thickness": 2.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2,
+        "currency": "EUR"
     },
     {
         "name": "Windu",
@@ -3106,16 +2771,25 @@
                 "percent": 10
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 65,
         "breakingStrength": 25,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.33,
+        "currency": "EUR"
     },
     {
-        "name": "Snake",
-        "brand": "SlackMountain",
+        "name": "Snake Tub",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 52,
+        "breakingStrength": 21,
         "stretch": [
             {
                 "kn": 0,
@@ -3134,15 +2808,21 @@
                 "percent": 14.7
             }
         ],
-        "materialType": "pes",
-        "weight": "52",
-        "breakingStrength": "21",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/5-snake-tub.html",
+        "thickness": 2.1,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.5,
+        "currency": "EUR"
     },
     {
-        "name": "Diablo",
-        "brand": "SlackMountain",
+        "name": "Diablo2",
+        "brand": "Slack Mountain",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 96,
+        "breakingStrength": 30,
         "stretch": [
             {
                 "kn": 0,
@@ -3165,11 +2845,13 @@
                 "percent": 5
             }
         ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/132-diablo2.html",
+        "thickness": 3.6,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1,
+        "currency": "EUR"
     },
     {
         "name": "Goku2",
@@ -3196,11 +2878,17 @@
                 "percent": 4.8
             }
         ],
-        "materialType": "hybrid",
-        "weight": "41",
-        "breakingStrength": "40",
+        "materialType": "Hybrid",
+        "weight": 41,
+        "breakingStrength": 40,
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/136-goku2.html"
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/136-goku2.html",
+        "width": 25,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.66,
+        "currency": "EUR"
     },
     {
         "name": "Artic Fox",
@@ -3223,16 +2911,25 @@
                 "percent": 14.7
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 52,
         "breakingStrength": 21,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.3,
+        "currency": "EUR"
     },
     {
-        "name": "flax",
-        "brand": "SlackMountain",
+        "name": "Flax",
+        "brand": "Slack Mountain",
+        "materialType": "Nylon",
+        "width": 25,
+        "weight": 38,
+        "breakingStrength": 20,
         "stretch": [
             {
                 "kn": 0,
@@ -3247,11 +2944,13 @@
                 "percent": 13
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "",
-        "breakingStrength": "",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 1.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.5,
+        "currency": "EUR"
     },
     {
         "name": "morpheus",
@@ -3278,12 +2977,17 @@
                 "percent": 14
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 57,
         "breakingStrength": 25,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "thickness": 2.1,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
         "name": "spectre",
@@ -3310,12 +3014,17 @@
                 "percent": 21.2
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 70,
         "breakingStrength": 30,
         "date_introduced": 1486425600000,
         "product_url": "http://slack-mountain.com/en/webbing-slackline/168-spectre.html",
-        "width": 25
+        "width": 25,
+        "thickness": 3,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.66,
+        "currency": "EUR"
     },
     {
         "name": "rubalise",
@@ -3334,12 +3043,17 @@
                 "percent": 4.6
             }
         ],
-        "materialType": "50mm pes",
+        "materialType": "Polyester",
         "weight": 80,
         "breakingStrength": 30,
         "date_introduced": null,
         "product_url": null,
-        "width": 50
+        "width": 50,
+        "thickness": 1.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.39,
+        "currency": "EUR"
     },
     {
         "name": "wallaby",
@@ -3358,12 +3072,17 @@
                 "percent": 3.3
             }
         ],
-        "materialType": "50mm pes",
-        "weight": "118",
-        "breakingStrength": "30",
+        "materialType": "Polyester",
+        "weight": 118,
+        "breakingStrength": 60,
         "date_introduced": null,
         "product_url": "http://slack-mountain.com/en/jumplines/6-wallaby.html",
-        "width": 48
+        "width": 48,
+        "thickness": 3.1,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.2,
+        "currency": "EUR"
     },
     {
         "name": "Storm",
@@ -3382,12 +3101,17 @@
                 "percent": 4.4
             }
         ],
-        "materialType": "50mm pes",
+        "materialType": "Polyester",
         "weight": 80,
         "breakingStrength": 30,
         "date_introduced": null,
         "product_url": null,
-        "width": 50
+        "width": 50,
+        "thickness": 1.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.2,
+        "currency": "EUR"
     },
     {
         "name": "plum",
@@ -3406,12 +3130,17 @@
                 "percent": 12.8
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 25,
-        "breakingStrength": "10",
+        "breakingStrength": 10,
         "date_introduced": null,
         "product_url": "http://slack-mountain.com/en/webbing-slackline/7-plum.html",
-        "width": 25
+        "width": 25,
+        "thickness": 1,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.67,
+        "currency": "EUR"
     },
     {
         "name": "Cosmic",
@@ -3482,87 +3211,16 @@
                 "percent": 11.47
             }
         ],
-        "materialType": "pes",
-        "weight": "50",
-        "breakingStrength": "31",
+        "materialType": "Polyester",
+        "weight": 50,
+        "breakingStrength": 31,
         "date_introduced": 1470528000000,
         "product_url": "http://slack-inov.com/gb/webbing/69-cosmic",
-        "width": 25
-    },
-    {
-        "name": "Flame3",
-        "brand": "Slack Inov",
-        "stretch": [
-            {
-                "kn": 0,
-                "percent": 0
-            },
-            {
-                "kn": 2,
-                "percent": 1.45
-            },
-            {
-                "kn": 4,
-                "percent": 2.21
-            },
-            {
-                "kn": 6,
-                "percent": 3.02
-            },
-            {
-                "kn": 8,
-                "percent": 4.14
-            },
-            {
-                "kn": 10,
-                "percent": 5.4
-            },
-            {
-                "kn": 12,
-                "percent": 6.71
-            },
-            {
-                "kn": 14,
-                "percent": 8.04
-            },
-            {
-                "kn": 16,
-                "percent": 9.26
-            },
-            {
-                "kn": 18,
-                "percent": 10.38
-            },
-            {
-                "kn": 20,
-                "percent": 11.3
-            },
-            {
-                "kn": 22,
-                "percent": 12.21
-            },
-            {
-                "kn": 24,
-                "percent": 12.97
-            },
-            {
-                "kn": 26,
-                "percent": 13.66
-            },
-            {
-                "kn": 28,
-                "percent": 14.34
-            },
-            {
-                "kn": 30,
-                "percent": 14.96
-            }
-        ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
-        "date_introduced": null,
-        "product_url": null
+        "width": 25,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.6,
+        "currency": "EUR"
     },
     {
         "name": "Donkey",
@@ -3589,12 +3247,16 @@
                 "percent": 13
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "66",
-        "breakingStrength": "32",
+        "materialType": "Nylon",
+        "weight": 66,
+        "breakingStrength": 32,
         "date_introduced": null,
         "product_url": "https://slack-inov.com/gb/longline/144-donkey",
-        "width": 25.4
+        "width": 25.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.9,
+        "currency": "EUR"
     },
     {
         "name": "Nova",
@@ -3621,15 +3283,19 @@
                 "percent": 23.1
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "56",
-        "breakingStrength": "27",
+        "materialType": "Nylon",
+        "weight": 56,
+        "breakingStrength": 27,
         "date_introduced": null,
         "product_url": "https://slack-inov.com/gb/longline/145-nova",
-        "width": 25.4
+        "width": 25.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.7,
+        "currency": "EUR"
     },
     {
-        "name": "(pes)",
+        "name": "Mammut",
         "brand": "Mammut",
         "stretch": [
             {
@@ -3717,11 +3383,14 @@
                 "percent": 15
             }
         ],
-        "materialType": "pes",
-        "weight": "",
-        "breakingStrength": "",
+        "materialType": "Polyester",
+        "weight": 76.8,
+        "breakingStrength": 25,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "width": 25.8,
+        "thickness": 4.2,
+        "webbing_construction": "Core/Sheath"
     },
     {
         "name": "Rainbow",
@@ -3796,12 +3465,16 @@
                 "percent": 12
             }
         ],
-        "materialType": "pes",
-        "weight": "62",
-        "breakingStrength": "36",
+        "materialType": "Polyester",
+        "weight": 62,
+        "breakingStrength": 36,
         "date_introduced": 1539118800000,
         "product_url": "https://raed-slacklines.com/rainbow-polyester-highline-webbing",
-        "width": 25.4
+        "width": 25.4,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.65,
+        "currency": "EUR"
     },
     {
         "name": "Parsec",
@@ -3892,12 +3565,16 @@
                 "percent": 8.5
             }
         ],
-        "materialType": "pes",
-        "weight": "59",
-        "breakingStrength": "33",
+        "materialType": "Polyester",
+        "weight": 59,
+        "breakingStrength": 35,
         "date_introduced": null,
         "product_url": "https://raed-slacklines.com/parsec-longline-webbing",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.99,
+        "currency": "EUR"
     },
     {
         "name": "MOTM",
@@ -3988,12 +3665,16 @@
                 "percent": 23.5
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "56",
-        "breakingStrength": "27",
+        "materialType": "Nylon",
+        "weight": 56,
+        "breakingStrength": 27,
         "date_introduced": null,
         "product_url": "https://raed-slacklines.com/motm-tubular-nylon-slackline-webbing",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
         "name": "Helium",
@@ -4084,12 +3765,16 @@
                 "percent": 9.1
             }
         ],
-        "materialType": "pes",
-        "weight": "38",
-        "breakingStrength": "24",
+        "materialType": "Hybrid",
+        "weight": 38,
+        "breakingStrength": 24,
         "date_introduced": null,
         "product_url": "https://raed-slacklines.com/helium-lightweight-polyester-slackline-webbing",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.69,
+        "currency": "EUR"
     },
     {
         "name": "Cumulus",
@@ -4160,12 +3845,16 @@
                 "percent": 13.2
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "66",
-        "breakingStrength": "35",
+        "materialType": "Nylon",
+        "weight": 66,
+        "breakingStrength": 35,
         "date_introduced": 1563919200000,
         "product_url": "https://raed-slacklines.com/cumulus-nylon-highline-webbing",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.99,
+        "currency": "EUR"
     },
     {
         "name": "pinkTube",
@@ -4272,12 +3961,16 @@
                 "percent": 35.4
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "48",
-        "breakingStrength": "20.6",
+        "materialType": "Nylon",
+        "weight": 48,
+        "breakingStrength": 23.6,
         "date_introduced": 1503349200000,
         "product_url": "https://www.slacktivity.com/pinktube-25m-200m",
-        "width": 25.5
+        "width": 25.5,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.83,
+        "currency": "EUR"
     },
     {
         "name": "redTube",
@@ -4436,12 +4129,16 @@
                 "percent": 34.3
             }
         ],
-        "materialType": "polyamid/nylon",
+        "materialType": "Nylon",
         "weight": 76,
-        "breakingStrength": 36,
+        "breakingStrength": 32,
         "date_introduced": null,
         "product_url": "https://www.slacktivity.com/redtube-30m-200m",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Tubular",
+        "isa_certified": true,
+        "priceMeter": 2.5,
+        "currency": "EUR"
     },
     {
         "name": "Marathon",
@@ -4596,12 +4293,16 @@
                 "percent": 15.9
             }
         ],
-        "materialType": "pes",
-        "weight": "61.5",
-        "breakingStrength": "37",
+        "materialType": "Polyester",
+        "weight": 61.5,
+        "breakingStrength": 37,
         "date_introduced": null,
         "product_url": "https://www.slacktivity.com/marathon-50m-500m",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.8,
+        "currency": "EUR"
     },
     {
         "name": "Marathon Play",
@@ -4756,12 +4457,16 @@
                 "percent": 18.8
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 65,
         "breakingStrength": 37,
         "date_introduced": null,
         "product_url": null,
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.9,
+        "currency": "EUR"
     },
     {
         "name": "halfMarathon 20mm",
@@ -4884,11 +4589,16 @@
                 "percent": 14
             }
         ],
-        "materialType": "pes",
-        "weight": "48.5",
-        "breakingStrength": "28",
+        "materialType": "Polyester",
+        "weight": 48.5,
+        "breakingStrength": 28,
         "date_introduced": null,
-        "product_url": null
+        "product_url": "https://slacktivity.com/shop/halfmarathon-20mm-webbing/",
+        "width": 20,
+        "thickness": 2.6,
+        "webbing_construction": "Core/Sheath",
+        "priceMeter": 2.7,
+        "currency": "EUR"
     },
     {
         "name": "Raven",
@@ -4963,12 +4673,17 @@
                 "percent": 13.07
             }
         ],
-        "materialType": "pes",
+        "materialType": "Polyester",
         "weight": 45,
         "breakingStrength": 16,
         "date_introduced": null,
         "product_url": "https://www.balanceur.ro/slackshop/benzi/pana-corbului/",
-        "width": 25
+        "width": 25,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.85,
+        "currency": "EUR"
     },
     {
         "name": "Milky Way",
@@ -5107,16 +4822,24 @@
                 "percent": 15.45
             }
         ],
-        "materialType": "pes",
-        "weight": "63",
-        "breakingStrength": "32",
+        "materialType": "Polyester",
+        "weight": 63,
+        "breakingStrength": 32,
         "date_introduced": 1562706000000,
         "product_url": "https://www.balanceur.ro/slackshop/benzi/milky-way/",
-        "width": 25
+        "width": 25,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.99,
+        "currency": "EUR"
     },
     {
         "name": "Tender",
-        "brand": "Spider Slacklines",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 48,
+        "breakingStrength": 23,
         "stretch": [
             {
                 "kn": 0,
@@ -5171,15 +4894,21 @@
                 "percent": 18
             }
         ],
-        "materialType": "pes",
-        "weight": "48",
-        "breakingStrength": "23",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/76-tender-line.html",
+        "thickness": 2.5,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.1,
+        "currency": "EUR"
     },
     {
         "name": "Fly",
-        "brand": "Spider Slacklines",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 58,
+        "breakingStrength": 33,
         "stretch": [
             {
                 "kn": 0,
@@ -5234,15 +4963,20 @@
                 "percent": 9.9
             }
         ],
-        "materialType": "pes",
-        "weight": "58",
-        "breakingStrength": "33",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/77-fly-line.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.37,
+        "currency": "EUR"
     },
     {
         "name": "Zao",
-        "brand": "Spider Slacklines",
+        "brand": "Spider slacklines",
+        "materialType": "Polyester",
+        "width": 25,
+        "weight": 65,
+        "breakingStrength": 32,
         "stretch": [
             {
                 "kn": 0,
@@ -5297,11 +5031,13 @@
                 "percent": 14.5
             }
         ],
-        "materialType": "pes",
-        "weight": "65",
-        "breakingStrength": "31",
         "date_introduced": null,
-        "product_url": null
+        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/69-zao-line.html",
+        "thickness": 3.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.4,
+        "currency": "EUR"
     },
     {
         "name": "Edge",
@@ -5360,12 +5096,17 @@
                 "percent": 9.2
             }
         ],
-        "materialType": "pes",
-        "weight": "62",
-        "breakingStrength": "35",
+        "materialType": "Polyester",
+        "weight": 62,
+        "breakingStrength": 35,
         "date_introduced": null,
         "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/74-edge-line.html",
-        "width": 25.4
+        "width": 25.4,
+        "thickness": 2.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.48,
+        "currency": "EUR"
     },
     {
         "name": "Jumbo",
@@ -5424,12 +5165,17 @@
                 "percent": 10.5
             }
         ],
-        "materialType": "pes",
-        "weight": "83",
-        "breakingStrength": "35",
+        "materialType": "Polyester",
+        "weight": 83,
+        "breakingStrength": 35,
         "date_introduced": null,
         "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/73-jumbo-line.html",
-        "width": 25.4
+        "width": 25.4,
+        "thickness": 4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.89,
+        "currency": "EUR"
     },
     {
         "name": "Nylove",
@@ -5488,12 +5234,17 @@
                 "percent": 17
             }
         ],
-        "materialType": "polyamid/nylon",
-        "weight": "62",
-        "breakingStrength": "31",
+        "materialType": "Nylon",
+        "weight": 62,
+        "breakingStrength": 31,
         "date_introduced": null,
         "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/245-nylove-longline-price-per-meter.html",
-        "width": 25
+        "width": 25,
+        "thickness": 3.4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.6,
+        "currency": "EUR"
     },
     {
         "name": "Y2k",
@@ -5506,61 +5257,14 @@
         ],
         "weight": 33.1,
         "breakingStrength": 34,
-        "materialType": "dyneema",
+        "materialType": "Hybrid",
         "date_introduced": 1534744800000,
         "product_url": "https://www.slacktivity.com/y2k",
-        "width": 25.4
-    },
-    {
-        "name": "Voyage",
-        "brand": "Aki Slackline",
-        "stretch": [
-            {
-                "kn": 2,
-                "percent": 0.6
-            },
-            {
-                "kn": 3,
-                "percent": 0.9
-            },
-            {
-                "kn": 4,
-                "percent": 1.2
-            },
-            {
-                "kn": 5,
-                "percent": 1.5
-            },
-            {
-                "kn": 6,
-                "percent": 1.9
-            },
-            {
-                "kn": 7,
-                "percent": 2.3
-            },
-            {
-                "kn": 8,
-                "percent": 3.1
-            },
-            {
-                "kn": 9,
-                "percent": 3.7
-            },
-            {
-                "kn": 10,
-                "percent": 4.4
-            }
-        ],
-        "weight": 55,
-        "priceMeter": {
-            "value": 1.69,
-            "currency": "euro"
-        },
-        "breakingStrength": 33,
-        "materialType": "pes",
-        "date_introduced": null,
-        "product_url": null
+        "width": 25.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.6,
+        "currency": "EUR"
     },
     {
         "name": "Ribera",
@@ -5571,7 +5275,9 @@
         "breakingStrength": 42,
         "stretch": null,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Bloodline",
@@ -5587,7 +5293,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Tape",
@@ -5602,7 +5310,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.singingrock.com/slackline-webbing-yellowblack"
+        "product_url": "http://www.singingrock.com/slackline-webbing-yellowblack",
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Ninja",
@@ -5618,7 +5328,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.eqb.cz/ninja-en.html"
+        "product_url": "https://www.eqb.cz/ninja-en.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 45,
+        "currency": "CZK"
     },
     {
         "name": "Nitro",
@@ -5634,7 +5348,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 55.6,
+        "currency": "CZK"
     },
     {
         "name": "Slim Green",
@@ -5650,7 +5368,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.slackshop.cz/en/webbing/29-eqb-slim.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/29-eqb-slim.html",
+        "thickness": 1.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 18,
+        "currency": "CZK"
     },
     {
         "name": "Chartreuse",
@@ -5666,7 +5389,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Dibona",
@@ -5682,7 +5407,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Elia",
@@ -5698,7 +5425,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Etna II",
@@ -5714,7 +5443,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Fuji",
@@ -5730,7 +5461,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Krakatoa",
@@ -5741,7 +5474,9 @@
         "breakingStrength": 45,
         "stretch": null,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Mauna Kea",
@@ -5757,7 +5492,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Pierra Menta",
@@ -5773,7 +5510,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Vercors",
@@ -5789,7 +5528,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Vesuve",
@@ -5805,7 +5546,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Sat'Elite",
@@ -5816,7 +5559,11 @@
         "breakingStrength": 75,
         "stretch": null,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.72,
+        "currency": "EUR"
     },
     {
         "name": "Red Zebra",
@@ -5832,7 +5579,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.19,
+        "currency": "EUR"
     },
     {
         "name": "Slack Swan",
@@ -5848,7 +5599,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Flamme II",
@@ -5864,7 +5617,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Emeraude",
@@ -5875,39 +5630,11 @@
         "breakingStrength": 40,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "http://slack-inov.com/gb/webbing/9-emeraude"
-    },
-    {
-        "name": "Diablo2",
-        "brand": "Slack Mountain",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 96,
-        "breakingStrength": 30,
-        "stretch": [
-            {
-                "percent": 3.5,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/132-diablo2.html"
-    },
-    {
-        "name": "Flax NY",
-        "brand": "Slack Mountain",
-        "materialType": "Nylon",
-        "width": 25,
-        "weight": 38,
-        "breakingStrength": 20,
-        "stretch": [
-            {
-                "percent": 13,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": null
+        "product_url": "http://slack-inov.com/gb/webbing/9-emeraude",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2,
+        "currency": "EUR"
     },
     {
         "name": "Goku",
@@ -5923,7 +5650,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Goku 2",
@@ -5939,23 +5668,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/136-goku2.html"
-    },
-    {
-        "name": "Snake Tub",
-        "brand": "Slack Mountain",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 52,
-        "breakingStrength": 21,
-        "stretch": [
-            {
-                "percent": 10,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/webbing-slackline/5-snake-tub.html"
+        "product_url": "http://slack-mountain.com/en/webbing-slackline/136-goku2.html",
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.66,
+        "currency": "EUR"
     },
     {
         "name": "Club S",
@@ -5971,7 +5689,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.06,
+        "currency": "EUR"
     },
     {
         "name": "Dark Blue",
@@ -5987,7 +5709,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.96,
+        "currency": "EUR"
     },
     {
         "name": "MILF",
@@ -6003,15 +5729,20 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.15,
+        "currency": "EUR"
     },
     {
         "name": "Neon Light",
         "brand": "Slack.fr",
         "materialType": "Polyester",
         "width": 25,
-        "weight": 62,
-        "breakingStrength": 35,
+        "weight": 57,
+        "breakingStrength": 33,
         "stretch": [
             {
                 "percent": 4.5,
@@ -6019,7 +5750,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "SuperFL Kill Bill",
@@ -6035,23 +5769,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "SuperFL Maverick V2",
-        "brand": "Slack.fr",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 62,
-        "breakingStrength": 31,
-        "stretch": [
-            {
-                "percent": 4.5,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.7,
+        "currency": "EUR"
     },
     {
         "name": "Supertube Norway",
@@ -6067,7 +5790,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.24,
+        "currency": "EUR"
     },
     {
         "name": "Jumpline",
@@ -6083,7 +5811,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Jumpline Pro Series",
@@ -6099,7 +5830,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.75,
+        "currency": "EUR"
     },
     {
         "name": "Jumpline AntiPop",
@@ -6115,23 +5851,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "Passion red",
-        "brand": "Elephant",
-        "materialType": "Nylon",
-        "width": 25,
-        "weight": 69,
-        "breakingStrength": 33,
-        "stretch": [
-            {
-                "percent": 12.3,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.72,
+        "currency": "EUR"
     },
     {
         "name": "Flash'line",
@@ -6147,7 +5872,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://elephant-slacklines.com"
+        "product_url": "http://elephant-slacklines.com",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.35,
+        "currency": "EUR"
     },
     {
         "name": "EcoLine",
@@ -6163,7 +5892,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://elephant-slacklines.com"
+        "product_url": "http://elephant-slacklines.com",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.95,
+        "currency": "EUR"
     },
     {
         "name": "Wing 3.5",
@@ -6179,7 +5912,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Skillshot HS",
@@ -6195,7 +5930,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.1,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Skillshot LS",
@@ -6211,7 +5949,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Flow Line",
@@ -6227,7 +5968,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.gibbon-slacklines.com/en/products/longline-modules/flowline/index.html"
+        "product_url": "http://www.gibbon-slacklines.com/en/products/longline-modules/flowline/index.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Tube Line",
@@ -6238,7 +5981,9 @@
         "breakingStrength": 30,
         "stretch": null,
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Verve 35mm",
@@ -6254,7 +5999,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Core 1",
@@ -6270,7 +6017,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.9,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Core 2 HS",
@@ -6286,7 +6036,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.5,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Core 2 LS",
@@ -6302,7 +6055,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.2,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Matrix",
@@ -6318,7 +6074,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 3.95,
+        "currency": "EUR"
     },
     {
         "name": "Matrix Outer",
@@ -6334,23 +6095,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "Sonic 2.0",
-        "brand": "Aki Slacklines",
-        "materialType": "Nylon",
-        "width": 25,
-        "weight": 68,
-        "breakingStrength": 34,
-        "stretch": [
-            {
-                "percent": 15,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/137/aki-sonic-2-slackline-webbing?c=12&fbclid=IwAR1eTq7La_8P4pp3HW0hq4rE2LNuzA2ZAbm-Vyx4gXORVdZU1EmhrtBbLAo"
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Wave Tube",
@@ -6366,7 +6113,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.3,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.69,
+        "currency": "EUR"
     },
     {
         "name": "Wave Tape 19",
@@ -6382,7 +6134,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.35,
+        "currency": "EUR"
     },
     {
         "name": "Wave Tube 19",
@@ -6398,7 +6155,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.35,
+        "currency": "EUR"
     },
     {
         "name": "Sigma Impact LS",
@@ -6414,23 +6176,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.slackliner.de/Slackline-Band/Flachband/Sigma-Impact-lowstretch.html"
-    },
-    {
-        "name": "Sigma X (HeliX)",
-        "brand": "Slackliner.de",
-        "materialType": "Nylon",
-        "width": 25,
-        "weight": 44,
-        "breakingStrength": 21,
-        "stretch": [
-            {
-                "percent": 15.5,
-                "kn": 8
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://www.slackliner.de/Slackline-Band/Schlauchband/Sigma-X.html"
+        "product_url": "http://www.slackliner.de/Slackline-Band/Flachband/Sigma-Impact-lowstretch.html",
+        "thickness": 2.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.9,
+        "currency": "EUR"
     },
     {
         "name": "Strong II",
@@ -6446,55 +6197,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.slack-shop.de/baender-schlingen/bander/strong/slacklineband-strong-ii.html"
-    },
-    {
-        "name": "FLY Line",
-        "brand": "Spider slacklines",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 58,
-        "breakingStrength": 33,
-        "stretch": [
-            {
-                "percent": 4,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/77-fly-line.html"
-    },
-    {
-        "name": "Tender Line",
-        "brand": "Spider slacklines",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 48,
-        "breakingStrength": 23,
-        "stretch": [
-            {
-                "percent": 6,
-                "kn": 8
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/longline-webbings/76-tender-line.html"
-    },
-    {
-        "name": "Zao Line",
-        "brand": "Spider slacklines",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 65,
-        "breakingStrength": 32,
-        "stretch": [
-            {
-                "percent": 9,
-                "kn": 12
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://spider-slacklines.com/shop/en/longline-webbings/69-zao-line.html"
+        "product_url": "https://www.slack-shop.de/baender-schlingen/bander/strong/slacklineband-strong-ii.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.99,
+        "currency": "EUR"
     },
     {
         "name": "Octopussy MKV",
@@ -6510,7 +6217,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slackhouseshop.pl/en/produkt/octopussy-en"
+        "product_url": "https://slackhouseshop.pl/en/produkt/octopussy-en",
+        "thickness": 2.85,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 3.66,
+        "currency": "PLN"
     },
     {
         "name": "Rubber Band MKIII BLU",
@@ -6526,7 +6238,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-blu"
+        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-blu",
+        "thickness": 3.35,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.47,
+        "currency": "PLN"
     },
     {
         "name": "Rubber Band MKIII SOL",
@@ -6542,7 +6259,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slackhouseshop.pl/en/produkt/slackhouse-rubber-band-25mm-sol/"
+        "product_url": "https://slackhouseshop.pl/en/produkt/slackhouse-rubber-band-25mm-sol/",
+        "thickness": 3.35,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.47,
+        "currency": "PLN"
     },
     {
         "name": "Blue Mile",
@@ -6558,7 +6280,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://slackline.pl/bluemile"
+        "product_url": "http://slackline.pl/bluemile",
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.5,
+        "currency": "PLN"
     },
     {
         "name": "Sin Más",
@@ -6574,7 +6301,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://ambaradam.net/product/sin-mas/"
+        "product_url": "http://ambaradam.net/product/sin-mas/",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.95,
+        "currency": "EUR"
     },
     {
         "name": "Black-White",
@@ -6590,23 +6321,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "Mantra MKIII",
-        "brand": "Balance Community: Slackline Outfitters",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 83,
-        "breakingStrength": 42,
-        "stretch": [
-            {
-                "percent": 8.8,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "EUR"
     },
     {
         "name": "Slack-Spec Tubelar",
@@ -6617,7 +6336,11 @@
         "breakingStrength": 20,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/1-slack-spec-tubular"
+        "product_url": "http://www.balancecommunity.com/1-slack-spec-tubular",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.38,
+        "currency": "USD"
     },
     {
         "name": "Slack-Spec 11/16\"",
@@ -6628,7 +6351,11 @@
         "breakingStrength": 13.3,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/11-16-slack-spec-tubular"
+        "product_url": "http://www.balancecommunity.com/11-16-slack-spec-tubular",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.18,
+        "currency": "USD"
     },
     {
         "name": "Slack-Spec Threaded Tubular",
@@ -6644,7 +6371,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Spider Silk 7/8\"",
@@ -6660,39 +6389,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "Spider Silk MKII",
-        "brand": "Balance Community: Slackline Outfitters",
-        "materialType": "Vectran",
-        "width": 25,
-        "weight": 48,
-        "breakingStrength": 67,
-        "stretch": [
-            {
-                "percent": 1.22,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/spider-silk-mkii"
-    },
-    {
-        "name": "Type 18 MKII",
-        "brand": "Balance Community: Slackline Outfitters",
-        "materialType": "Nylon",
-        "width": 25,
-        "weight": 62,
-        "breakingStrength": 35.6,
-        "stretch": [
-            {
-                "percent": 14.8,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/type-18-mkii"
+        "product_url": null,
+        "thickness": 2.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "RAGEline",
@@ -6708,7 +6408,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/rageline"
+        "product_url": "http://www.balancecommunity.com/rageline",
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "CoreTek",
@@ -6724,7 +6426,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slacklineindustries.com/collections/1-inch/products/coretek"
+        "product_url": "https://slacklineindustries.com/collections/1-inch/products/coretek",
+        "thickness": 2.7,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "USD"
     },
     {
         "name": "Sugoi",
@@ -6740,7 +6447,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slacklineindustries.com/collections/all-products/products/sugoi"
+        "product_url": "https://slacklineindustries.com/collections/all-products/products/sugoi",
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "USD"
     },
     {
         "name": "Great White",
@@ -6756,7 +6468,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.slackgear.co.za/product/great-white/"
+        "product_url": "http://www.slackgear.co.za/product/great-white/",
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 14,
+        "currency": "ZAR"
     },
     {
         "name": "Tantalus",
@@ -6772,7 +6489,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.6,
+        "currency": "CAD"
     },
     {
         "name": "Sky Pilot (Green/Orange)",
@@ -6788,7 +6510,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "HighTech",
@@ -6804,7 +6529,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Type 18 CG4",
@@ -6820,7 +6548,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.balancingearthslacklines.com/slackline_webbing_flat_nylon_type_18_cg4_slackline_p/cg4.htm"
+        "product_url": "http://www.balancingearthslacklines.com/slackline_webbing_flat_nylon_type_18_cg4_slackline_p/cg4.htm",
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "USD"
     },
     {
         "name": "Rasta Tubelar",
@@ -6831,7 +6564,12 @@
         "breakingStrength": 20,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "http://www.balancingearthslacklines.com/webbing_tubular_rasta_slackline_balancing_earth_p/rtw.htm"
+        "product_url": "http://www.balancingearthslacklines.com/webbing_tubular_rasta_slackline_balancing_earth_p/rtw.htm",
+        "thickness": 2.2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.38,
+        "currency": "USD"
     },
     {
         "name": "Chi",
@@ -6847,7 +6585,12 @@
             }
         ],
         "date_introduced": 1454371200000,
-        "product_url": "https://www.middlewayslacklines.com"
+        "product_url": "https://www.middlewayslacklines.com",
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 6,
+        "currency": "ILS"
     },
     {
         "name": "Zen",
@@ -6863,7 +6606,12 @@
             }
         ],
         "date_introduced": 1454371200000,
-        "product_url": "http://www.middlewayslacklines.com/?gclid=CNuN-J2FrssCFS8z0wodUssKNQ#!product-page/q2heq/175dcc60-c3b2-604d-301a-41aa51e3fc68"
+        "product_url": "http://www.middlewayslacklines.com/?gclid=CNuN-J2FrssCFS8z0wodUssKNQ#!product-page/q2heq/175dcc60-c3b2-604d-301a-41aa51e3fc68",
+        "thickness": 2.9,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 9,
+        "currency": "ILS"
     },
     {
         "name": "Flat",
@@ -6879,7 +6627,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.slacklineshop.co.nz/product/25mm-flat-slackline-webbing/"
+        "product_url": "https://www.slacklineshop.co.nz/product/25mm-flat-slackline-webbing/",
+        "thickness": 1.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.98,
+        "currency": "NZD"
     },
     {
         "name": "Sky Pilot (Black/White)",
@@ -6895,7 +6648,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.slacklifebc.com/product/skypilot-nylon"
+        "product_url": "https://www.slacklifebc.com/product/skypilot-nylon",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.2,
+        "currency": "CAD"
     },
     {
         "name": "Lion Line",
@@ -6906,7 +6663,11 @@
         "breakingStrength": 35.6,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "https://www.slacklifebc.com/product/lions-line-hightech-webbing/"
+        "product_url": "https://www.slacklifebc.com/product/lions-line-hightech-webbing/",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 8.99,
+        "currency": "CAD"
     },
     {
         "name": "Tube #1",
@@ -6917,7 +6678,11 @@
         "breakingStrength": 18,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "http://www.slacklineshop.co.nz/product/25-mm-tubular-nylon-slackline-webbing-assorted-colors-order-by-the-metre/"
+        "product_url": "http://www.slacklineshop.co.nz/product/25-mm-tubular-nylon-slackline-webbing-assorted-colors-order-by-the-metre/",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.7,
+        "currency": "NZD"
     },
     {
         "name": "Mirage",
@@ -6933,7 +6698,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.8,
+        "currency": "CAD"
     },
     {
         "name": "Alfa",
@@ -6949,7 +6719,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://www.slacklining.ca/shop/alfa/"
+        "product_url": "http://www.slacklining.ca/shop/alfa/",
+        "thickness": 3.1,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "CAD"
     },
     {
         "name": "Mamba",
@@ -6965,7 +6740,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 3.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.59,
+        "currency": "EUR"
     },
     {
         "name": "Flamme III",
@@ -6981,7 +6761,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1,
+        "currency": "EUR"
     },
     {
         "name": "Abysses",
@@ -6997,7 +6781,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "EUR"
     },
     {
         "name": "Verve 25mm",
@@ -7013,7 +6801,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyester/11/landcruising-verve-25-mm-slackline-30m?c=6"
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/11/landcruising-verve-25-mm-slackline-30m?c=6",
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.33,
+        "currency": "EUR"
     },
     {
         "name": "Wave Tube  32",
@@ -7029,7 +6822,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.3,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.95,
+        "currency": "EUR"
     },
     {
         "name": "#FFF",
@@ -7045,23 +6843,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
-    },
-    {
-        "name": "SlackPro 42kN",
-        "brand": "Slack Pro!",
-        "materialType": "Polyester",
-        "width": 25,
-        "weight": 72,
-        "breakingStrength": 42,
-        "stretch": [
-            {
-                "percent": 3.5,
-                "kn": 10
-            }
-        ],
-        "date_introduced": null,
-        "product_url": "http://www.slackpro.de/en/products/2542slackline.shtml"
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.89,
+        "currency": "EUR"
     },
     {
         "name": "Neon Light",
@@ -7077,7 +6863,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "Reggae",
@@ -7093,7 +6882,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/143-reggae-tubular.html"
+        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/143-reggae-tubular.html",
+        "thickness": 2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.24,
+        "currency": "EUR"
     },
     {
         "name": "RVD",
@@ -7109,7 +6903,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/146-rvd-tubular.html"
+        "product_url": "https://laboutique.slack.fr/en/tubular-webbing/146-rvd-tubular.html",
+        "thickness": 2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.24,
+        "currency": "EUR"
     },
     {
         "name": "Half-Marathon",
@@ -7125,7 +6924,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/halfmarathon-50m-500m"
+        "product_url": "https://www.slacktivity.com/halfmarathon-50m-500m",
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.8,
+        "currency": "EUR"
     },
     {
         "name": "Low stretch Webbing",
@@ -7141,7 +6944,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.79,
+        "currency": "EUR"
     },
     {
         "name": "SuperMOTM",
@@ -7157,7 +6964,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 3.29,
+        "currency": "EUR"
     },
     {
         "name": "Plasma",
@@ -7173,7 +6984,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "http://slack-inov.com/gb/webbing/92-flamme3-webbing"
+        "product_url": "http://slack-inov.com/gb/webbing/92-flamme3-webbing",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.2,
+        "currency": "EUR"
     },
     {
         "name": "Mammut",
@@ -7189,7 +7004,10 @@
             }
         ],
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "thickness": 4.2,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false
     },
     {
         "name": "Firefly (phosphorescent)",
@@ -7205,7 +7023,12 @@
             }
         ],
         "date_introduced": 1510700400000,
-        "product_url": "https://slack-mountain.com/fr/sangle-hybride/185-firefly.html"
+        "product_url": "https://slack-mountain.com/fr/sangle-hybride/185-firefly.html",
+        "thickness": 2,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.79,
+        "currency": "EUR"
     },
     {
         "name": "French Line",
@@ -7221,7 +7044,12 @@
             }
         ],
         "date_introduced": 1512946800000,
-        "product_url": "https://slack-mountain.com/fr/sangles-slackline/189-french-line.html"
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/189-french-line.html",
+        "thickness": 2,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.34,
+        "currency": "EUR"
     },
     {
         "name": "Pop-Art",
@@ -7232,7 +7060,12 @@
         "breakingStrength": 30,
         "stretch": null,
         "date_introduced": 1513465200000,
-        "product_url": "https://slack-mountain.com/fr/jumplines/191-pop-art.html"
+        "product_url": "https://slack-mountain.com/fr/jumplines/191-pop-art.html",
+        "thickness": 1.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.4,
+        "currency": "EUR"
     },
     {
         "name": "Project 44",
@@ -7248,7 +7081,12 @@
             }
         ],
         "date_introduced": 1519340400000,
-        "product_url": "https://slack-mountain.com/fr/sangles-slackline/194-project-44.html"
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/194-project-44.html",
+        "thickness": 1.8,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.65,
+        "currency": "EUR"
     },
     {
         "name": "Aloha (Aka Aki Tidal)",
@@ -7264,7 +7102,12 @@
             }
         ],
         "date_introduced": 1511128800000,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyester/99/aki-tidal-webbing?c=6"
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/99/aki-tidal-webbing?c=6",
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.19,
+        "currency": "EUR"
     },
     {
         "name": "Panda",
@@ -7280,7 +7123,12 @@
             }
         ],
         "date_introduced": 1493758800000,
-        "product_url": "https://slacklineindustries.com/collections/1-inch/products/panda"
+        "product_url": "https://slacklineindustries.com/collections/1-inch/products/panda",
+        "thickness": 2.1,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.59,
+        "currency": "USD"
     },
     {
         "name": "Joker",
@@ -7296,7 +7144,11 @@
             }
         ],
         "date_introduced": 1533934800000,
-        "product_url": "http://slack-inov.com/gb/webbing/110-joker-sold-by-meter"
+        "product_url": "http://slack-inov.com/gb/webbing/110-joker-sold-by-meter",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.99,
+        "currency": "EUR"
     },
     {
         "name": "Y.a.w",
@@ -7312,7 +7164,11 @@
             }
         ],
         "date_introduced": 1541368800000,
-        "product_url": "https://www.slackliner.de/Webbing/Flat-Webbing/yaw.html?language=en"
+        "product_url": "https://www.slackliner.de/Webbing/Flat-Webbing/yaw.html?language=en",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.59,
+        "currency": "EUR"
     },
     {
         "name": "Coelum",
@@ -7328,7 +7184,12 @@
             }
         ],
         "date_introduced": 1539118800000,
-        "product_url": "https://petramslacklines.site123.me/shop-1/coelum-webbing-1"
+        "product_url": "https://petramslacklines.site123.me/shop-1/coelum-webbing-1",
+        "thickness": 2.7,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.65,
+        "currency": "EUR"
     },
     {
         "name": "Skyway",
@@ -7344,7 +7205,12 @@
             }
         ],
         "date_introduced": 1542232800000,
-        "product_url": "https://slack-mountain.com/en/webbing-slackline/213-skyway.html"
+        "product_url": "https://slack-mountain.com/en/webbing-slackline/213-skyway.html",
+        "thickness": 2.3,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.53,
+        "currency": "EUR"
     },
     {
         "name": "Totally Tubular",
@@ -7355,7 +7221,11 @@
         "breakingStrength": 17.7,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "https://www.slacklifebc.com/product/totally-tubular/"
+        "product_url": "https://www.slacklifebc.com/product/totally-tubular/",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.55,
+        "currency": "CAD"
     },
     {
         "name": "FIREFOX",
@@ -7371,7 +7241,12 @@
             }
         ],
         "date_introduced": 1543618800000,
-        "product_url": "https://slack-mountain.com/fr/sangles-slackline/214-firefox.html"
+        "product_url": "https://slack-mountain.com/fr/sangles-slackline/214-firefox.html",
+        "thickness": 2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.5,
+        "currency": "EUR"
     },
     {
         "name": "Spice",
@@ -7387,7 +7262,12 @@
             }
         ],
         "date_introduced": 1541026800000,
-        "product_url": null
+        "product_url": null,
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.1,
+        "currency": "EUR"
     },
     {
         "name": "Orange",
@@ -7403,7 +7283,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://souzslackline.com/product/violet"
+        "product_url": "https://souzslackline.com/product/violet",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 47.53,
+        "currency": "RUB"
     },
     {
         "name": "S.O.S - Sunset Over Seas",
@@ -7419,7 +7303,12 @@
             }
         ],
         "date_introduced": 1554152400000,
-        "product_url": "https://slack-mountain.com/en/hybrid-webbing/221-cloud.html#/242-swen_loop-with/65-longueur-55_m"
+        "product_url": "https://slack-mountain.com/en/hybrid-webbing/221-cloud.html#/242-swen_loop-with/65-longueur-55_m",
+        "thickness": 2.14,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 3.2,
+        "currency": "EUR"
     },
     {
         "name": "Blue",
@@ -7435,7 +7324,12 @@
             }
         ],
         "date_introduced": 1567976400000,
-        "product_url": "https://www.balancecommunity.com/products/blue"
+        "product_url": "https://www.balancecommunity.com/products/blue",
+        "thickness": 2.46,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2,
+        "currency": "USD"
     },
     {
         "name": "Green",
@@ -7451,7 +7345,12 @@
             }
         ],
         "date_introduced": 1567976400000,
-        "product_url": "https://www.balancecommunity.com/products/green"
+        "product_url": "https://www.balancecommunity.com/products/green",
+        "thickness": 2.46,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "USD"
     },
     {
         "name": "Polar",
@@ -7467,7 +7366,12 @@
             }
         ],
         "date_introduced": 1582668000000,
-        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/162"
+        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/162",
+        "thickness": 2.4,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.89,
+        "currency": "EUR"
     },
     {
         "name": "Jybn",
@@ -7483,7 +7387,12 @@
             }
         ],
         "date_introduced": 1583272800000,
-        "product_url": "https://www.balancecommunity.com/products/jybn"
+        "product_url": "https://www.balancecommunity.com/products/jybn",
+        "thickness": 2.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.8,
+        "currency": "USD"
     },
     {
         "name": "SuperTape 19mm",
@@ -7494,7 +7403,9 @@
         "breakingStrength": 15,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "https://www.edelrid.de/en/sports/flat-webbings1/flachband-supertape-19mm.html"
+        "product_url": "https://www.edelrid.de/en/sports/flat-webbings1/flachband-supertape-19mm.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false
     },
     {
         "name": "X-Tuble 16mm",
@@ -7505,7 +7416,9 @@
         "breakingStrength": 15,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-16mm.html"
+        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-16mm.html",
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "X-Tube 25mm",
@@ -7521,7 +7434,9 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-25mm.html"
+        "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-25mm.html",
+        "webbing_construction": "Tubular",
+        "isa_certified": false
     },
     {
         "name": "Abysses Bounce",
@@ -7537,7 +7452,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slack-inov.com/gb/longline/106-abysses-bounce-sold-by-meter"
+        "product_url": "https://slack-inov.com/gb/longline/106-abysses-bounce-sold-by-meter",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.6,
+        "currency": "EUR"
     },
     {
         "name": "Photon",
@@ -7553,7 +7472,11 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slack-mountain.com/en/webbing-slackline/233-photon.html"
+        "product_url": "https://slack-mountain.com/en/webbing-slackline/233-photon.html",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.96,
+        "currency": "EUR"
     },
     {
         "name": "Rubber Band PUR",
@@ -7569,7 +7492,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-pur/"
+        "product_url": "https://slackhouseshop.pl/produkt/rubber-band-pur/",
+        "thickness": 3.35,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.47,
+        "currency": "PLN"
     },
     {
         "name": "Levitation",
@@ -7585,7 +7513,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://slackhouseshop.pl/en/produkt/levitation/"
+        "product_url": "https://slackhouseshop.pl/en/produkt/levitation/",
+        "thickness": 2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.93,
+        "currency": "PLN"
     },
     {
         "name": "MOTM light",
@@ -7596,7 +7529,11 @@
         "breakingStrength": null,
         "stretch": null,
         "date_introduced": null,
-        "product_url": "https://raed-slacklines.com/motm-light"
+        "product_url": "https://raed-slacklines.com/motm-light",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 1.49,
+        "currency": "EUR"
     },
     {
         "name": "Ocean",
@@ -7612,7 +7549,12 @@
             }
         ],
         "date_introduced": 1590008400000,
-        "product_url": "https://www.slackshop.cz/en/webbing/176-eqb-ocean.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/176-eqb-ocean.html",
+        "thickness": 2.8,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.74,
+        "currency": "EUR"
     },
     {
         "name": "Skye2",
@@ -7628,7 +7570,12 @@
             }
         ],
         "date_introduced": 1590008400000,
-        "product_url": "https://www.slackshop.cz/en/webbing/175-eqb-skye2.html"
+        "product_url": "https://www.slackshop.cz/en/webbing/175-eqb-skye2.html",
+        "thickness": 2.4,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.84,
+        "currency": "EUR"
     },
     {
         "name": "LSDTube",
@@ -7644,7 +7591,11 @@
             }
         ],
         "date_introduced": 1597006800000,
-        "product_url": "https://www.slacktivity.com/lsdtube"
+        "product_url": "https://www.slacktivity.com/lsdtube",
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.65,
+        "currency": "EUR"
     },
     {
         "name": "Spider Silk MK3",
@@ -7660,7 +7611,12 @@
             }
         ],
         "date_introduced": 1592341200000,
-        "product_url": "https://www.balancecommunity.com/products/spider-silk-mk3"
+        "product_url": "https://www.balancecommunity.com/products/spider-silk-mk3",
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.17,
+        "currency": "USD"
     },
     {
         "name": "Dyneemite",
@@ -7676,7 +7632,11 @@
             }
         ],
         "date_introduced": 1598734800000,
-        "product_url": "https://raed-slacklines.com/dyneemite-ultralight-highline-project-webbing"
+        "product_url": "https://raed-slacklines.com/dyneemite-ultralight-highline-project-webbing",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.99,
+        "currency": "EUR"
     },
     {
         "name": "Aurora",
@@ -7692,7 +7652,11 @@
             }
         ],
         "date_introduced": 1602190800000,
-        "product_url": "https://raed-slacklines.com/aurora-polyester-highline-webbing"
+        "product_url": "https://raed-slacklines.com/aurora-polyester-highline-webbing",
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 1.99,
+        "currency": "EUR"
     },
     {
         "name": "ReBL",
@@ -7703,7 +7667,12 @@
         "breakingStrength": 36,
         "stretch": null,
         "date_introduced": 1603490400000,
-        "product_url": "https://www.slackliner.de/en/Sigma-ReBL.html"
+        "product_url": "https://www.slackliner.de/en/Sigma-ReBL.html",
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.05,
+        "currency": "EUR"
     },
     {
         "name": "Zen 2",
@@ -7719,7 +7688,11 @@
             }
         ],
         "date_introduced": 1604181600000,
-        "product_url": "https://middlewayslacklines.com/product/zen25mm/"
+        "product_url": "https://middlewayslacklines.com/product/zen25mm/",
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 6.9,
+        "currency": "ILS"
     },
     {
         "name": "Lift 2be",
@@ -7735,7 +7708,12 @@
             }
         ],
         "date_introduced": 1596834000000,
-        "product_url": "https://www.balancecommunity.com/products/lift-2be"
+        "product_url": "https://www.balancecommunity.com/products/lift-2be",
+        "thickness": 3.2,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.25,
+        "currency": "USD"
     },
     {
         "name": "Candy",
@@ -7751,7 +7729,12 @@
             }
         ],
         "date_introduced": 1604354400000,
-        "product_url": "https://www.slackshop.cz/en/polyester/195-eqb-candy.html"
+        "product_url": "https://www.slackshop.cz/en/polyester/195-eqb-candy.html",
+        "thickness": 2.6,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.61,
+        "currency": "EUR"
     },
     {
         "name": "Eclipse",
@@ -7767,7 +7750,12 @@
             }
         ],
         "date_introduced": 1617051600000,
-        "product_url": "https://raed-slacklines.com/eclipse-lightweight-polyester-webbing"
+        "product_url": "https://raed-slacklines.com/eclipse-lightweight-polyester-webbing",
+        "thickness": 1.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 0.69,
+        "currency": "EUR"
     },
     {
         "name": "Jelly",
@@ -7783,7 +7771,12 @@
             }
         ],
         "date_introduced": 1616450400000,
-        "product_url": "https://www.balancecommunity.com/products/jelly-webbing"
+        "product_url": "https://www.balancecommunity.com/products/jelly-webbing",
+        "thickness": 2.3,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2,
+        "currency": "USD"
     },
     {
         "name": "Blue 20",
@@ -7799,7 +7792,12 @@
             }
         ],
         "date_introduced": 1614290400000,
-        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/blue-20"
+        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/blue-20",
+        "thickness": 3,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2,
+        "currency": "USD"
     },
     {
         "name": "Green 20",
@@ -7815,7 +7813,12 @@
             }
         ],
         "date_introduced": 1614290400000,
-        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/green-20?variant"
+        "product_url": "https://www.balancecommunity.com/collections/20mm-webbing/products/green-20?variant",
+        "thickness": 3.38,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 2.45,
+        "currency": "USD"
     },
     {
         "name": "Green Magic",
@@ -7831,7 +7834,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://www.acrobatslackline.com/slackline1inch-1"
+        "product_url": "https://www.acrobatslackline.com/slackline1inch-1",
+        "thickness": 2.2,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 6,
+        "currency": "ILS"
     },
     {
         "name": "Purple Gold",
@@ -7847,7 +7855,12 @@
             }
         ],
         "date_introduced": 1605132000000,
-        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/188/sCategory/6"
+        "product_url": "https://aki-slacklines.de/en/detail/index/sArticle/188/sCategory/6",
+        "thickness": 3.4,
+        "webbing_construction": "Tubular",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "EUR"
     },
     {
         "name": "Nomad",
@@ -7863,7 +7876,12 @@
             }
         ],
         "date_introduced": 1605391200000,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyester/187/aki-nomad-webbing"
+        "product_url": "https://aki-slacklines.de/en/webbing/polyester/187/aki-nomad-webbing",
+        "thickness": 1.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1,
+        "currency": "EUR"
     },
     {
         "name": "Sonic Light",
@@ -7879,7 +7897,12 @@
             }
         ],
         "date_introduced": 1600030800000,
-        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/176/aki-sonic-light-webbing"
+        "product_url": "https://aki-slacklines.de/en/webbing/polyamide/176/aki-sonic-light-webbing",
+        "thickness": 2.8,
+        "webbing_construction": "Core/Sheath",
+        "isa_certified": false,
+        "priceMeter": 2.3,
+        "currency": "EUR"
     },
     {
         "name": "Sky Diamond",
@@ -7895,7 +7918,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/highline-webbing/426-2764-sky-diamond-longline-presale.html#/306-select_model-price_by_meter"
+        "product_url": "https://spider-slacklines.com/shop/en/highline-webbing/426-2764-sky-diamond-longline-presale.html#/306-select_model-price_by_meter",
+        "thickness": 3.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 4.97,
+        "currency": "EUR"
     },
     {
         "name": "Rodeo",
@@ -7911,7 +7939,12 @@
             }
         ],
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/products/344-3723-rodeo-line.html"
+        "product_url": "https://spider-slacklines.com/shop/en/products/344-3723-rodeo-line.html",
+        "thickness": 3.5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 1.62,
+        "currency": "EUR"
     },
     {
         "name": "Heavy",
@@ -7927,6 +7960,11 @@
             }
         ],
         "date_introduced": 1623358800000,
-        "product_url": "https://www.balancecommunity.com/products/heavy"
+        "product_url": "https://www.balancecommunity.com/products/heavy",
+        "thickness": 5,
+        "webbing_construction": "Flat",
+        "isa_certified": false,
+        "priceMeter": 3.5,
+        "currency": "USD"
     }
 ]


### PR DESCRIPTION
Pulls the full set of structured fields from SlackDB's `/api/gear/WEB` into the webbing dataset, de-duplicates it, and wires the new fields through the model, loader, and brand handling. Branches cleanly off `main` (no frontend changes).

## What's in here (2 commits)
- **Expand and enrich webbings dataset from SlackDB API** — base dataset expansion.
- **Enrich, de-duplicate, and clean up webbing dataset from SlackDB** — the cleanup:

### Data (`webbings.json`)
- Pull `width`, `thickness`, `webbing_construction`, `isa_certified`, `price`/`currency` from SlackDB (matched by name; Roman-numeral / `line`-suffix / prefix reconciliation).
- Merge **14 duplicate pairs** (keep richer stretch curve + SlackDB specs under the canonical name).
- Move 8 static/climbing-rope items to **`ropes.json`** (not slackline webbing).
- Resolve remaining unmatched items; `eLine` and `halfMarathon 20mm` scraped from vendor pages. Net: **214 webbings**.

### Schema + loader
- Add `webbing_construction` (enum) and `thickness` to the `Webbing` model.
- `load_webbings` stores every mapped field, with robust `parse_price` (handles legacy `{value, currency}` form) and defensive `parse_currency`.
- Canonicalize brand-name variants via `utilities/brand_aliases` so each manufacturer is one `Brand` row (66 → 56 brands).
- Add `NZD` currency.

### Bug fix
- Fix `parse_currency_from_weblock` `UnboundLocalError` that silently dropped weblocks — recovers all **109** weblocks (was 42), matching the SlackDB source of truth.

## Notes
- `id`-field additions and CORS are deliberately excluded (they live on the `frontend` branch).
- This branch keeps `main`'s `weblock_router.py`; the `Weblock.model_validate` fix currently lives on `frontend`.
