### PR TITLE
feat(api): expose id on Public models + enable CORS

### DIFF
--- a/slack_data/main.py
+++ b/slack_data/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import select
 
 from slack_data.database import get_session, create_db_and_tables
@@ -73,6 +74,18 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
+
+# Allow the local Vite dev server (and preview) to call the API from the browser.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(brand_router)
 app.include_router(grip_router)

--- a/slack_data/models/brands.py
+++ b/slack_data/models/brands.py
@@ -116,7 +116,7 @@ class BrandPublic(BaseBrands):
     """
     Model for public brand data.
     """
-
+    id: int
     webbings: list[str]
 
 

--- a/slack_data/models/grips.py
+++ b/slack_data/models/grips.py
@@ -49,6 +49,7 @@ class Grip(BaseGrip, table=True):
 
 class GripPublic(BaseGrip):
     """Model for public grip data."""
+    id: int
     name: str
     material: MetalMaterial
     width_min: int

--- a/slack_data/models/leashrings.py
+++ b/slack_data/models/leashrings.py
@@ -39,6 +39,7 @@ class LeashRing(BaseLeashRing, table=True):
 
 class LeashRingPublic(BaseLeashRing):
     """Model for public leash ring data."""
+    id: int
     name: str
     material: MetalMaterial
     brand_name: str

--- a/slack_data/models/rollers.py
+++ b/slack_data/models/rollers.py
@@ -68,6 +68,7 @@ class Roller(BaseRoller, table=True):
 
 class RollerPublic(BaseRoller):
     """Model for public roller data."""
+    id: int
     name: str
     material: MetalMaterial
     roller_material: RollerMaterial

--- a/slack_data/models/starterkits.py
+++ b/slack_data/models/starterkits.py
@@ -47,6 +47,7 @@ class StarterKit(BaseStarterKit, table=True):
 
 class StarterKitPublic(BaseStarterKit):
     """Model for public starter kit data."""
+    id: int
     name: str
     webbing_length: int
     webbing_width: int

--- a/slack_data/models/treepro.py
+++ b/slack_data/models/treepro.py
@@ -43,6 +43,7 @@ class TreePro(BaseTreePro, table=True):
 
 class TreeProPublic(BaseTreePro):
     """Model for public tree protector data."""
+    id: int
     name: str
     brand_name: str
 

--- a/slack_data/models/tricklinekits.py
+++ b/slack_data/models/tricklinekits.py
@@ -46,6 +46,7 @@ class TricklineKit(BaseTricklineKit, table=True):
 
 class TricklineKitPublic(BaseTricklineKit):
     """Model for public trickline kit data."""
+    id: int
     name: str
     webbing_length: int
     webbing_width: int

--- a/slack_data/models/webbing.py
+++ b/slack_data/models/webbing.py
@@ -66,6 +66,7 @@ class Webbing(BaseWebbing, table=True):
 
 class WebbingPublic(BaseWebbing):
     """Model for public webbing data."""
+    id: int
     name: str                             # required in response
     material: FiberMaterial               # required in response
     width: int                            # required in response

--- a/slack_data/models/weblocks.py
+++ b/slack_data/models/weblocks.py
@@ -62,6 +62,7 @@ class Weblock(BaseWeblock, table=True):
 
 class WeblockPublic(BaseWeblock):
     """Model for public weblock data."""
+    id: int
     name: str
     material: MetalMaterial
     width_min: int


### PR DESCRIPTION
## What

- Add `id: int` to every `*Public` response model (`BrandPublic`, `WebbingPublic`, `WeblockPublic`, `RollerPublic`, `LeashRingPublic`, `GripPublic`, `TreeProPublic`, `StarterKitPublic`, `TricklineKitPublic`).
- Add `CORSMiddleware` allowing the local Vite dev origins (`http://localhost:5173`, `http://127.0.0.1:5173`).

## Why

The frontend needs the row `id` to build detail (`/:slug/:id`) and compare (`?ids=`) routes, and the browser needs CORS to call the API directly (Cypress `cy.request` bypasses CORS, but the app itself does not). These are the minimal backend enablers for the frontend build; no behavior changes for existing consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
