### PR TITLE
feat(frontend): Phases 1-3 — routing, nav, gear listing & cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ venv/
 *.db
 
 # Scraper output (images + manifests)
-scraper/output/
+scraper/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,15 @@
+# Backlog
+
+Non-phase engineering tasks not tracked in [PLAN.md](PLAN.md) (frontend roadmap).
+
+## Backend / data
+
+- [ ] **Auto-sync ISA certification (every 24h).** Build a scheduled job that fetches the
+  official ISA-approved gear list from
+  <https://data.slacklineinternational.org/safety/isa-approved-gear/> once per day and
+  reconciles it against the DB, setting `isa_certified` (top-level bool on webbing / leashring /
+  grip / starterkit / tricklinekit; `specifications["ISA approved"]` string `"true"` on weblock;
+  `isa_approved` on roller). Match on brand + model. Report/queue items on the ISA list that have
+  no matching row so the catalog can be filled in (as of last manual sync these were unmatched:
+  BC Wafer 2.0, BC Wafer XL, BC Loop, BC Threaded Highline Leash, Cong Gear Path,
+  Slack Inov Zenlock, SlackX Orange, Slacktivity HighlineLeash).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,15 @@ Current state: backend only (FastAPI + SQLModel + SQLite), no frontend, no hoste
 
 ## Frontend (in progress)
 
-**Immediate priority:** A sandboxed React + TypeScript + Vite frontend using **simulated/mock data only** — no backend connection yet. Focus entirely on UI display, layout, and component design before wiring up real API calls.
+**Live status + the phase-by-phase roadmap live in [PLAN.md](PLAN.md) — read it first.** It is the
+single source of truth for where the build is and what's next. The visual/UX spec is in
+[DESIGN.md](DESIGN.md).
 
-Directory: `frontend/` at repo root (not yet created).
+Directory: `frontend/` at repo root. Built **TDD against the real backend** (localhost:8000) via a
+red-first Cypress suite — not mock data.
 
-**Tech:** React, TypeScript, Vite. No framework decision beyond that has been made yet.
+**Tech:** React 19, TypeScript, Vite, Tailwind v4, react-router-dom v7. `erasableSyntaxOnly` tsconfig
+→ no TS `enum`s / parameter-properties; use string-literal unions + `as const` arrays.
 
 Key screens to design (in priority order):
 1. Gear listing page (filterable, sortable cards/table per gear type)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,169 @@
+# Frontend Build Plan & Status
+
+The single source of truth for **where the frontend build is and what's next**. TDD against a
+pre-written, red-first Cypress suite that runs on the **real backend** (no mocks).
+
+- **Design spec** (visual + per-type filter/sort/spec-row definitions): [DESIGN.md](DESIGN.md)
+- **Architecture / backend conventions**: [CLAUDE.md](CLAUDE.md)
+- **Schema is canonical in the Python models** — always read `slack_data/models/*.py` before
+  writing frontend code that depends on field names, enums, or nullability. Never trust this doc,
+  DESIGN.md, or memory as the schema source.
+
+---
+
+## Snapshot
+
+- **Branch:** `frontend`, based on `origin/main` @ `#22` (webbing enrichment is in history).
+- **Uncommitted working tree** = all frontend WIP (Phases 1–3) + two backend enablers that are
+  **not** on main and must stay on this branch:
+  - `id: int` added to every `*Public` model (needed for detail/compare routes).
+  - `CORSMiddleware` in `slack_data/main.py` (browser fetch; Cypress `cy.request` bypasses CORS but the app doesn't).
+  - Plus a tiny `webbings.json` cleanup (dup `product_url`, stray `width`) and a `.gitignore` tweak.
+- Local `frontend` has diverged from pushed `origin/frontend` (still @ 2d5d69c). A future push needs `--force-with-lease`.
+
+**Stack:** React 19 + TypeScript + Vite + Tailwind v4, react-router-dom v7. `erasableSyntaxOnly`
+tsconfig → **no TS `enum`s / parameter-properties**; use string-literal unions + `as const` arrays.
+
+---
+
+## Running things
+
+```bash
+# Backend — port 8000 (must be up + seeded for Cypress)
+cd slack_data && fastapi dev main.py
+# Reseed after JSON/loader edits: rm slack_data/database.db then restart (seeding is one-shot per type)
+
+# Frontend dev server — port 5173
+cd frontend && npm run dev
+
+# Cypress (this WSL box needs the X11 libs + ELECTRON var unset)
+cd frontend
+export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh"
+export LD_LIBRARY_PATH="$HOME/.local/lib/cypress-deps:$LD_LIBRARY_PATH"
+unset ELECTRON_RUN_AS_NODE
+npx cypress run --spec cypress/e2e/<spec>.cy.ts
+```
+
+**Verify the app compiles before running tests:** `npm run build` (tsc + vite) and `npm run lint`.
+
+---
+
+## Contract rules (locked in)
+
+- **`data-cy` attributes** drive every test; **`data-{field}="<value>"`** on cards (empty string when null) drive order/filter verification.
+- **Only numeric (int/float) fields are sortable.** Enums/booleans are filter-only (pills), never in the sort dropdown.
+- **Null-last sorting** in both directions. Default sort = API order (first card == API's first item). Name sort = locale compare.
+- **Search** is punctuation/space/case-insensitive (`normalize()` strips `[.\-()/ ]`), matches name OR brand; empty query → all, punctuation-only → none.
+- **Compare:** max 4 items, same gear type, CTA disabled < 2, clears on gear-type switch, deep-linkable via `?ids=`.
+- **URL is state:** `?q=`, `?sort=field-direction`, `?<field>=a,b` (pills), `?<field>_min` / `?<field>_max` (ranges).
+
+---
+
+## Phase roadmap
+
+| # | Phase | Spec | Status |
+|---|-------|------|--------|
+| 1 | Foundation | — | ✅ done (tsc/build/lint clean) |
+| 2 | Nav & layout | `navigation.cy.ts` | ✅ 13/13 |
+| 3 | Listing + cards | `gear_cards`, `gear_listing`, `isa_certification`(cards) | ✅ see below |
+| 4 | Filters | `filters.cy.ts` | 🟡 NEXT — plan below |
+| 5 | Search & sort refinement | `search_sort.cy.ts` | ⬜ |
+| 6 | Detail page | `gear_detail.cy.ts` + `isa_certification`(detail) | ⬜ |
+| 7 | Compare | `compare.cy.ts` | ⬜ |
+| 8 | Manufacturers | `manufacturers.cy.ts` | ⬜ |
+| 9 | URL-state sweep | `url_state.cy.ts` | ⬜ |
+| 10 | Full green + cleanup | (whole suite) | ⬜ |
+
+### ✅ Phase 1 — Foundation
+Types mirroring `*Public` schemas (`types/`), gear registry (`config/gearTypes.ts` — 8 available + Bungees/Leash-Ring-Pro upcoming), API layer (`api/` — paginates past the 100-cap, `API_BASE` from `VITE_API_URL`), `useUrlState` hook, router + `AppLayout` + page stubs.
+
+### ✅ Phase 2 — Nav & layout
+`TopNav` two-tier header (fixed wordmark + Manufacturers row; wrapping category tabs — `nav-tab` vs `nav-tab-upcoming`, active on nested routes). `navigation.cy.ts` **13/13**.
+
+### ✅ Phase 3 — Listing + cards
+Built: `useGearList`, `utils/{search,sort,format}`, `config/{gearFields,sortFields}`, `GearCard` (full anatomy + `data-{field}` + ISA stamp), `IsaApprovedBadge`, `GearGrid`, `GearTable` (chart view), `SortDropdown`, `GearListingPage` (toolbar/skeleton/empty state/grid⇄chart toggle). `FilterSidebar` is a **placeholder** (header only — real groups are Phase 4).
+- `gear_cards` — ✅ **119/119**
+- `isa_certification` — cards pass; **17 failures are the detail-page section** (unblocked by Phase 6)
+- `gear_listing` — ✅ **168/168** (re-run 2026-07-14, 2m10s, all green). The earlier 56 chart-view
+  failures were a spec bug (chart `it`s sat outside the `describe`'s `cy.visit`) → moved inside. **Phase 3 closed.**
+
+### 🟡 Phase 4 — Filters — ACTIVE
+Build the real `FilterSidebar` and wire filtering into the listing pipeline. Contract =
+`filters.cy.ts` (verified against it + the models on 2026-07-14). Runs for all 8 gear types + a
+dedicated webbing-stretch block. Serve both servers (:8000 seeded, :5173) and run:
+`npx cypress run --spec cypress/e2e/filters.cy.ts` (~2–3 min like gear_listing; buffered — stream to a log).
+
+**`data-cy` contract (from the spec — do not rename):**
+`filter-sidebar`, `filter-sidebar-header` (contains `label.toUpperCase()`), `filter-group[data-group="<field>"]`,
+`filter-group-dot`, `filter-group-toggle`, `filter-pill[data-active]`, `range-min`, `range-max`,
+`clear-filters` (already exists in the empty state), plus stretch-only `stretch-kn-pill[data-active]`.
+`data-group` **equals the Python field name** (`width_min`, `breaking_strength`, `isa_certified`, …).
+
+**Step 1 — filter config (`config/filterGroups.ts`, NEW).** Mirror the spec's `FILTER_GROUPS` map
+exactly: per `GearSlug`, an ordered list of `{ group, label, type: 'pill'|'range', unit? }`. Pill order
+follows the spec (pills first, then ranges is how the spec concatenates, but render order in the sidebar
+should match DESIGN's per-type line). **Drive rendering from this config, NOT from model field presence**
+(treepro has an `isa_warning` model field but no ISA filter group; kits have `isa_certified` but no
+`isa_warning`). This is the schema-first artifact for Phase 4 — the source is `slack_data/models/*.py` +
+the enum-value comments already in `filters.cy.ts` and DESIGN.md §"Left Filter Sidebar".
+
+**Step 2 — pill value derivation (data-driven, no phantom values).** For each pill group, compute the
+distinct present values from the *loaded dataset* (not the enum definition) so every pill matches ≥1 item
+and clicking always reduces the count (tests assert `card count <= all`). Enum pills → distinct string
+values; discrete-int pills (`width`, `width_min`, `webbing_width`, `webbing_length`) → sorted distinct
+numbers rendered as `String(n)`; boolean pills (`isa_certified`, `includes_treepro`, `has_sling_attachment`)
+→ Yes/No; `isa_warning` → the distinct `ISAWarning` values present (incl. a "No Warning"/null bucket).
+
+**Step 3 — filter logic (`utils/filter.ts`, NEW) + wire into `GearListingPage`.** Add a `applyFilters(items, activePills, activeRanges)` step between `filterBySearch` and `sortItems` in the page's `visible` memo.
+- Pill match: item passes a group if it has **no** active pills OR `String(item[field])` ∈ selected (multi-select = OR within group, AND across groups). Booleans map value↔`'true'/'false'` or Yes/No consistently with the pill labels.
+- Range match: `min`/`max` from `useUrlState().getRange(field)`; null/blank item values are **excluded** when a bound is set (matches null-last philosophy). Both bounds inclusive.
+- `item-count` + card/table lists already read `visible`, so count stays correct for free.
+
+**Step 4 — URL state.** Reuse `useUrlState` as-is — it already has `getPillValues/togglePill/setPillValues`
+(`?<field>=a,b`) and `getRange/setRangeBound` (`?<field>_min`/`_max`). `clearAll()` already resets
+everything and is what the empty-state `clear-filters` calls. Add a **second** `clear-filters` control in the
+sidebar (spec calls `cy.get('[data-cy="clear-filters"]').first()`), also wired to `clearAll`.
+
+**Step 5 — components.** Replace the `FilterSidebar` placeholder; add `FilterGroup` (collapsible section:
+teal `filter-group-dot`, small-caps label, `filter-group-toggle`; collapse hides its controls via
+`hidden`/unmount — test checks `not.be.visible`), `FilterPill`, `RangeInput` (min+max + unit label text
+inside the group). Styling per DESIGN §"Left Filter Sidebar": pills inactive = white/gray, active =
+teal border + teal text + `#E0F2F1` bg; `data-active` reflects state.
+
+**Step 6 — webbing stretch widget (`StretchFilter.tsx`, the hard part).** `data-group="stretch"`. Parse
+each webbing's `stretch` JSON string (`[{kn,percent}]`). Single-select `stretch-kn-pill`s populated from the
+**union of all kn values** in the dataset (exact count — no phantoms); default-select the kn present in the
+**most** webbing arrays. Selecting a kn: only webbings with a point at that exact kn are eligible; the
+group's `range-min`/`range-max` narrow by `percent` at that kn. Clicking the active kn pill → inactive (all
+show). Changing kn resets the % range. Rules: DESIGN §"Stretch at X kN filter".
+
+**Step 7 — contextual stretch sort.** When a kn is selected, `SortDropdown` gains two `sort-option`s
+matching `/stretch.*low/i` and `/stretch.*high/i` (`data-field="stretch"`). Sorting orders by `percent` at
+the selected kn (null-last, not excluded). Add `data-stretch-percent` to webbing cards (via a computed field
+fed into the card) so the sort test can read the ordered values. This couples the stretch filter state to
+`SortDropdown` + `sortItems` — thread the active kn through the page.
+
+**Watch-outs:** (a) `data-group` must be the raw field name, but card `data-*` attrs are hyphenated — the
+range "excluded" test reads `data-${group.replace(/_/g,'-')}`, already emitted by `dataAttrs`. (b) Range
+fields are all in `CARD_DATA_FIELDS` already — no card change needed except `data-stretch-percent`. (c) Rollers
+`width` is a raw string ("25–35mm") → **not** a filter (excluded per spec). (d) Kits differ only in that
+trickline `tensioning_type` has no "Primitive" — handled automatically by data-driven pills. (e) Keep the
+existing Phase 3 specs green (re-run `gear_listing` + `gear_cards` after wiring filters into `visible`).
+
+### ⬜ Phase 5 — Search & sort refinement
+`search_sort.cy.ts`: normalized name+brand search, "Name A→Z = no `sort` param" default nuance, sort persistence + reset-on-type-switch, contextual stretch sort, search+filter combination. Sort tables: **DESIGN.md → "Sort options".**
+
+### ⬜ Phase 6 — Detail page
+Replace `GearDetailPage` stub: back link, brand/name/price, spec table (`spec-row[data-field]` + units, omit null rows), description, "View product →", ISA certification block + ISA warning banner, not-found. Special cases: weblock width range, webbing classification pill, treepro `price_unit`. Unblocks the 17 `isa_certification` detail failures. Per-type spec rows: **DESIGN.md → "Spec rows per gear type".**
+
+### ⬜ Phase 7 — Compare
+Sticky compare bar (chips, count, max 4, same-type, CTA disabled < 2, clears on gear-type switch) + side-by-side `ComparePage` (columns per item, spec rows, back link, deep-linkable `?ids=`).
+
+### ⬜ Phase 8 — Manufacturers
+Replace `ManufacturersPage` stub: brand cards, View Gear, per-type gear counts (`data-count-*`), search, graceful country/continent filter, list toggle. `BrandPublic` only serializes `webbings` reliably — read the model. Layout: **DESIGN.md → "Manufacturers Page".**
+
+### ⬜ Phase 9 — URL-state sweep
+`url_state.cy.ts`: q / sort / pill / range / combined round-trips, clear-all, 404.
+
+### ⬜ Phase 10 — Full green + cleanup
+Whole suite green; simplify/dedupe.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ SlackData is open source, with an open API to allow other tools to use the datab
 
 ## Frontend
 
-The frontend is scaffolded (React, TypeScript, Vite) with a full Cypress E2E test suite written red-first against the real backend. UI implementation has not started yet.
+A React + TypeScript + Vite app, built TDD against a red-first Cypress E2E suite that runs on the
+real backend. Nav, gear listing, and cards are in place; filters, detail, compare, and manufacturers
+are in progress.
+
+**Build status and the phase-by-phase roadmap live in [PLAN.md](PLAN.md); the visual/UX spec is in [DESIGN.md](DESIGN.md).**
 
 ### Setup
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,32 +1,19 @@
-# React + TypeScript + Vite
+# SlackData Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some Oxlint rules.
+React + TypeScript + Vite. Built TDD against the Cypress E2E suite in `cypress/e2e/`, which runs
+against the **real backend** on `localhost:8000` (start it first — see the root README).
 
-Currently, two official plugins are available:
+- **Build status + phase roadmap:** [../PLAN.md](../PLAN.md)
+- **Visual / UX + per-type spec:** [../DESIGN.md](../DESIGN.md)
+- **Data schema (canonical):** `../slack_data/models/*.py`
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+```bash
+npm install
+npm run dev        # http://localhost:5173
+npm run build      # tsc + vite (compile check)
+npm run lint
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the Oxlint configuration
-
-If you are developing a production application, we recommend enabling type-aware lint rules by installing `oxlint-tsgolint` and editing `.oxlintrc.json`:
-
-```json
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "oxc"],
-  "options": {
-    "typeAware": true
-  },
-  "rules": {
-    "react/rules-of-hooks": "error",
-    "react/only-export-components": ["warn", { "allowConstantExport": true }]
-  }
-}
+# Cypress (see PLAN.md for the WSL env incantation this box needs)
+npm run cypress:open
+npm run cypress:run
 ```
-
-See the [Oxlint rules documentation](https://oxc.rs/docs/guide/usage/linter/rules) for the full list of rules and categories.

--- a/frontend/cypress/e2e/gear_listing.cy.ts
+++ b/frontend/cypress/e2e/gear_listing.cy.ts
@@ -101,9 +101,9 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         cy.get('[data-cy="gear-card"]').should('have.length', all.length)
       })
     })
-  })
 
   // ── Chart (table) view ────────────────────────────────────────────────────
+  // These live inside the describe above so they inherit its cy.visit beforeEach.
   // Chart view shows items as rows in a data table instead of visual cards.
   // Same items, same filters — just a different display format.
   //
@@ -154,5 +154,6 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
     cy.get('[data-cy="view-chart"]').click()
     cy.get('[data-cy="gear-table-row"]').should('not.exist')
     cy.get('[data-cy="empty-state"]').should('be.visible')
+  })
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,27 @@
+// Route table. Route ranking (not JSX order) resolves overlaps: the static
+// segments `/manufacturers` and `:slug/compare` outrank the dynamic `:slug`
+// and `:slug/:id` patterns.
+
+import { Navigate, Route, Routes } from 'react-router-dom'
+import AppLayout from '@/components/layout/AppLayout'
+import GearListingPage from '@/pages/GearListingPage'
+import GearDetailPage from '@/pages/GearDetailPage'
+import ComparePage from '@/pages/ComparePage'
+import ManufacturersPage from '@/pages/ManufacturersPage'
+import NotFoundPage from '@/pages/NotFoundPage'
 import './index.css'
 
 export default function App() {
   return (
-    <div className="min-h-screen" style={{ background: '#F8F7F4' }}>
-      <header data-cy="top-nav" className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-6 h-14 flex items-center gap-8">
-          <span data-cy="wordmark" className="font-bold text-gray-900 text-lg">
-            SlackData
-          </span>
-          <nav data-cy="gear-tabs" className="flex gap-1" />
-        </div>
-      </header>
-      <main className="max-w-7xl mx-auto px-6 py-12">
-        <p className="text-gray-400 text-sm">Coming soon</p>
-      </main>
-    </div>
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<Navigate to="/webbings" replace />} />
+        <Route path="manufacturers" element={<ManufacturersPage />} />
+        <Route path=":slug/compare" element={<ComparePage />} />
+        <Route path=":slug/:id" element={<GearDetailPage />} />
+        <Route path=":slug" element={<GearListingPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
+    </Routes>
   )
 }

--- a/frontend/src/api/brands.ts
+++ b/frontend/src/api/brands.ts
@@ -1,0 +1,12 @@
+// Brand (manufacturer) data access.
+
+import type { Brand } from '@/types'
+import { getAll, getItem } from './client'
+
+export function fetchBrands(): Promise<Brand[]> {
+  return getAll<Brand>('brand')
+}
+
+export function fetchBrand(id: number | string): Promise<Brand> {
+  return getItem<Brand>('brand', id)
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,46 @@
+// Base API client. Talks to the FastAPI backend (default http://localhost:8000).
+// Override with VITE_API_URL at build/dev time.
+
+export const API_BASE =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:8000'
+
+export class ApiError extends Error {
+  status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}
+
+async function request<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`)
+  if (!res.ok) {
+    throw new ApiError(res.status, `GET ${path} failed: ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+// Fetch a single page. `apiPath` is the router prefix (e.g. "webbing").
+export function getPage<T>(apiPath: string, offset = 0, limit = 100): Promise<T[]> {
+  return request<T[]>(`/${apiPath}/?limit=${limit}&offset=${offset}`)
+}
+
+// Fetch a single item by id.
+export function getItem<T>(apiPath: string, id: number | string): Promise<T> {
+  return request<T>(`/${apiPath}/${id}`)
+}
+
+// The backend caps `limit` at 100, so page until a short page comes back.
+export async function getAll<T>(apiPath: string): Promise<T[]> {
+  const PAGE = 100
+  const all: T[] = []
+  let offset = 0
+  for (;;) {
+    const page = await getPage<T>(apiPath, offset, PAGE)
+    all.push(...page)
+    if (page.length < PAGE) break
+    offset += PAGE
+  }
+  return all
+}

--- a/frontend/src/api/gear.ts
+++ b/frontend/src/api/gear.ts
@@ -1,0 +1,21 @@
+// Gear data access. Resolves a URL slug to its backend apiPath via the registry.
+
+import { getGearType } from '@/config/gearTypes'
+import type { GearItem } from '@/types'
+import { getAll, getItem } from './client'
+
+function apiPathFor(slug: string): string {
+  const meta = getGearType(slug)
+  if (!meta) throw new Error(`Unknown gear slug: ${slug}`)
+  return meta.apiPath
+}
+
+// All items for a gear type (fully paginated).
+export function fetchGearList(slug: string): Promise<GearItem[]> {
+  return getAll<GearItem>(apiPathFor(slug))
+}
+
+// A single gear item by id.
+export function fetchGearItem(slug: string, id: number | string): Promise<GearItem> {
+  return getItem<GearItem>(apiPathFor(slug), id)
+}

--- a/frontend/src/components/gear/FilterSidebar.tsx
+++ b/frontend/src/components/gear/FilterSidebar.tsx
@@ -1,0 +1,18 @@
+// Left filter sidebar. Phase 3 renders the container + header; the filter groups
+// (pills, ranges, stretch widget) are built in Phase 4.
+
+import type { GearTypeMeta } from '@/config/gearTypes'
+
+export default function FilterSidebar({ meta }: { meta: GearTypeMeta }) {
+  return (
+    <aside data-cy="filter-sidebar" className="w-[280px] shrink-0">
+      <div
+        data-cy="filter-sidebar-header"
+        className="mb-4 text-xs font-semibold uppercase tracking-wide text-gray-500"
+      >
+        Find your {meta.label.toUpperCase()}
+      </div>
+      {/* filter groups added in Phase 4 */}
+    </aside>
+  )
+}

--- a/frontend/src/components/gear/GearCard.tsx
+++ b/frontend/src/components/gear/GearCard.tsx
@@ -1,0 +1,90 @@
+// A single gear card. Anatomy (top→bottom) per DESIGN.md and gear_cards.cy.ts:
+//   category badge (coral, in image area) · ISA stamp (if certified) · image
+//   brand (small caps) · product name (link) · inline specs · price (amber)
+//   Save / Alert / Compare buttons.
+//
+// The card root carries data-{field} attributes (numeric fields) so sort/filter
+// tests can read raw values. Save/Alert/Compare are non-functional stubs here
+// (Compare is wired in Phase 7).
+
+import { Link } from 'react-router-dom'
+import type { GearTypeMeta } from '@/config/gearTypes'
+import { CARD_DATA_FIELDS, INLINE_SPECS } from '@/config/gearFields'
+import { dataAttrs, formatPrice, formatValue, type AnyItem } from '@/utils/format'
+import IsaApprovedBadge from './IsaApprovedBadge'
+
+const pillBtn =
+  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors'
+
+export default function GearCard({ item, meta }: { item: AnyItem; meta: GearTypeMeta }) {
+  const { slug, label, hasISA } = meta
+  const price = formatPrice(item.price, item.currency)
+  const specs = INLINE_SPECS[slug] ?? []
+  const isaCertified = hasISA && item.isa_certified === true
+
+  const specParts = specs
+    .map(s => formatValue(item[s.field], s.unit))
+    .filter(v => v !== '')
+
+  return (
+    <article
+      data-cy="gear-card"
+      {...dataAttrs(item, CARD_DATA_FIELDS[slug] ?? [])}
+      className="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div
+        data-cy="gear-card-image-area"
+        className="relative flex h-40 items-center justify-center bg-gray-50"
+      >
+        <span
+          data-cy="gear-card-badge"
+          className="absolute left-2 top-2 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white"
+          style={{ background: '#D04A3E' }}
+        >
+          {label}
+        </span>
+        {isaCertified && (
+          <div className="absolute right-2 top-2">
+            <IsaApprovedBadge />
+          </div>
+        )}
+        <span className="text-xs text-gray-300">No image</span>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-1 p-4">
+        <div
+          data-cy="gear-card-brand"
+          className="text-[11px] font-medium uppercase tracking-wide text-gray-500"
+        >
+          {String(item.brand_name)}
+        </div>
+
+        <Link
+          data-cy="gear-card-name"
+          to={`/${slug}/${item.id}`}
+          className="font-bold leading-snug text-gray-900 hover:text-teal-primary"
+        >
+          {String(item.name)}
+        </Link>
+
+        <div data-cy="gear-card-specs" className="text-xs text-gray-500">
+          {specParts.join(' · ')}
+        </div>
+
+        <div className="mt-auto pt-2">
+          {price && (
+            <span data-cy="gear-card-price" className="font-bold" style={{ color: '#E8770A' }}>
+              {price}
+            </span>
+          )}
+        </div>
+
+        <div className="flex gap-2 pt-2">
+          <button data-cy="btn-save" type="button" className={pillBtn}>Save</button>
+          <button data-cy="btn-alert" type="button" className={pillBtn}>Alert</button>
+          <button data-cy="btn-compare" type="button" className={pillBtn}>Compare</button>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/src/components/gear/GearGrid.tsx
+++ b/frontend/src/components/gear/GearGrid.tsx
@@ -1,0 +1,27 @@
+// Card grid (3 columns at ≥lg, per DESIGN.md). `className` lets the page hide it
+// (display:none) when the Chart view is active while keeping it in the DOM.
+
+import type { GearTypeMeta } from '@/config/gearTypes'
+import type { AnyItem } from '@/utils/format'
+import GearCard from './GearCard'
+
+export default function GearGrid({
+  items,
+  meta,
+  className = '',
+}: {
+  items: AnyItem[]
+  meta: GearTypeMeta
+  className?: string
+}) {
+  return (
+    <div
+      data-cy="gear-grid"
+      className={`grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 ${className}`}
+    >
+      {items.map(item => (
+        <GearCard key={String(item.id)} item={item} meta={meta} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/gear/GearTable.tsx
+++ b/frontend/src/components/gear/GearTable.tsx
@@ -1,0 +1,59 @@
+// Chart (table) view — same items as the grid, tabular. Each row links to the
+// item's detail page (gear_listing.cy.ts). `className` lets the page hide it
+// when the Cards view is active.
+
+import { Link } from 'react-router-dom'
+import type { GearTypeMeta } from '@/config/gearTypes'
+import { INLINE_SPECS } from '@/config/gearFields'
+import { formatPrice, formatValue, type AnyItem } from '@/utils/format'
+
+export default function GearTable({
+  items,
+  meta,
+  className = '',
+}: {
+  items: AnyItem[]
+  meta: GearTypeMeta
+  className?: string
+}) {
+  const specs = INLINE_SPECS[meta.slug] ?? []
+
+  return (
+    <div data-cy="gear-table" className={`overflow-x-auto rounded-xl border border-gray-200 bg-white ${className}`}>
+      <table className="w-full text-sm">
+        <thead data-cy="gear-table-header" className="border-b border-gray-200 text-left text-gray-500">
+          <tr>
+            <th className="px-4 py-3 font-medium">Name</th>
+            <th className="px-4 py-3 font-medium">Brand</th>
+            {specs.map(s => (
+              <th key={s.field} className="px-4 py-3 font-medium capitalize">
+                {s.field.replace(/_/g, ' ')}
+              </th>
+            ))}
+            <th className="px-4 py-3 font-medium">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(item => (
+            <tr data-cy="gear-table-row" key={String(item.id)} className="border-b border-gray-100 last:border-0">
+              <td className="px-4 py-2">
+                <Link to={`/${meta.slug}/${item.id}`} className="font-medium text-teal-primary hover:underline">
+                  {String(item.name)}
+                </Link>
+              </td>
+              <td className="px-4 py-2 text-gray-600">{String(item.brand_name)}</td>
+              {specs.map(s => (
+                <td key={s.field} className="px-4 py-2 text-gray-600">
+                  {formatValue(item[s.field], s.unit) || '—'}
+                </td>
+              ))}
+              <td className="px-4 py-2 text-gray-600">
+                {formatPrice(item.price, item.currency) ?? '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/gear/IsaApprovedBadge.tsx
+++ b/frontend/src/components/gear/IsaApprovedBadge.tsx
@@ -1,0 +1,18 @@
+// The ISA "Approved" stamp — the ONLY representation of certification
+// (isa_certification.cy.ts requires this specific badge, not a plain checkmark
+// or text pill). Charcoal frame, teal check, coral accent.
+
+export default function IsaApprovedBadge({ className = '' }: { className?: string }) {
+  return (
+    <div
+      data-cy="isa-approved-badge"
+      title="ISA Approved"
+      className={`inline-flex items-center gap-1 rounded-md border-2 bg-white px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide shadow-sm ${className}`}
+      style={{ borderColor: '#2f3640' }}
+    >
+      <span style={{ color: '#00897B' }} aria-hidden>✓</span>
+      <span style={{ color: '#2f3640' }}>ISA</span>
+      <span style={{ color: '#D04A3E' }}>Approved</span>
+    </div>
+  )
+}

--- a/frontend/src/components/gear/SortDropdown.tsx
+++ b/frontend/src/components/gear/SortDropdown.tsx
@@ -1,0 +1,115 @@
+// Sort dropdown. Only numeric fields are sortable; Name A→Z / Z→A are always
+// present. The button label reflects the current sort; options carry
+// data-field / data-direction for the tests.
+//
+// Phase 3 scope: functional dropdown that writes the sort. The Name-A→Z-as-
+// default (no URL param) nuance and the contextual stretch options are refined
+// in Phase 5.
+
+import { Fragment, useEffect, useRef, useState } from 'react'
+import type { SortSpec } from '@/hooks/useUrlState'
+import { sortFieldsFor } from '@/config/sortFields'
+import type { GearSlug } from '@/types'
+
+function labelFor(sort: SortSpec | null, slug: GearSlug): string {
+  if (!sort) return 'Sort by'
+  if (sort.field === 'name') return sort.direction === 'asc' ? 'Name: A→Z' : 'Name: Z→A'
+  const meta = sortFieldsFor(slug).find(f => f.field === sort.field)
+  const name = meta?.label ?? sort.field
+  return `${name}: ${sort.direction === 'asc' ? 'Low→High' : 'High→Low'}`
+}
+
+export default function SortDropdown({
+  slug,
+  sort,
+  onChange,
+}: {
+  slug: GearSlug
+  sort: SortSpec | null
+  onChange: (spec: SortSpec | null) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const fields = sortFieldsFor(slug)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('mousedown', onClick)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('mousedown', onClick)
+    }
+  }, [open])
+
+  const pick = (spec: SortSpec | null) => {
+    onChange(spec)
+    setOpen(false)
+  }
+
+  const optionClass =
+    'block w-full px-3 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50'
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        data-cy="sort-dropdown"
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:border-gray-400"
+      >
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Sort by</span>
+        <span>{labelFor(sort, slug)}</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 z-30 mt-1 min-w-[210px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          <button
+            data-cy="sort-option"
+            data-field="name"
+            data-direction="asc"
+            className={optionClass}
+            onClick={() => pick({ field: 'name', direction: 'asc' })}
+          >
+            Name: A→Z
+          </button>
+          <button
+            data-cy="sort-option"
+            data-field="name"
+            data-direction="desc"
+            className={optionClass}
+            onClick={() => pick({ field: 'name', direction: 'desc' })}
+          >
+            Name: Z→A
+          </button>
+          {fields.map(f => (
+            <Fragment key={f.field}>
+              <button
+                data-cy="sort-option"
+                data-field={f.field}
+                data-direction="asc"
+                className={optionClass}
+                onClick={() => pick({ field: f.field, direction: 'asc' })}
+              >
+                {f.label}: Low→High
+              </button>
+              <button
+                data-cy="sort-option"
+                data-field={f.field}
+                data-direction="desc"
+                className={optionClass}
+                onClick={() => pick({ field: f.field, direction: 'desc' })}
+              >
+                {f.label}: High→Low
+              </button>
+            </Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,15 @@
+// App shell: persistent top nav + routed page content.
+
+import { Outlet } from 'react-router-dom'
+import TopNav from './TopNav'
+
+export default function AppLayout() {
+  return (
+    <div className="min-h-screen" style={{ background: '#F8F7F4' }}>
+      <TopNav />
+      <main className="max-w-7xl mx-auto px-6 py-8">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -1,0 +1,89 @@
+// Persistent top navigation, two tiers:
+//   Tier 1 (fixed height): wordmark + manufacturers link — the stable upper area.
+//   Tier 2: gear-category tabs. Fixed-size tabs that WRAP onto more rows on
+//           narrow/mobile widths (the header grows downward) rather than
+//           scrolling horizontally.
+//
+// Contract (navigation.cy.ts + manufacturers.cy.ts):
+//   [data-cy="nav-tab"]            one per data-backed gear type (exactly 8)
+//     data-type="{slug}", data-active="true"|"false"
+//   [data-cy="nav-tab-upcoming"]   coming-soon categories (not counted as tabs)
+//   [data-cy="manufacturers-link"] data-active semantics like a tab
+//   [data-cy="wordmark"]           "SlackData"
+//
+// A gear tab is active on its listing page and any nested route (detail/compare).
+
+import { Link, useLocation } from 'react-router-dom'
+import { ALL_GEAR_TYPES } from '@/config/gearTypes'
+
+function isSectionActive(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`)
+}
+
+const tabClass = (active: boolean, muted = false) =>
+  `whitespace-nowrap px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+    active
+      ? 'text-teal-primary border-teal-primary font-semibold'
+      : muted
+        ? 'text-gray-400 border-transparent hover:text-gray-600'
+        : 'text-gray-500 border-transparent hover:text-gray-800'
+  }`
+
+export default function TopNav() {
+  const { pathname } = useLocation()
+  const mfrActive = isSectionActive(pathname, '/manufacturers')
+
+  return (
+    <header
+      data-cy="top-nav"
+      className="bg-white border-b border-gray-200 sticky top-0 z-20"
+    >
+      {/* Tier 1 — fixed upper area */}
+      <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between gap-4">
+        <Link
+          to="/webbings"
+          data-cy="wordmark"
+          className="font-bold text-gray-900 text-lg shrink-0"
+        >
+          SlackData
+        </Link>
+        <Link
+          to="/manufacturers"
+          data-cy="manufacturers-link"
+          data-active={mfrActive ? 'true' : 'false'}
+          className={tabClass(mfrActive)}
+        >
+          Manufacturers
+        </Link>
+      </div>
+
+      {/* Tier 2 — category tabs, wrap on small screens */}
+      <nav
+        aria-label="Gear categories"
+        className="max-w-7xl mx-auto px-6 flex flex-wrap items-center gap-x-1 border-t border-gray-100"
+      >
+        {ALL_GEAR_TYPES.map(({ slug, label, available }) => {
+          const active = isSectionActive(pathname, `/${slug}`)
+          return (
+            <Link
+              key={slug}
+              to={`/${slug}`}
+              data-cy={available ? 'nav-tab' : 'nav-tab-upcoming'}
+              data-type={slug}
+              data-active={active ? 'true' : 'false'}
+              className={tabClass(active, !available)}
+              title={available ? undefined : 'Coming soon'}
+            >
+              {label}
+              {!available && (
+                <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-300">
+                  soon
+                </span>
+              )}
+            </Link>
+          )
+        })}
+      </nav>
+    </header>
+  )
+}

--- a/frontend/src/config/gearFields.ts
+++ b/frontend/src/config/gearFields.ts
@@ -1,0 +1,42 @@
+// Per-gear-type field configuration for the card.
+//
+//  - CARD_DATA_FIELDS: numeric fields emitted as data-{field} attributes on each
+//    card, so sort/filter tests can read raw values without parsing display text.
+//    This is the union of the range-filter fields and the numeric sort fields for
+//    each type (see filters.cy.ts / search_sort.cy.ts). Source of truth for the
+//    field names is slack_data/models/*.py.
+//  - INLINE_SPECS: the few specs shown in the card's inline specs row.
+
+import type { GearSlug } from '@/types'
+
+export const CARD_DATA_FIELDS: Record<GearSlug, string[]> = {
+  webbings:      ['price', 'weight', 'width', 'breaking_strength'],
+  weblocks:      ['price', 'weight', 'width_min', 'breaking_strength'],
+  leashrings:    ['price', 'weight', 'inner_diameter', 'outer_diameter', 'breaking_strength'],
+  grips:         ['price', 'weight', 'width_min', 'wll', 'mbs', 'common_slipping_threshold'],
+  rollers:       ['price', 'weight', 'breaking_strength'],
+  treepros:      ['price', 'weight', 'width', 'length', 'thickness'],
+  starterkits:   ['price', 'weight', 'webbing_length', 'webbing_width'],
+  tricklinekits: ['price', 'weight', 'webbing_length', 'webbing_width'],
+  // upcoming types have no data / cards yet
+  bungees:       [],
+  leashringpro:  [],
+}
+
+export interface InlineSpec {
+  field: string
+  unit?: string
+}
+
+export const INLINE_SPECS: Record<GearSlug, InlineSpec[]> = {
+  webbings:      [{ field: 'material' }, { field: 'width', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
+  weblocks:      [{ field: 'material' }, { field: 'width_min', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
+  leashrings:    [{ field: 'material' }, { field: 'inner_diameter', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
+  grips:         [{ field: 'material' }, { field: 'mbs', unit: 'kN' }],
+  rollers:       [{ field: 'material' }, { field: 'breaking_strength', unit: 'kN' }],
+  treepros:      [{ field: 'width', unit: 'cm' }, { field: 'length', unit: 'cm' }],
+  starterkits:   [{ field: 'webbing_length', unit: 'm' }, { field: 'webbing_width', unit: 'mm' }, { field: 'tensioning_type' }],
+  tricklinekits: [{ field: 'webbing_length', unit: 'm' }, { field: 'webbing_width', unit: 'mm' }, { field: 'tensioning_type' }],
+  bungees:       [],
+  leashringpro:  [],
+}

--- a/frontend/src/config/gearTypes.ts
+++ b/frontend/src/config/gearTypes.ts
@@ -1,0 +1,47 @@
+// Central gear-type registry. Single source of truth for the nav tabs, routing,
+// and API path resolution.
+//
+// `GEAR_TYPES` are the eight data-backed types the test suite iterates over
+// (mirrors cypress/support/gear_types.ts) and the only ones rendered as
+// [data-cy="nav-tab"]. `UPCOMING_GEAR_TYPES` are categories with no data yet —
+// shown in the nav (as [data-cy="nav-tab-upcoming"]) and routing to a
+// "coming soon" listing. `ALL_GEAR_TYPES` is the full nav order.
+
+import type { GearSlug } from '@/types'
+
+export interface GearTypeMeta {
+  slug: GearSlug
+  apiPath: string        // backend router prefix (singular)
+  label: string          // human label shown in the nav + headings
+  hasISA: boolean        // has an isa_certified field
+  hasISAWarning: boolean // has an isa_warning field
+  available: boolean      // false = no data/router yet (coming soon)
+}
+
+export const GEAR_TYPES: GearTypeMeta[] = [
+  { slug: 'webbings',      apiPath: 'webbing',      label: 'Webbings',        hasISA: true,  hasISAWarning: true,  available: true },
+  { slug: 'weblocks',      apiPath: 'weblock',      label: 'Weblocks',        hasISA: true,  hasISAWarning: true,  available: true },
+  { slug: 'leashrings',    apiPath: 'leashring',    label: 'Leash Rings',     hasISA: true,  hasISAWarning: true,  available: true },
+  { slug: 'grips',         apiPath: 'grip',         label: 'Grips',           hasISA: true,  hasISAWarning: true,  available: true },
+  { slug: 'rollers',       apiPath: 'roller',       label: 'Rollers',         hasISA: true,  hasISAWarning: true,  available: true },
+  { slug: 'treepros',      apiPath: 'treepro',      label: 'Tree Protectors', hasISA: false, hasISAWarning: false, available: true },
+  { slug: 'starterkits',   apiPath: 'starterkit',   label: 'Starter Kits',    hasISA: true,  hasISAWarning: false, available: true },
+  { slug: 'tricklinekits', apiPath: 'tricklinekit', label: 'Trickline Kits',  hasISA: true,  hasISAWarning: false, available: true },
+]
+
+export const UPCOMING_GEAR_TYPES: GearTypeMeta[] = [
+  { slug: 'bungees',      apiPath: 'bungee',      label: 'Bungees',        hasISA: false, hasISAWarning: false, available: false },
+  { slug: 'leashringpro', apiPath: 'ringpadding', label: 'Leash Ring Pro', hasISA: false, hasISAWarning: false, available: false },
+]
+
+export const ALL_GEAR_TYPES: GearTypeMeta[] = [...GEAR_TYPES, ...UPCOMING_GEAR_TYPES]
+
+const BY_SLUG = new Map(ALL_GEAR_TYPES.map(g => [g.slug, g]))
+
+export function getGearType(slug: string): GearTypeMeta | undefined {
+  return BY_SLUG.get(slug as GearSlug)
+}
+
+export function isGearSlug(slug: string): slug is GearSlug {
+  return BY_SLUG.has(slug as GearSlug)
+}

--- a/frontend/src/config/sortFields.ts
+++ b/frontend/src/config/sortFields.ts
@@ -1,0 +1,61 @@
+// Sort options per gear type. ONLY numeric fields are sortable; enums/booleans
+// are filter-only (see search_sort.cy.ts). Name A→Z / Z→A are always present.
+// Source of truth for field names/types is slack_data/models/*.py.
+
+import type { GearSlug } from '@/types'
+
+export interface SortFieldMeta {
+  field: string
+  label: string
+  nullLast: boolean // items with null value sort to the bottom in both directions
+}
+
+// Present for every gear type.
+export const UNIVERSAL_SORT_FIELDS: SortFieldMeta[] = [
+  { field: 'price',  label: 'Price',  nullLast: true },
+  { field: 'weight', label: 'Weight', nullLast: true },
+]
+
+export const EXTRA_SORT_FIELDS: Record<GearSlug, SortFieldMeta[]> = {
+  webbings: [
+    { field: 'width',             label: 'Width',             nullLast: false },
+    { field: 'breaking_strength', label: 'Breaking Strength', nullLast: true },
+  ],
+  weblocks: [
+    { field: 'width_min',         label: 'Min Width',         nullLast: false },
+    { field: 'breaking_strength', label: 'Breaking Strength', nullLast: true },
+  ],
+  leashrings: [
+    { field: 'inner_diameter',    label: 'Inner Diameter',    nullLast: true },
+    { field: 'outer_diameter',    label: 'Outer Diameter',    nullLast: true },
+    { field: 'breaking_strength', label: 'Breaking Strength', nullLast: true },
+  ],
+  grips: [
+    { field: 'width_min',                 label: 'Min Width',          nullLast: false },
+    { field: 'wll',                       label: 'WLL',                nullLast: true },
+    { field: 'mbs',                       label: 'MBS',                nullLast: true },
+    { field: 'common_slipping_threshold', label: 'Slipping Threshold', nullLast: true },
+  ],
+  rollers: [
+    { field: 'breaking_strength', label: 'Breaking Strength', nullLast: true },
+  ],
+  treepros: [
+    { field: 'width',     label: 'Width',     nullLast: true },
+    { field: 'length',    label: 'Length',    nullLast: true },
+    { field: 'thickness', label: 'Thickness', nullLast: true },
+  ],
+  starterkits: [
+    { field: 'webbing_length', label: 'Webbing Length', nullLast: false },
+    { field: 'webbing_width',  label: 'Webbing Width',  nullLast: false },
+  ],
+  tricklinekits: [
+    { field: 'webbing_length', label: 'Webbing Length', nullLast: false },
+    { field: 'webbing_width',  label: 'Webbing Width',  nullLast: false },
+  ],
+  bungees:      [],
+  leashringpro: [],
+}
+
+export function sortFieldsFor(slug: GearSlug): SortFieldMeta[] {
+  return [...UNIVERSAL_SORT_FIELDS, ...(EXTRA_SORT_FIELDS[slug] ?? [])]
+}

--- a/frontend/src/hooks/useGearList.ts
+++ b/frontend/src/hooks/useGearList.ts
@@ -1,0 +1,37 @@
+// Fetches the full item list for a gear type (paginated to completion).
+// `enabled` is false for upcoming/no-data types so we don't hit a missing route.
+
+import { useEffect, useState } from 'react'
+import { fetchGearList } from '@/api/gear'
+import type { GearItem } from '@/types'
+
+export function useGearList(slug: string, enabled = true) {
+  const [items, setItems] = useState<GearItem[]>([])
+  const [loading, setLoading] = useState(enabled)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchGearList(slug)
+      .then(data => {
+        if (!cancelled) setItems(data)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err as Error)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug, enabled])
+
+  return { items, loading, error }
+}

--- a/frontend/src/hooks/useUrlState.ts
+++ b/frontend/src/hooks/useUrlState.ts
@@ -1,0 +1,135 @@
+// URL-as-state hook. The listing page keeps search, sort, and every filter in
+// the query string so any view is bookmarkable / shareable (see url_state.cy.ts).
+//
+// Param contract:
+//   ?q=term                          search query
+//   ?sort=field-direction            e.g. ?sort=weight-asc  (Name A→Z = no param)
+//   ?{field}=value1,value2           pill filter (comma-separated multi-select)
+//   ?{field}_min=val&{field}_max=val range filter bounds
+//
+// The hook is generic: `q` and `sort` are fixed keys; pill/range accessors take
+// the field name, and the calling page supplies those from its filter config.
+
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+export type SortDirection = 'asc' | 'desc'
+export interface SortSpec {
+  field: string
+  direction: SortDirection
+}
+
+export function useUrlState() {
+  const [params, setParams] = useSearchParams()
+
+  const q = params.get('q') ?? ''
+
+  const sort = useMemo<SortSpec | null>(() => {
+    const raw = params.get('sort')
+    if (!raw) return null
+    const idx = raw.lastIndexOf('-')
+    if (idx < 0) return null
+    const direction = raw.slice(idx + 1)
+    if (direction !== 'asc' && direction !== 'desc') return null
+    return { field: raw.slice(0, idx), direction }
+  }, [params])
+
+  // All mutations replace history (typing a search term shouldn't spam the
+  // back button) and operate on a copy of the current params.
+  const mutate = useCallback(
+    (fn: (next: URLSearchParams) => void) => {
+      setParams(
+        prev => {
+          const next = new URLSearchParams(prev)
+          fn(next)
+          return next
+        },
+        { replace: true },
+      )
+    },
+    [setParams],
+  )
+
+  const setQ = useCallback(
+    (value: string) => mutate(next => (value ? next.set('q', value) : next.delete('q'))),
+    [mutate],
+  )
+
+  const setSort = useCallback(
+    (spec: SortSpec | null) =>
+      mutate(next =>
+        spec ? next.set('sort', `${spec.field}-${spec.direction}`) : next.delete('sort'),
+      ),
+    [mutate],
+  )
+
+  const getPillValues = useCallback(
+    (field: string): string[] => {
+      const raw = params.get(field)
+      return raw ? raw.split(',') : []
+    },
+    [params],
+  )
+
+  const setPillValues = useCallback(
+    (field: string, values: string[]) =>
+      mutate(next => (values.length ? next.set(field, values.join(',')) : next.delete(field))),
+    [mutate],
+  )
+
+  const togglePill = useCallback(
+    (field: string, value: string) =>
+      mutate(next => {
+        const raw = next.get(field)
+        const values = raw ? raw.split(',') : []
+        const nextValues = values.includes(value)
+          ? values.filter(v => v !== value)
+          : [...values, value]
+        if (nextValues.length) next.set(field, nextValues.join(','))
+        else next.delete(field)
+      }),
+    [mutate],
+  )
+
+  const getRange = useCallback(
+    (field: string): { min?: number; max?: number } => {
+      const min = params.get(`${field}_min`)
+      const max = params.get(`${field}_max`)
+      return {
+        min: min !== null && min !== '' ? Number(min) : undefined,
+        max: max !== null && max !== '' ? Number(max) : undefined,
+      }
+    },
+    [params],
+  )
+
+  const setRangeBound = useCallback(
+    (field: string, bound: 'min' | 'max', value: string) =>
+      mutate(next => {
+        const key = `${field}_${bound}`
+        if (value !== '') next.set(key, value)
+        else next.delete(key)
+      }),
+    [mutate],
+  )
+
+  // Clears search + all filters but stays on the current route.
+  const clearAll = useCallback(
+    () => setParams(new URLSearchParams(), { replace: true }),
+    [setParams],
+  )
+
+  return {
+    params,
+    q,
+    setQ,
+    sort,
+    setSort,
+    getPillValues,
+    setPillValues,
+    togglePill,
+    getRange,
+    setRangeBound,
+    clearAll,
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -1,0 +1,18 @@
+// Compare view (stub — built out in Phase 7).
+
+import { useParams } from 'react-router-dom'
+import { getGearType } from '@/config/gearTypes'
+import NotFoundPage from './NotFoundPage'
+
+export default function ComparePage() {
+  const { slug } = useParams()
+  const meta = slug ? getGearType(slug) : undefined
+  if (!meta) return <NotFoundPage />
+
+  return (
+    <div data-cy="compare-page">
+      <h1 className="text-xl font-bold text-gray-900">Compare {meta.label}</h1>
+      <p className="mt-2 text-gray-400 text-sm">Comparison coming soon.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/GearDetailPage.tsx
+++ b/frontend/src/pages/GearDetailPage.tsx
@@ -1,0 +1,20 @@
+// Gear detail page (stub — built out in Phase 6).
+
+import { useParams } from 'react-router-dom'
+import { getGearType } from '@/config/gearTypes'
+import NotFoundPage from './NotFoundPage'
+
+export default function GearDetailPage() {
+  const { slug, id } = useParams()
+  const meta = slug ? getGearType(slug) : undefined
+  if (!meta) return <NotFoundPage />
+
+  return (
+    <div data-cy="gear-detail">
+      <h1 className="text-xl font-bold text-gray-900">
+        {meta.label} #{id}
+      </h1>
+      <p className="mt-2 text-gray-400 text-sm">Detail coming soon.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -1,0 +1,145 @@
+// Gear listing page: filter sidebar + toolbar (search / count / view toggle /
+// sort) + card grid or chart table.
+//
+// Grid and table are both mounted when there are results; the inactive one is
+// hidden (display:none) so the view toggle just flips visibility. When there are
+// no results, an empty state with a clear-filters action replaces both.
+
+import { useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getGearType } from '@/config/gearTypes'
+import { useGearList } from '@/hooks/useGearList'
+import { useUrlState } from '@/hooks/useUrlState'
+import { filterBySearch } from '@/utils/search'
+import { sortItems } from '@/utils/sort'
+import type { AnyItem } from '@/utils/format'
+import FilterSidebar from '@/components/gear/FilterSidebar'
+import SortDropdown from '@/components/gear/SortDropdown'
+import GearGrid from '@/components/gear/GearGrid'
+import GearTable from '@/components/gear/GearTable'
+import NotFoundPage from './NotFoundPage'
+
+type View = 'cards' | 'chart'
+
+function LoadingSkeleton() {
+  return (
+    <div data-cy="loading-skeleton" className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="h-72 animate-pulse rounded-xl border border-gray-200 bg-white" />
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({ onClear }: { onClear: () => void }) {
+  return (
+    <div data-cy="empty-state" className="py-16 text-center">
+      <p className="text-gray-500">No matches found.</p>
+      <button
+        data-cy="clear-filters"
+        type="button"
+        onClick={onClear}
+        className="mt-3 font-medium text-teal-primary hover:underline"
+      >
+        Clear filters
+      </button>
+    </div>
+  )
+}
+
+const viewBtn = (active: boolean) =>
+  `px-3 py-1.5 text-sm ${active ? 'bg-teal-primary text-white' : 'bg-white text-gray-600 hover:text-gray-900'}`
+
+export default function GearListingPage() {
+  const { slug } = useParams()
+  const meta = slug ? getGearType(slug) : undefined
+  const available = !!meta?.available
+  const { items, loading } = useGearList(meta?.slug ?? '', available)
+  const { q, setQ, sort, setSort, clearAll } = useUrlState()
+  const [view, setView] = useState<View>('cards')
+
+  const visible = useMemo(() => {
+    const filtered = filterBySearch(items, q)
+    return sortItems(filtered as unknown as AnyItem[], sort)
+  }, [items, q, sort])
+
+  if (!meta) return <NotFoundPage />
+
+  if (!available) {
+    return (
+      <div data-cy="gear-listing">
+        <h1 className="text-xl font-bold text-gray-900">{meta.label}</h1>
+        <p data-cy="coming-soon" className="mt-3 text-gray-500">
+          Coming soon — we don&apos;t have {meta.label.toLowerCase()} data yet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div data-cy="gear-listing">
+      <h1 className="mb-6 text-2xl font-bold text-gray-900">{meta.label}</h1>
+
+      <div className="flex gap-8">
+        <FilterSidebar meta={meta} />
+
+        <div className="min-w-0 flex-1">
+          {/* Toolbar */}
+          <div className="mb-6 flex flex-wrap items-center gap-3">
+            <input
+              data-cy="search-input"
+              type="search"
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              placeholder={`Search ${meta.label}…`}
+              className="w-64 rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-teal-primary focus:outline-none"
+            />
+            <span data-cy="item-count" className="text-sm text-gray-500">
+              {visible.length} {visible.length === 1 ? 'item' : 'items'}
+            </span>
+
+            <div className="ml-auto flex items-center gap-3">
+              <div className="flex overflow-hidden rounded-lg border border-gray-300">
+                <button
+                  data-cy="view-cards"
+                  type="button"
+                  data-active={view === 'cards' ? 'true' : 'false'}
+                  onClick={() => setView('cards')}
+                  className={viewBtn(view === 'cards')}
+                >
+                  Cards
+                </button>
+                <button
+                  data-cy="view-chart"
+                  type="button"
+                  data-active={view === 'chart' ? 'true' : 'false'}
+                  onClick={() => setView('chart')}
+                  className={`border-l border-gray-300 ${viewBtn(view === 'chart')}`}
+                >
+                  Chart
+                </button>
+              </div>
+              <SortDropdown slug={meta.slug} sort={sort} onChange={setSort} />
+            </div>
+          </div>
+
+          {/* Results */}
+          {loading ? (
+            <LoadingSkeleton />
+          ) : visible.length === 0 ? (
+            <EmptyState onClear={clearAll} />
+          ) : (
+            <>
+              <div className={view === 'chart' ? 'hidden' : ''}>
+                <GearGrid items={visible} meta={meta} />
+              </div>
+              <div className={view === 'cards' ? 'hidden' : ''}>
+                <GearTable items={visible} meta={meta} />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ManufacturersPage.tsx
+++ b/frontend/src/pages/ManufacturersPage.tsx
@@ -1,0 +1,10 @@
+// Manufacturers directory (stub — built out in Phase 8).
+
+export default function ManufacturersPage() {
+  return (
+    <div data-cy="manufacturers-page">
+      <h1 className="text-xl font-bold text-gray-900">Manufacturers</h1>
+      <p className="mt-2 text-gray-400 text-sm">Directory coming soon.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,21 @@
+// Shown for unknown routes and unknown item ids.
+
+import { Link } from 'react-router-dom'
+
+export default function NotFoundPage() {
+  return (
+    <div data-cy="not-found" className="py-24 text-center">
+      <h1 className="text-2xl font-bold text-gray-900">Page not found</h1>
+      <p className="mt-2 text-gray-500">
+        We couldn&apos;t find what you were looking for.
+      </p>
+      <Link
+        data-cy="not-found-home-link"
+        to="/webbings"
+        className="mt-6 inline-block text-teal-primary font-medium"
+      >
+        ← Back to Webbings
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/types/brand.ts
+++ b/frontend/src/types/brand.ts
@@ -1,0 +1,22 @@
+// Brand (manufacturer) type — mirrors BrandPublic in slack_data/models/brands.py.
+//
+// BrandPublic exposes only `webbings` among the gear lists (the other gear-type
+// computed fields exist on the ORM model but are not declared in the response
+// schema). `id` is added in Phase 0 for routing. Gear counts per type are NOT
+// provided by the API — the client computes them by fetching each gear endpoint.
+
+import type { Country } from './enums'
+
+export interface Brand {
+  id: number
+  name: string
+  country: Country | null
+  year_founded: number | null
+  active: boolean
+  slackline_focused: boolean
+  website: string | null
+  socials: string | null
+  description: string | null
+  notes: string | null
+  webbings: string[]
+}

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -1,0 +1,92 @@
+// Enum values mirrored from slack_data/models/*.py and slack_data/utilities/*.py.
+// The backend uses Python Enums; the tsconfig has `erasableSyntaxOnly`, so we
+// model them as string-literal unions plus `as const` arrays (usable at runtime
+// for labels/ordering) instead of TS enums.
+
+// utilities/materials.py — MetalMaterial
+export const METAL_MATERIALS = [
+  'Aluminum', 'Steel', 'Stainless Steel', 'Titanium', 'Other',
+] as const
+export type MetalMaterial = (typeof METAL_MATERIALS)[number]
+
+// utilities/materials.py — RollerMaterial
+export const ROLLER_MATERIALS = [
+  'Aluminum', 'Steel', 'Stainless Steel', 'Plastic', 'Other',
+] as const
+export type RollerMaterial = (typeof ROLLER_MATERIALS)[number]
+
+// utilities/isa_warnings.py — ISAWarning
+export const ISA_WARNINGS = ['Recall', 'Warning', 'Notice', 'No Warning'] as const
+export type ISAWarning = (typeof ISA_WARNINGS)[number]
+
+// models/webbing.py — FiberMaterial
+export const FIBER_MATERIALS = [
+  'Nylon', 'Polyester', 'Dyneema', 'Vectran', 'Hybrid', 'Other',
+] as const
+export type FiberMaterial = (typeof FIBER_MATERIALS)[number]
+
+// models/webbing.py — Classification
+export const CLASSIFICATIONS = ['A+', 'A', 'B', 'C', 'Other'] as const
+export type Classification = (typeof CLASSIFICATIONS)[number]
+
+// models/webbing.py — WebbingConstruction
+export const WEBBING_CONSTRUCTIONS = ['Flat', 'Tubular', 'Core/Sheath', 'Other'] as const
+export type WebbingConstruction = (typeof WEBBING_CONSTRUCTIONS)[number]
+
+// models/weblocks.py — FrontPin
+export const FRONT_PINS = [
+  'Push Pin', 'Pull Pin', 'Captive Pin', 'Fixed Bolt', 'Other',
+] as const
+export type FrontPin = (typeof FRONT_PINS)[number]
+
+// models/weblocks.py — AttachmentPoint
+export const ATTACHMENT_POINTS = [
+  'Universal', 'Hole', 'Pin', 'Bolt', 'Bent Plate', 'Sling', 'Other',
+] as const
+export type AttachmentPoint = (typeof ATTACHMENT_POINTS)[number]
+
+// models/grips.py — ConnectionType
+export const CONNECTION_TYPES = [
+  'Dyneema Sling Loop', 'Mounting Hole', 'Other',
+] as const
+export type ConnectionType = (typeof CONNECTION_TYPES)[number]
+
+// models/rollers.py — SliderType
+export const SLIDER_TYPES = [
+  'Moving plates', 'Carabiner', 'Locking Carabiner', 'Other',
+] as const
+export type SliderType = (typeof SLIDER_TYPES)[number]
+
+// models/rollers.py — LockType
+export const LOCK_TYPES = [
+  'Non-locking', 'Screw Lock', 'Auto Lock', 'Twist Lock', 'Magnetic Lock', 'Other',
+] as const
+export type LockType = (typeof LOCK_TYPES)[number]
+
+// models/rollers.py — BearingMaterial
+export const BEARING_MATERIALS = ['Stainless Steel', 'Steel', 'Other'] as const
+export type BearingMaterial = (typeof BEARING_MATERIALS)[number]
+
+// models/starterkits.py — TensioningType (includes Primitive)
+export const STARTERKIT_TENSIONING_TYPES = [
+  'Single Ratchet', 'Double Ratchet', 'Primitive', 'Other',
+] as const
+export type StarterKitTensioningType = (typeof STARTERKIT_TENSIONING_TYPES)[number]
+
+// models/tricklinekits.py — TensioningType (no Primitive)
+export const TRICKLINEKIT_TENSIONING_TYPES = [
+  'Single Ratchet', 'Double Ratchet', 'Other',
+] as const
+export type TricklineKitTensioningType = (typeof TRICKLINEKIT_TENSIONING_TYPES)[number]
+
+// models/treepro.py — PriceUnit
+export const PRICE_UNITS = ['single', 'pair'] as const
+export type PriceUnit = (typeof PRICE_UNITS)[number]
+
+// utilities/currencies.py — Currency (ISO 4217). Kept as a plain string union
+// alias; the full list is rarely needed on the client, so we don't enumerate it.
+export type Currency = string
+
+// utilities/countries.py — Country. Also aliased to string; the full list is
+// not needed on the client, and brand.country is null for nearly all rows today.
+export type Country = string

--- a/frontend/src/types/gear.ts
+++ b/frontend/src/types/gear.ts
@@ -1,0 +1,128 @@
+// Gear item types — one interface per gear type, mirroring the `*Public`
+// response models in slack_data/models/*.py exactly.
+//
+// NOTE on `id`: the `*Public` models currently omit `id`, so the live API does
+// not return it yet (Phase 0 adds it). The types below declare it because the
+// whole app — detail routes, card links, compare — is built against that
+// contract. Until Phase 0 lands, detail/compare features will not resolve.
+
+import type {
+  AttachmentPoint, BearingMaterial, Classification, ConnectionType, Currency,
+  FiberMaterial, FrontPin, ISAWarning, LockType, MetalMaterial, PriceUnit,
+  RollerMaterial, SliderType, StarterKitTensioningType, TricklineKitTensioningType,
+  WebbingConstruction,
+} from './enums'
+
+// Fields shared by every gear type (from each Base* class + the brand_name
+// computed field, plus the id we add in Phase 0).
+export interface GearBase {
+  id: number
+  name: string
+  release_date: number | null
+  product_url: string | null
+  weight: number | null
+  price: number | null
+  currency: Currency | null
+  description: string | null
+  version: string | null
+  notes: string | null
+  brand_name: string
+}
+
+export interface Webbing extends GearBase {
+  material: FiberMaterial
+  webbing_construction: WebbingConstruction | null
+  width: number
+  thickness: number | null
+  breaking_strength: number | null
+  stretch: string | null // JSON array: [{"kn": 0, "percent": 0.0}, ...]
+  isa_certified: boolean
+  classification: Classification | null
+  isa_warning: ISAWarning | null
+  colors: string | null
+}
+
+export interface Weblock extends GearBase {
+  material: MetalMaterial
+  width_min: number
+  width_max: number | null
+  breaking_strength: number | null
+  front_pin: FrontPin | null
+  attachment_point: AttachmentPoint | null
+  isa_certified: boolean
+  isa_warning: ISAWarning | null
+  colors: string | null
+}
+
+export interface LeashRing extends GearBase {
+  material: MetalMaterial
+  inner_diameter: number | null
+  outer_diameter: number | null
+  breaking_strength: number | null
+  isa_certified: boolean
+  isa_warning: ISAWarning | null
+}
+
+export interface Grip extends GearBase {
+  material: MetalMaterial
+  width_min: number
+  width_max: number | null
+  wll: number | null
+  mbs: number | null
+  common_slipping_threshold: number | null
+  connection_type: ConnectionType | null
+  isa_certified: boolean
+  isa_warning: ISAWarning | null
+}
+
+export interface Roller extends GearBase {
+  material: MetalMaterial
+  roller_material: RollerMaterial
+  slider_type: SliderType
+  lock_type: LockType
+  bearing_material: BearingMaterial
+  width: string | null // raw range text e.g. "25–35mm" — not numeric
+  breaking_strength: number | null
+  isa_certified: boolean
+  isa_warning: ISAWarning | null
+  colors: string | null
+}
+
+export interface TreePro extends GearBase {
+  width: number | null
+  length: number | null
+  thickness: number | null
+  has_sling_attachment: boolean
+  price_unit: PriceUnit | null
+  // NOTE: no isa_certified, no isa_warning on this model.
+}
+
+export interface StarterKit extends GearBase {
+  webbing_length: number
+  webbing_width: number
+  tensioning_type: StarterKitTensioningType
+  includes_treepro: boolean
+  isa_certified: boolean
+  // NOTE: no isa_warning on this model.
+}
+
+export interface TricklineKit extends GearBase {
+  webbing_length: number
+  webbing_width: number
+  tensioning_type: TricklineKitTensioningType
+  includes_treepro: boolean
+  isa_certified: boolean
+  // NOTE: no isa_warning on this model.
+}
+
+// Union of every concrete gear item.
+export type GearItem =
+  | Webbing | Weblock | LeashRing | Grip | Roller | TreePro | StarterKit | TricklineKit
+
+// URL slugs (mirror config/gearTypes.ts). The first eight are data-backed and
+// covered by the test suite; the last two are upcoming categories with no data
+// yet (shown in the nav, listing renders a "coming soon" state).
+export type GearSlug =
+  | 'webbings' | 'weblocks' | 'leashrings' | 'grips'
+  | 'rollers' | 'treepros' | 'starterkits' | 'tricklinekits'
+  | 'bungees' | 'leashringpro'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,4 @@
+// Barrel for all shared types.
+export * from './enums'
+export * from './gear'
+export * from './brand'

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,34 @@
+// Display helpers for gear values.
+
+// A gear item is a union; card/spec code reads arbitrary fields by name, so we
+// treat items as loose records at the display layer.
+export type AnyItem = Record<string, unknown>
+
+// Raw numeric value for a data-{field} attribute: the number as a string, or
+// "" when null/absent (empty string sorts/filters as "no value" — null-last).
+export function rawAttr(item: AnyItem, field: string): string {
+  const v = item[field]
+  return v == null ? '' : String(v)
+}
+
+// Build the set of data-{field} attributes for a card, e.g.
+// { "data-weight": "280", "data-breaking-strength": "" }.
+export function dataAttrs(item: AnyItem, fields: string[]): Record<string, string> {
+  const attrs: Record<string, string> = {}
+  for (const f of fields) attrs[`data-${f.replace(/_/g, '-')}`] = rawAttr(item, f)
+  return attrs
+}
+
+// Price with its currency code, e.g. "120 EUR". Returns null when no price.
+export function formatPrice(price: unknown, currency: unknown): string | null {
+  if (price == null) return null
+  const amount = typeof price === 'number' ? price : Number(price)
+  const cur = currency ? ` ${String(currency)}` : ''
+  return `${amount}${cur}`
+}
+
+// A spec value with an optional unit appended, e.g. "25 mm". "" when null.
+export function formatValue(value: unknown, unit?: string): string {
+  if (value == null || value === '') return ''
+  return unit ? `${value} ${unit}` : String(value)
+}

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -1,0 +1,23 @@
+// Punctuation-insensitive search. Strips [.\-()/ ] and lowercases before a
+// substring match, so "82" matches "8.2", "twave" matches "T-Wave", etc.
+// (see search_sort.cy.ts — "normalized" search).
+
+export function normalize(s: string): string {
+  return s.replace(/[.\-()/ ]/g, '').toLowerCase()
+}
+
+// Filtering rules:
+//   - empty input            → all items (no filtering)
+//   - punctuation-only input → nothing (normalizes to "")
+//   - otherwise              → name OR brand contains the normalized query
+export function filterBySearch<T extends { name: string; brand_name: string }>(
+  items: T[],
+  rawQuery: string,
+): T[] {
+  if (rawQuery.trim() === '') return items
+  const q = normalize(rawQuery)
+  if (q === '') return []
+  return items.filter(
+    i => normalize(i.name).includes(q) || normalize(i.brand_name).includes(q),
+  )
+}

--- a/frontend/src/utils/sort.ts
+++ b/frontend/src/utils/sort.ts
@@ -1,0 +1,33 @@
+// Client-side sorting for the listing.
+//
+// A null/absent sort = the backend's own order (the gear_cards tests assert the
+// first card matches the API's first item, so the default must NOT reorder).
+// Name sorts use locale compare; numeric sorts put nulls/blanks last in both
+// directions.
+
+import type { SortSpec } from '@/hooks/useUrlState'
+import type { AnyItem } from '@/utils/format'
+
+export function sortItems(items: AnyItem[], sort: SortSpec | null): AnyItem[] {
+  if (!sort) return items // default: backend order
+
+  const { field, direction } = sort
+  const factor = direction === 'asc' ? 1 : -1
+
+  if (field === 'name') {
+    return [...items].sort(
+      (a, b) => factor * String(a.name).localeCompare(String(b.name)),
+    )
+  }
+
+  return [...items].sort((a, b) => {
+    const av = a[field]
+    const bv = b[field]
+    const an = av == null || av === '' ? null : Number(av)
+    const bn = bv == null || bv === '' ? null : Number(bv)
+    if (an === null && bn === null) return 0
+    if (an === null) return 1 // nulls last, regardless of direction
+    if (bn === null) return -1
+    return factor * (an - bn)
+  })
+}


### PR DESCRIPTION
Builds the frontend through **Phase 3** of the roadmap in [PLAN.md](PLAN.md), TDD against the real backend via the red-first Cypress suite. Depends on the `id`+CORS enablers from #23 (already in `main`).

## What

- **Data layer** — TypeScript types mirroring the `*Public` schemas, a paginating API client (pages past the 100-cap), the gear-type registry, per-type field/sort config, and `useUrlState` / `useGearList` hooks, plus search/sort/format helpers.
- **UI** — `BrowserRouter` with a ranked route table, `AppLayout` + two-tier `TopNav`, the gear listing page (search / item count / cards⇄chart toggle / sort dropdown / loading skeleton / empty state), `GearCard` + `GearGrid` + `GearTable`, `SortDropdown`, an ISA badge, and a `FilterSidebar` placeholder (real filter groups land in Phase 4). Detail/compare/manufacturers pages are stubs.
- **Test fix** — the `gear_listing` chart-view specs sat outside their `describe` and never ran `cy.visit`; moved inside so they inherit the `beforeEach`.
- **Docs** — `PLAN.md` (build source-of-truth: Phase 3 done, Phase 4 planned), `BACKLOG.md`, refreshed README/CLAUDE frontend sections, and a `.gitignore` tweak to ignore the whole `scraper/` dir.

## Tests

`navigation.cy.ts` 13/13, `gear_cards` 119/119, `gear_listing` **168/168**. (ISA detail-page + filter/detail/compare specs are later phases.)

## Note

`.gitignore` now ignores all of `scraper/` (was `scraper/output/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
