### PR TITLE
feat(frontend): TS type sync + full-stack quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,50 @@ SlackData is open source, with an open API to allow other tools to use the datab
 
 ---
 
+## Quick start (full local stack)
+
+The frontend reads its data from the backend API, so **the backend must be running** or the
+listing pages come up empty. Start both:
+
+```bash
+# 1. Backend — http://127.0.0.1:8000
+uv sync                          # creates .venv with all deps
+source .venv/bin/activate
+cd slack_data
+fastapi dev main.py              # seeds database.db on first run
+
+# 2. Frontend — http://localhost:5173 (in a second terminal)
+cd frontend
+npm install
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173). The backend allows CORS from the Vite dev
+server (`localhost:5173` / `127.0.0.1:5173`); override the API URL with `VITE_API_URL` if you run
+the backend elsewhere.
+
+### Troubleshooting: frontend loads but shows no data
+
+The frontend is almost never the cause — check the backend first:
+
+```bash
+curl http://localhost:8000/webbing/?limit=1
+```
+
+- **HTTP 500 on every endpoint** — the backend process is unhealthy. The most common cause is a
+  broken environment (e.g. a corrupt `sniffio`/`anyio` install breaks every request with a 500).
+  Recreate the env cleanly with `uv sync` and run the backend from `.venv`, or reinstall the
+  offending package (`pip install --force-reinstall sniffio`) **and restart the server** —
+  `fastapi dev` reloads on source edits, not on dependency changes.
+- **Connection refused** — the backend isn't running, or not on port 8000.
+- **Empty array `[]`** — the DB seeded with no rows; delete `slack_data/database.db` and restart to
+  re-seed from the root `*.json` files.
+
+> Note: `uv` creates **`.venv`**; the pip path below creates **`venv`**. Don't mix them — activate
+> and run the backend from whichever one you installed into.
+
+---
+
 ## Frontend
 
 A React + TypeScript + Vite app, built TDD against a red-first Cypress E2E suite that runs on the
@@ -65,7 +109,7 @@ pip install '-e.[dev]'
 ### Run
 
 ```bash
-cd slack_data
+cd slack_datacd slack_data
 fastapi dev main.py
 ```
 

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -21,12 +21,12 @@ export type ISAWarning = (typeof ISA_WARNINGS)[number]
 
 // models/webbing.py — FiberMaterial
 export const FIBER_MATERIALS = [
-  'Nylon', 'Polyester', 'Dyneema', 'Vectran', 'Hybrid', 'Other',
+  'Nylon', 'Polyester', 'Dyneema/HMPE', 'Vectran', 'Hybrid', 'Other',
 ] as const
 export type FiberMaterial = (typeof FIBER_MATERIALS)[number]
 
 // models/webbing.py — Classification
-export const CLASSIFICATIONS = ['A+', 'A', 'B', 'C', 'Other'] as const
+export const CLASSIFICATIONS = ['A+', 'A', 'B', 'C', 'Not for Highline'] as const
 export type Classification = (typeof CLASSIFICATIONS)[number]
 
 // models/webbing.py — WebbingConstruction

--- a/frontend/src/types/gear.ts
+++ b/frontend/src/types/gear.ts
@@ -31,6 +31,8 @@ export interface GearBase {
 
 export interface Webbing extends GearBase {
   material: FiberMaterial
+  // For Hybrid webbings: JSON array of component fiber names, e.g. ["Polyester", "Dyneema/HMPE"]
+  material_composition: string | null
   webbing_construction: WebbingConstruction | null
   width: number
   thickness: number | null
@@ -76,7 +78,7 @@ export interface Grip extends GearBase {
 }
 
 export interface Roller extends GearBase {
-  material: MetalMaterial
+  material: MetalMaterial[] // JSON column: frame can be multiple materials
   roller_material: RollerMaterial
   slider_type: SliderType
   lock_type: LockType


### PR DESCRIPTION
## Frontend groundwork: TypeScript type sync + full-stack quickstart docs.

The base of the frontend PR stack. Small, low-risk changes that the images PR (#C) and the Phase 4 filters PR (#D) build on. Targets `main`.

> **Stack:** this is the base. `feat/frontend-gear-images` → `feat/frontend-phase-4-filters` stack on top. Merge bottom-up.

### 1 · Mirror backend model changes in TS types
Keeps the frontend types in lockstep with the backend model changes in the backend PR (per this repo's schema-first rule — the Python models are the source of truth):

- `FiberMaterial` — `'Dyneema'` → `'Dyneema/HMPE'`
- `Classification` — `'Other'` → `'Not for Highline'`
- `Webbing.material_composition: string | null` — the hybrid component-fiber JSON list
- `Roller.material: MetalMaterial[]` — now a list (JSON column), was a scalar

These are consumed by the filter config in the Phase 4 PR (classification pills, per-metal roller pills), which is why they land first.

### 2 · Full-stack local quickstart + troubleshooting (`README.md`)
- How to run backend + frontend together (the frontend reads from the API, so the backend must be up or listings come up empty).
- CORS / `VITE_API_URL` notes.
- A "frontend loads but shows no data → check the backend first" troubleshooting section (the common cause is a 500ing backend, not the frontend).

### Verification
Type-only + docs change. `npm run build` (tsc) on the Phase 4 branch that consumes these types is the effective check; run it before merging the stack.
