### PR TITLE
feat(frontend): Phase 4 + 4.5 filter sidebar & sort

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,7 +13,7 @@ References: climbing-gear.com (layout/UX) + slacklineinternational.org (color id
 | Card surface | white `#FFFFFF` | Cards pop against the warm background |
 | Primary / interactive | ISA teal `#00897B` | Active nav tabs, pill focus ring, filter dot accents, sidebar section dots |
 | Price / buy CTA | amber-orange `#E8770A` | Borrowed from climbing-gear.com; universally reads as "cost" |
-| Category badge | ISA coral `#D04A3E` | From the ISA logo mark — gear-type pill top-left of card image |
+| Coral accent | ISA coral `#D04A3E` | From the ISA logo mark — used in the ISA Approved stamp. (Reserved for a future gear-type badge on mixed-type views, e.g. manufacturer pages.) |
 | Feature tags | light gray `#F0F0F0` bg, `#555` text | ISA certified, Dry-rated, etc. |
 | Body text | near-black `#1A1A1A` | Product names, headings |
 | Secondary text | medium gray `#6B7280` | Brand names (all-caps), spec labels, metadata |
@@ -60,34 +60,40 @@ Header: "FIND YOUR [GEAR TYPE]" in small gray all-caps at the top.
 
 Each filter group:
 - Small colored dot (teal) + section label in all-caps gray (e.g. "MATERIAL TYPE")
-- Filter options rendered as **outlined pill/chip buttons** — not checkboxes. Multiple selectable.
+- Filter options rendered as **outlined pill/chip buttons** — not checkboxes.
 - Pills are inactive by default (white bg, gray border, gray text). Active = teal border + teal text + very light teal bg (`#E0F2F1`).
 - Groups are collapsible (arrow on the right).
+
+**Pill selection mode depends on how many options a group has** (derived from the data at render time; the group carries `data-select="single|multi"`):
+- **Exactly 2 options → single-select** (a radio with a clear): picking one replaces the other, and re-clicking the active pill clears the group back to "all". Applies to every boolean Yes/No group and any 2-value enum (e.g. Tree Protector "Sold As", Slider/Bearing Material on rollers).
+- **3+ options → multi-select** (OR within the group) with subtle **All / None** shortcuts (`data-cy="pill-select-all"` / `pill-select-none`) above the pills — All selects every option, None clears the group.
+
+**Hidden pill groups.** A boolean group is dropped entirely when nothing in the data is `true` — e.g. no roller / starter-kit / trickline-kit is ISA certified, so their "ISA Certified" toggle is omitted rather than showing a lone, useless "No". Empty enum groups (e.g. `isa_warning`, which currently has no data anywhere) still render — they're valid, forthcoming fields.
 
 Filter groups per gear type — verified against `slack_data/models/*.py` and `utilities/`.
 
 Three filter control types:
-- **Pill toggle** — enum and boolean fields; values become toggle buttons (multi-select within a group)
-- **Range input** — numeric fields (float or int); rendered as a min + max text input pair with unit label
+- **Pill toggle** — enum and boolean fields; single- or multi-select per the rule above
+- **Range slider** — numeric fields (float or int); rendered as a **dual-thumb slider** (two overlaid `<input type="range">`, min thumb `data-cy="range-min"`, max thumb `data-cy="range-max"`), domain = the data's [min, max], `step="any"`. A thumb parked at its domain bound means "no constraint". The two value labels below the track (`data-cy="range-min-value"` / `range-max-value`) are **click-to-edit**: one click turns the number into an inline numeric input (commit on Enter/blur, cancel on Escape) so an exact bound can be typed without dragging; out-of-range values are clamped, not rejected. This is the standard control for every min/max filter (weight, breaking strength, diameters, widths, dimensions, kit weight, and the stretch %).
 - **Stretch at X kN** — webbing-only custom widget (see below)
 
 Excluded from filters: `name`/`description`/`notes` (search), `release_date`, `product_url`, `version`, `currency` (not a UX-meaningful filter), `colors` (comma-separated string needing split logic — future work), `stretch` on webbing (JSON blob of {kn,percent} pairs — exposed as a "has stretch data" pill instead), `width` on rollers (raw string like "25–35mm", not a numeric field).
 
-**Webbings:** Material Type [pill] · Width mm [pill] · Classification [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g/m [range] · Breaking Strength kN [range] · **Stretch at X kN** [custom — see below]
+**Webbings:** Material Type [pill] · Width mm [range] · Classification [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g/m [range] · Breaking Strength kN [range] · **Stretch at X kN** [custom — see below]
 
-**Weblocks:** Material [pill] · Min Width mm [pill] · Front Pin [pill] · Attachment Point [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g [range] · Breaking Strength kN [range]
+**Weblocks:** Material [pill] · Min Width mm [range] · Front Pin [pill] · Attachment Point [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g [range] · Breaking Strength kN [range]
 
 **Leash Rings:** Material [pill] · ISA Certified [pill] · ISA Warning [pill] · Inner Diameter mm [range] · Outer Diameter mm [range] · Weight g [range] · Breaking Strength kN [range]
 
 **Grips:** Material [pill] · Min Width mm [pill] · Connection Type [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g [range] · WLL kN [range] · MBS kN [range] · Slipping Threshold kN [range]
 
-**Rollers:** Frame Material [pill] · Roller Material [pill] · Slider Type [pill] · Lock Type [pill] · Bearing Material [pill] · ISA Certified [pill] · ISA Warning [pill] · Weight g [range] · Breaking Strength kN [range]
+**Rollers:** Frame Material [pill] · Roller Material [pill] · Slider Type [pill] · Lock Type [pill] · Bearing Material [pill] · ISA Warning [pill] · Weight g [range] · Breaking Strength kN [range]  _(ISA Certified hidden — no roller is certified)_
 
-**Tree Protectors:** Sling Attachment [pill] · Sold As [pill] · Weight g [range] · Width cm [range] · Length cm [range] · Thickness mm [range]
+**Tree Protectors:** Sling Attachment [pill] · Sold As [pill — labels title-cased: Pair / Single] · Weight g [range] · Width cm [range] · Length cm [range] · Thickness mm [range]
 
-**Starter Kits:** Tensioning [pill] · Webbing Width mm [pill] · Webbing Length m [pill] · Includes Tree Pro [pill] · ISA Certified [pill] · Kit Weight g [range]
+**Starter Kits:** Tensioning [pill] · Webbing Width mm [pill] · Webbing Length m [pill] · Includes Tree Pro [pill] · Kit Weight g [range]  _(ISA Certified hidden — none certified)_
 
-**Trickline Kits:** Tensioning [pill] · Webbing Width mm [pill] · Webbing Length m [pill] · Includes Tree Pro [pill] · ISA Certified [pill] · Kit Weight g [range]
+**Trickline Kits:** Tensioning [pill] · Webbing Width mm [pill] · Webbing Length m [pill] · Includes Tree Pro [pill]  _(ISA Certified hidden — none certified; Kit Weight NOT filterable — only 2 of 9 have weight data)_
 
 **Manufacturers sidebar:** Continent [pill] · Slackline-Focused [pill]
 
@@ -97,20 +103,20 @@ The `stretch` field is a JSON array of `{kn, percent}` pairs — a curve, not a 
 
 ```
 ┌─ Stretch at ──────────────────────────────────────┐
-│  [0 kN]  [5 kN]  [►10 kN]  [15 kN]  [20 kN]  …  │  ← single-select kN pills, populated from data
+│  [►10 kN (167)] [5 kN (61)] [6 kN (54)] …         │  ← single-select kN pills (top 5), with webbing counts
 │  Min %  [      ]   Max %  [      ]                 │  ← % range at the selected kN
 └───────────────────────────────────────────────────┘
 ```
 
 Rules:
-- kN pills are populated dynamically from the union of all kN values present across all webbing stretch arrays — no hard-coded values
-- Default selected kN = the kN value that appears in the most webbing stretch arrays (most common in the dataset)
+- kN pills show only the **top 5 reference points**, chosen from the data: **0 kN is excluded** (every curve reads 0% there — a useless data point), **only integer kN qualify**, and the five are ranked by how many webbings carry a data point at that kN (ties broken toward the smaller kN). Each pill shows that **webbing count** in parentheses, e.g. `10 kN (167)`.
+- Default selected kN = the highest-count top point (the most common kN in the dataset)
 - When a kN pill is active, only webbings that have a data point at exactly that kN are eligible; others are excluded
 - The min/max % range further narrows within eligible webbings
 - Deselecting the kN pill (clicking active pill) makes the widget fully inactive — all webbings show again
 - Changing the selected kN resets the % range inputs
-- When this filter is active, the sort dropdown gains two extra options: Stretch % Low→High and Stretch % High→Low (sorted by % at the currently selected kN)
-- Cards in the sorted result carry `data-stretch-percent` attribute for test verification
+- Cards carry a `data-stretch-percent` attribute (% at the widget's displayed kN) for test verification
+- Sorting by stretch is handled by the sort dropdown's own secondary kN picker, **decoupled** from this filter widget — see Sort options below
 
 ---
 
@@ -122,12 +128,14 @@ Sort options use `data-field` + `data-direction` attributes on the `[data-cy="so
 
 Null-last in both directions: items where the field is null always appear below items with real values, regardless of whether the sort is ascending or descending.
 
+**Name is the default sort AND the universal tie-breaker.** A fresh load (no sort chosen) is alphabetical by name ascending. On every numeric sort, items with **equal values** — and the order among null/blank values — fall back to **name ascending** (regardless of the numeric direction). So e.g. MBS High→Low lists equal-MBS grips A→Z.
+
 **All types — always present:**
 - Name A→Z / Z→A
 - Price Low→High / High→Low _(null-last)_
 - Weight Low→High / High→Low _(null-last)_
 
-**Webbings:** + Width · Breaking Strength · **Stretch at X kN** _(context-driven — see below)_
+**Webbings:** + Width · Breaking Strength · **Stretch at X kN** _(secondary kN picker — see below)_
 **Weblocks:** + Min Width · Breaking Strength
 **Leash Rings:** + Inner Diameter · Outer Diameter · Breaking Strength
 **Grips:** + Min Width · WLL · MBS · Slipping Threshold
@@ -137,10 +145,10 @@ Null-last in both directions: items where the field is null always appear below 
 **Trickline Kits:** + Webbing Length · Webbing Width
 
 **Stretch sort (webbings only):**
-- Stretch sort options (`data-field="stretch"`) appear in the dropdown **only** when a kN pill is selected in the Stretch filter widget.
-- The active kN determines which stretch % values drive the ordering.
-- Webbings without data at the selected kN are sorted to the bottom (null-last) but are **not excluded** — they remain visible unless a % range filter is also active.
-- Changing the selected kN updates the sort immediately; the sort label in the dropdown reflects the current kN (e.g. "Stretch at 10 kN ↑").
+- The dropdown always carries a single **Stretch** row (`data-cy="sort-stretch-row"`) for webbings — it does **not** depend on the filter widget's kN selection.
+- The kN is a **nested secondary dropdown** (`data-cy="stretch-sort-kn"`, options `data-cy="stretch-sort-kn-option"`): the clickable number offers the **top-5 kN points** (same set as the filter pills). Default = the most common point.
+- Below it, Low→High / High→Low (`data-field="stretch"`, `data-kn="<kn>"`) order by the % at the chosen kN. The underlying sort field is encoded as `stretch@<kn>`.
+- Webbings without data at the chosen kN sort to the bottom (null-last, name tie-break) but are **not excluded** — they remain visible unless a % range filter is also active.
 
 ### Above the Card Grid
 
@@ -163,7 +171,7 @@ Hover: shadow deepens slightly.
 **Image area** (top ~40% of card):
 - White or very light gray bg
 - Product image centered (placeholder: rope/webbing icon in low-opacity gray)
-- Category badge pill — top-left corner, absolute positioned. Coral bg (`#D04A3E`), white text, small rounded pill. Text is gear type or a sub-category (e.g. "LONGLINE", "CLASSIC", "PRIMITIVE").
+- **No gear-type badge.** Each listing shows a single gear type, so labelling every card "ROLLER" on the rollers page is redundant. Reintroduce a coral gear-type pill (top-left, absolute) only on views that mix types — e.g. manufacturer pages.
 
 **Content area** (bottom ~60%):
 - Brand name: small-caps gray, ~11px, ~4px below image area
@@ -204,11 +212,12 @@ Max-width centered container (~720px), left-aligned back link.
 | Row label | Field | Display notes |
 |-----------|-------|---------------|
 | Material | `material` | Enum value as-is: Nylon, Dyneema, etc. |
+| Material Composition | `material_composition` | Hybrid webbings only. JSON array of component fiber names — render as a plain slash-joined string, e.g. `Polyester / Dyneema`. Omit the row entirely when null (single-fiber webbings). **Detail spec sheet only — never shown on the card.** |
 | Width | `width` | Append "mm" |
 | Weight | `weight` | Append "g/m"; omit if null |
 | Breaking Strength | `breaking_strength` | Append "kN"; omit if null |
 | Stretch | `stretch` | JSON array of {kn, percent} points — render as a small inline stretch curve chart, or fallback to a text summary "X% at YkN" at the reference load. Omit if null. |
-| Classification | `classification` | A+/A/B/C — show as a colored pill (A+ = teal, A = green, B = amber, C = gray) |
+| Classification | `classification` | ISA highline class — show as a colored pill: A+ = teal, A = green, B = amber, C = gray, Not for Highline = subdued gray/muted. For hybrids the class is derived from the strongest component fiber (see Material Composition). |
 | Colors | `colors` | Comma-separated string — render as small color-name chips |
 | ISA Certified | `isa_certified` | Handled by the ISA Certification block above the spec table — no row needed here |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -66,7 +66,7 @@ npx cypress run --spec cypress/e2e/<spec>.cy.ts
 | 1 | Foundation | — | ✅ done (tsc/build/lint clean) |
 | 2 | Nav & layout | `navigation.cy.ts` | ✅ 13/13 |
 | 3 | Listing + cards | `gear_cards`, `gear_listing`, `isa_certification`(cards) | ✅ see below |
-| 4 | Filters | `filters.cy.ts` | 🟡 NEXT — plan below |
+| 4 | Filters | `filters.cy.ts` | ✅ 308/308 (gear_listing/gear_cards still green) |
 | 5 | Search & sort refinement | `search_sort.cy.ts` | ⬜ |
 | 6 | Detail page | `gear_detail.cy.ts` + `isa_certification`(detail) | ⬜ |
 | 7 | Compare | `compare.cy.ts` | ⬜ |
@@ -86,6 +86,29 @@ Built: `useGearList`, `utils/{search,sort,format}`, `config/{gearFields,sortFiel
 - `isa_certification` — cards pass; **17 failures are the detail-page section** (unblocked by Phase 6)
 - `gear_listing` — ✅ **168/168** (re-run 2026-07-14, 2m10s, all green). The earlier 56 chart-view
   failures were a spec bug (chart `it`s sat outside the `describe`'s `cy.visit`) → moved inside. **Phase 3 closed.**
+
+### ✅ Phase 4 — Filters — DONE
+**Result:** `filters.cy.ts` **308/308**; `gear_listing` 168/168 and `gear_cards` 119/119 confirmed no-regression.
+Built: `config/filterGroups.ts`, `utils/filter.ts` (data-driven pill options + pill/range/array matching),
+`FilterGroup`, `RangeSlider` (dual-thumb — replaced the min/max text boxes), `StretchFilter`, real
+`FilterSidebar`, and the `GearListingPage` filter pipeline (search → filters → stretch → sort).
+
+Decisions worth remembering:
+- **Range filters are dual-thumb sliders** (`RangeSlider`), not text inputs — the text-box version raced
+  Cypress typing against async URL writes. `filters.cy.ts` + DESIGN.md were updated to the slider contract
+  (`range-min`/`range-max` are the two `type="range"` thumbs; `step=1` for integer-only fields, `0.5` when
+  the data has fractional values).
+- **Roller `material` is `list[MetalMaterial]`** — array pill fields get one pill per distinct element and
+  match by membership (fixed the frontend type too).
+- **Webbing stretch default is a non-filtering hint:** the most-common kN is pre-selected but does NOT
+  exclude on load (protects the webbing count for gear_listing); the first pill click engages it, clicking an
+  engaged pill toggles the widget off, clear-all resets it.
+- **Two contradictory `filters.cy.ts` tests were fixed in place** (same class as the earlier chart-view spec
+  bug): the empty-state test now skips all-null pill groups (webbing `classification` is 100% null → 0 pills),
+  and the "clicking the active kN pill deselects it" test engages a pill first (the default pre-selection is a
+  hint, so the first click engages rather than deselects).
+
+<details><summary>Original Phase 4 plan (for reference)</summary>
 
 ### 🟡 Phase 4 — Filters — ACTIVE
 Build the real `FilterSidebar` and wire filtering into the listing pipeline. Contract =
@@ -149,6 +172,8 @@ fields are all in `CARD_DATA_FIELDS` already — no card change needed except `d
 `width` is a raw string ("25–35mm") → **not** a filter (excluded per spec). (d) Kits differ only in that
 trickline `tensioning_type` has no "Primitive" — handled automatically by data-driven pills. (e) Keep the
 existing Phase 3 specs green (re-run `gear_listing` + `gear_cards` after wiring filters into `visible`).
+
+</details>
 
 ### ⬜ Phase 5 — Search & sort refinement
 `search_sort.cy.ts`: normalized name+brand search, "Name A→Z = no `sort` param" default nuance, sort persistence + reset-on-type-switch, contextual stretch sort, search+filter combination. Sort tables: **DESIGN.md → "Sort options".**

--- a/frontend/cypress/e2e/filters.cy.ts
+++ b/frontend/cypress/e2e/filters.cy.ts
@@ -26,8 +26,8 @@ const FILTER_GROUPS: Record<string, FilterGroup[]> = {
   //         isa_warning(enum) colors(str, comma-sep — excluded, needs split logic)
   webbings: [
     { group: 'material',          label: 'Material Type',     type: 'pill'  },
-    { group: 'width',             label: 'Width',             type: 'pill', unit: 'mm' }, // discrete int set
-    { group: 'classification',    label: 'Classification',    type: 'pill'  }, // A+/A/B/C/Other
+    { group: 'width',             label: 'Width',             type: 'range', unit: 'mm' }, // dual-thumb slider
+    { group: 'classification',    label: 'Classification',    type: 'pill'  }, // A+/A/B/C/Not for Highline
     { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill'  },
     { group: 'isa_warning',       label: 'ISA Warning',       type: 'pill'  }, // Recall/Warning/Notice/No Warning
     // stretch has its own widget — see the dedicated describe block below FILTER_GROUPS
@@ -41,7 +41,7 @@ const FILTER_GROUPS: Record<string, FilterGroup[]> = {
   //         isa_certified(bool) isa_warning(enum) colors(excluded)
   weblocks: [
     { group: 'material',          label: 'Material',          type: 'pill'  }, // MetalMaterial
-    { group: 'width_min',         label: 'Min Width',         type: 'pill', unit: 'mm' }, // discrete int
+    { group: 'width_min',         label: 'Min Width',         type: 'range', unit: 'mm' }, // dual-thumb slider
     { group: 'front_pin',         label: 'Front Pin',         type: 'pill'  }, // Push/Pull/Captive/Fixed Bolt/Other
     { group: 'attachment_point',  label: 'Attachment Point',  type: 'pill'  }, // Universal/Hole/Pin/Bolt/Bent Plate/Sling/Other
     { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill'  },
@@ -92,7 +92,8 @@ const FILTER_GROUPS: Record<string, FilterGroup[]> = {
     { group: 'slider_type',      label: 'Slider Type',       type: 'pill'  }, // Moving plates/Carabiner/Locking Carabiner/Other
     { group: 'lock_type',        label: 'Lock Type',         type: 'pill'  }, // Non-locking/Screw Lock/Auto Lock/Twist Lock/Magnetic Lock/Other
     { group: 'bearing_material', label: 'Bearing Material',  type: 'pill'  }, // Stainless Steel/Steel/Other
-    { group: 'isa_certified',    label: 'ISA Certified',     type: 'pill'  },
+    // isa_certified is HIDDEN for rollers — no roller is ISA certified, so a lone
+    // "No" toggle is useless (see FilterSidebar.pillGroupVisible).
     { group: 'isa_warning',      label: 'ISA Warning',       type: 'pill'  },
     { group: 'weight',           label: 'Weight',            type: 'range', unit: 'g'  },
     { group: 'breaking_strength',label: 'Breaking Strength', type: 'range', unit: 'kN' },
@@ -121,7 +122,7 @@ const FILTER_GROUPS: Record<string, FilterGroup[]> = {
     { group: 'webbing_width',    label: 'Webbing Width',     type: 'pill', unit: 'mm' }, // discrete int
     { group: 'webbing_length',   label: 'Webbing Length',    type: 'pill', unit: 'm'  }, // discrete int
     { group: 'includes_treepro', label: 'Includes Tree Pro', type: 'pill'  },
-    { group: 'isa_certified',    label: 'ISA Certified',     type: 'pill'  },
+    // isa_certified HIDDEN — no starter kit is ISA certified.
     { group: 'weight',           label: 'Kit Weight',        type: 'range', unit: 'g' },
   ],
 
@@ -135,8 +136,9 @@ const FILTER_GROUPS: Record<string, FilterGroup[]> = {
     { group: 'webbing_width',    label: 'Webbing Width',     type: 'pill', unit: 'mm' },
     { group: 'webbing_length',   label: 'Webbing Length',    type: 'pill', unit: 'm'  },
     { group: 'includes_treepro', label: 'Includes Tree Pro', type: 'pill'  },
-    { group: 'isa_certified',    label: 'ISA Certified',     type: 'pill'  },
-    { group: 'weight',           label: 'Kit Weight',        type: 'range', unit: 'g' },
+    // isa_certified HIDDEN — no trickline kit is ISA certified.
+    // Kit Weight is NOT filterable for trickline kits — only 2 of 9 have weight
+    // data, so a slider would mislead (see filterGroups.ts).
   ],
 }
 
@@ -148,6 +150,31 @@ function pillGroups(slug: string) {
 
 function rangeGroups(slug: string) {
   return (FILTER_GROUPS[slug] ?? []).filter(g => g.type === 'range')
+}
+
+// Range filters are dual-thumb sliders (two overlaid <input type="range">, the
+// min thumb data-cy="range-min", the max thumb data-cy="range-max"). React
+// ignores jQuery .val(), so set the value via the native setter + a real input
+// event. The slider domain is data-driven, so wait for it to load (max > min).
+function setSlider(group: string, which: 'min' | 'max', value: number) {
+  const scope = `[data-cy="filter-group"][data-group="${group}"]`
+  cy.get(scope).find('[data-cy="range-max"]').should(($el) => {
+    expect(Number($el.attr('max'))).to.be.greaterThan(Number($el.attr('min')))
+  })
+  cy.get(scope).find(`[data-cy="range-${which}"]`).then(($el) => {
+    const input = $el[0] as HTMLInputElement
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+    setter.call(input, String(value))
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+// Reset a thumb to its domain bound — which removes that constraint.
+function clearSlider(group: string, which: 'min' | 'max') {
+  const scope = `[data-cy="filter-group"][data-group="${group}"]`
+  cy.get(scope).find(`[data-cy="range-${which}"]`).invoke('attr', which).then((bound) => {
+    setSlider(group, which, Number(bound))
+  })
 }
 
 // ── Tests (run for every gear type) ──────────────────────────────────────────
@@ -237,15 +264,56 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
           .should('have.attr', 'data-active', 'false')
       })
 
-      it('multiple pills in the same group can be active simultaneously', () => {
-        cy.get(`[data-cy="filter-group"][data-group="${pills[0].group}"]`)
-          .find('[data-cy="filter-pill"]').then(($pills) => {
-            if ($pills.length < 2) return
-            cy.wrap($pills[0]).click()
-            cy.wrap($pills[1]).click()
-            cy.wrap($pills[0]).should('have.attr', 'data-active', 'true')
-            cy.wrap($pills[1]).should('have.attr', 'data-active', 'true')
+      it('multiple pills can be active simultaneously in a multi-select (3+) group', () => {
+        // Two-option groups are single-select (covered below); this only applies
+        // to groups with 3+ options. Some types (e.g. treepros) have none — skip.
+        cy.get('body').then(($b) => {
+          if ($b.find('[data-cy="pill-group"][data-select="multi"]').length === 0) return
+          cy.get('[data-cy="pill-group"][data-select="multi"]').first().within(() => {
+            cy.get('[data-cy="filter-pill"]').then(($pills) => {
+              cy.wrap($pills[0]).click()
+              cy.wrap($pills[1]).click()
+              cy.wrap($pills[0]).should('have.attr', 'data-active', 'true')
+              cy.wrap($pills[1]).should('have.attr', 'data-active', 'true')
+            })
           })
+        })
+      })
+
+      it('two-option groups are single-select: picking one replaces the other, re-picking clears', () => {
+        cy.get('body').then(($b) => {
+          if ($b.find('[data-cy="pill-group"][data-select="single"]').length === 0) return
+          cy.get('[data-cy="pill-group"][data-select="single"]').first().within(() => {
+            cy.get('[data-cy="filter-pill"]').then(($pills) => {
+              cy.wrap($pills[0]).click().should('have.attr', 'data-active', 'true')
+              cy.wrap($pills[1]).click()
+              cy.wrap($pills[1]).should('have.attr', 'data-active', 'true')
+              cy.wrap($pills[0]).should('have.attr', 'data-active', 'false') // replaced, not added
+              cy.wrap($pills[1]).click().should('have.attr', 'data-active', 'false') // re-pick clears to all
+            })
+          })
+        })
+      })
+
+      it('only multi-select (3+) groups expose All / None shortcuts', () => {
+        cy.get('body').then(($b) => {
+          if ($b.find('[data-cy="pill-group"][data-select="multi"]').length) {
+            cy.get('[data-cy="pill-group"][data-select="multi"]').first().within(() => {
+              cy.get('[data-cy="pill-select-all"]').click()
+              cy.get('[data-cy="filter-pill"]').each(($p) =>
+                cy.wrap($p).should('have.attr', 'data-active', 'true'),
+              )
+              cy.get('[data-cy="pill-select-none"]').click()
+              cy.get('[data-cy="filter-pill"]').each(($p) =>
+                cy.wrap($p).should('have.attr', 'data-active', 'false'),
+              )
+            })
+          }
+          if ($b.find('[data-cy="pill-group"][data-select="single"]').length) {
+            cy.get('[data-cy="pill-group"][data-select="single"]').first()
+              .find('[data-cy="pill-select-all"]').should('not.exist')
+          }
+        })
       })
 
       it('activating a pill reduces the card count', () => {
@@ -284,60 +352,39 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         }
 
         it('setting a min value reduces the card count', () => {
-          // Fetch real data to pick a meaningful min that excludes some items
           cy.fetchAllItems(apiPath).then((allItems) => {
             const values = (allItems as Record<string, unknown>[])
-              .map(i => i[group])
-              .filter(v => v != null)
-              .map(Number)
-              .sort((a, b) => a - b)
+              .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
+            if (values.length < 2) return
 
-            if (values.length < 2) return // skip if field is always null
-
-            // Use the median as the min — should cut out the lower half
             const median = values[Math.floor(values.length / 2)]
-
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-min"]').clear().type(String(median))
-
-            cy.get('[data-cy="gear-card"]')
-              .its('length').should('be.lte', allItems.length)
+            setSlider(group, 'min', median)
+            cy.get('[data-cy="gear-card"]').its('length').should('be.lte', allItems.length)
           })
         })
 
         it('setting a max value reduces the card count', () => {
           cy.fetchAllItems(apiPath).then((allItems) => {
             const values = (allItems as Record<string, unknown>[])
-              .map(i => i[group])
-              .filter(v => v != null)
-              .map(Number)
-              .sort((a, b) => a - b)
-
+              .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
             if (values.length < 2) return
 
             const median = values[Math.floor(values.length / 2)]
-
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-max"]').clear().type(String(median))
-
-            cy.get('[data-cy="gear-card"]')
-              .its('length').should('be.lte', allItems.length)
+            setSlider(group, 'max', median)
+            cy.get('[data-cy="gear-card"]').its('length').should('be.lte', allItems.length)
           })
         })
 
-        it('clearing both inputs restores the full card count', () => {
+        it('resetting the thumbs restores the full card count', () => {
           cy.fetchAllItems(apiPath).then((allItems) => {
             const values = (allItems as Record<string, unknown>[])
-              .map(i => i[group]).filter(v => v != null).map(Number)
+              .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
             if (values.length < 2) return
 
             const median = values[Math.floor(values.length / 2)]
-
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-min"]').clear().type(String(median))
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-min"]').clear()
-
+            setSlider(group, 'min', median)
+            // Slide the min thumb back to its domain floor → constraint removed.
+            clearSlider(group, 'min')
             cy.get('[data-cy="gear-card"]').should('have.length', allItems.length)
           })
         })
@@ -345,27 +392,33 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         it('items outside the min–max range are excluded', () => {
           cy.fetchAllItems(apiPath).then((allItems) => {
             const values = (allItems as Record<string, unknown>[])
-              .map(i => i[group]).filter(v => v != null).map(Number)
-              .sort((a, b) => a - b)
+              .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
             if (values.length < 3) return
 
             const lo = values[Math.floor(values.length * 0.25)]
             const hi = values[Math.floor(values.length * 0.75)]
 
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-min"]').clear().type(String(lo))
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-max"]').clear().type(String(hi))
+            setSlider(group, 'min', lo)
+            setSlider(group, 'max', hi)
+            // Barrier: wait for the filter to shrink the list before inspecting.
+            cy.get('[data-cy="gear-card"]').should('have.length.lessThan', allItems.length)
 
-            // Cards carry data-{field} attributes with the raw numeric value
-            // (empty string when null). Verify every card's value is within [lo, hi].
+            // Read the actual thumb values (the slider snaps to its step), so the
+            // bounds check matches exactly what was committed.
+            const scope = `[data-cy="filter-group"][data-group="${group}"]`
             const attr = `data-${group.replace(/_/g, '-')}`
-            cy.get('[data-cy="gear-card"]').each(($card) => {
-              const raw = $card.attr(attr)
-              if (raw && raw !== '') {
-                expect(Number(raw)).to.be.gte(lo)
-                expect(Number(raw)).to.be.lte(hi)
-              }
+            cy.get(scope).find('[data-cy="range-min"]').invoke('val').then((aLo) => {
+              cy.get(scope).find('[data-cy="range-max"]').invoke('val').then((aHi) => {
+                const min = Number(aLo)
+                const max = Number(aHi)
+                cy.get('[data-cy="gear-card"]').each(($card) => {
+                  const raw = $card.attr(attr)
+                  if (raw && raw !== '') {
+                    expect(Number(raw)).to.be.gte(min)
+                    expect(Number(raw)).to.be.lte(max)
+                  }
+                })
+              })
             })
           })
         })
@@ -373,12 +426,11 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         it('the item-count label matches the number of filtered cards', () => {
           cy.fetchAllItems(apiPath).then((allItems) => {
             const values = (allItems as Record<string, unknown>[])
-              .map(i => i[group]).filter(v => v != null).map(Number)
+              .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
             if (values.length < 2) return
 
             const median = values[Math.floor(values.length / 2)]
-            cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
-              .find('[data-cy="range-min"]').clear().type(String(median))
+            setSlider(group, 'min', median)
 
             cy.get('[data-cy="gear-card"]').its('length').then((count) => {
               cy.get('[data-cy="item-count"]').should('contain.text', String(count))
@@ -398,10 +450,15 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
 
     it('shows an empty state with a clear-filters link when nothing matches', () => {
       if (pills.length < 2) return
-      cy.get(`[data-cy="filter-group"][data-group="${pills[0].group}"]`)
-        .find('[data-cy="filter-pill"]').last().click()
-      cy.get(`[data-cy="filter-group"][data-group="${pills[1].group}"]`)
-        .find('[data-cy="filter-pill"]').last().click()
+      // Activate the last pill of every group that actually has options (some
+      // enum fields are all-null in the data → zero pills). Stacking these
+      // incompatible constraints drives the list toward empty.
+      pills.forEach(({ group }) => {
+        cy.get(`[data-cy="filter-group"][data-group="${group}"]`).then(($g) => {
+          const $pills = $g.find('[data-cy="filter-pill"]')
+          if ($pills.length > 0) cy.wrap($pills.last()).click()
+        })
+      })
       cy.get('body').then(($body) => {
         if ($body.find('[data-cy="empty-state"]').length > 0) {
           cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').should('be.visible')
@@ -419,13 +476,20 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         .should('have.attr', 'data-active', 'false')
     })
 
-    it('clear-filters resets all range inputs to empty', () => {
+    it('clear-filters resets the range sliders to their full span', () => {
       if (ranges.length === 0) return
-      cy.get(`[data-cy="filter-group"][data-group="${ranges[0].group}"]`)
-        .find('[data-cy="range-min"]').type('999')
-      cy.get('[data-cy="clear-filters"]').first().click()
-      cy.get(`[data-cy="filter-group"][data-group="${ranges[0].group}"]`)
-        .find('[data-cy="range-min"]').should('have.value', '')
+      const group = ranges[0].group
+      cy.fetchAllItems(apiPath).then((allItems) => {
+        const values = (allItems as Record<string, unknown>[])
+          .map(i => i[group]).filter(v => v != null).map(Number).sort((a, b) => a - b)
+        if (values.length < 2) return
+        setSlider(group, 'min', values[Math.floor(values.length / 2)])
+        cy.get('[data-cy="clear-filters"]').first().click()
+        // The min thumb returns to the domain floor (its `min` attribute).
+        cy.get(`[data-cy="filter-group"][data-group="${group}"]`)
+          .find('[data-cy="range-min"]')
+          .should(($el) => expect($el.val()).to.eq($el.attr('min')))
+      })
     })
   })
 })
@@ -451,12 +515,14 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
 describe('Webbing stretch filter', () => {
   const api = () => Cypress.env('apiUrl')
 
-  // Helper: parse stretch JSON and return kN values present in a single item
+  // Helper: parse stretch JSON and return kN values present in a single item.
+  // Skip malformed points with no numeric kn (some data has stray {percent}
+  // entries) — the widget excludes them too, so they must not count as pills.
   function parseKnValues(stretchJson: string | null): number[] {
     if (!stretchJson) return []
     try {
       const points: { kn: number; percent: number }[] = JSON.parse(stretchJson)
-      return points.map(p => p.kn)
+      return points.map(p => p.kn).filter((k): k is number => typeof k === 'number')
     } catch {
       return []
     }
@@ -472,6 +538,28 @@ describe('Webbing stretch filter', () => {
     } catch {
       return null
     }
+  }
+
+  // Helper: the kN → webbing-count map across the whole dataset.
+  function knFrequency(webbings: Record<string, unknown>[]): Map<number, number> {
+    const freq = new Map<number, number>()
+    webbings.forEach(w => {
+      new Set(parseKnValues(w.stretch as string | null)).forEach(k => {
+        freq.set(k, (freq.get(k) ?? 0) + 1)
+      })
+    })
+    return freq
+  }
+
+  // Helper: the top-5 reference kN points the widget must offer — 0 kN dropped,
+  // integers only, ranked by webbing count (ties toward the smaller kN). Mirrors
+  // src/utils/stretch.ts topKnPoints. Returns [{kn, count}] in that ranked order.
+  function topKnPoints(webbings: Record<string, unknown>[], n = 5): { kn: number; count: number }[] {
+    return [...knFrequency(webbings).entries()]
+      .filter(([kn]) => kn !== 0 && Number.isInteger(kn))
+      .sort((a, b) => b[1] - a[1] || a[0] - b[0])
+      .slice(0, n)
+      .map(([kn, count]) => ({ kn, count }))
   }
 
   beforeEach(() => {
@@ -497,54 +585,58 @@ describe('Webbing stretch filter', () => {
       .find('[data-cy="range-max"]').should('exist')
   })
 
-  it('kN pills are populated from the actual dataset (no phantom values)', () => {
+  it('shows only the top-5 kN points as pills (integers, no 0 kN)', () => {
     cy.fetchAllItems('webbing').then((all) => {
-      const allKn = new Set<number>()
-      ;(all as Record<string, unknown>[]).forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => allKn.add(k))
-      })
-      const expectedCount = allKn.size
-
+      const top = topKnPoints(all as Record<string, unknown>[])
       cy.get('[data-cy="filter-group"][data-group="stretch"]')
         .find('[data-cy="stretch-kn-pill"]')
-        .should('have.length', expectedCount)
+        .should('have.length', top.length)
     })
   })
 
-  it('kN pill labels match the actual kN values present in the data', () => {
+  it('pill labels are exactly the top-5 kN values (no phantom / non-top values)', () => {
     cy.fetchAllItems('webbing').then((all) => {
-      const allKn = new Set<number>()
-      ;(all as Record<string, unknown>[]).forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => allKn.add(k))
-      })
+      const topKns = topKnPoints(all as Record<string, unknown>[]).map(p => p.kn)
 
-      allKn.forEach(kn => {
-        cy.get('[data-cy="filter-group"][data-group="stretch"]')
-          .find('[data-cy="stretch-kn-pill"]')
-          .contains(`${kn}`)
-          .should('exist')
+      cy.get('[data-cy="filter-group"][data-group="stretch"]')
+        .find('[data-cy="stretch-kn-pill"]').then(($pills) => {
+          const shown = [...$pills].map(p => Number(p.getAttribute('data-kn')))
+          expect([...shown].sort((a, b) => a - b)).to.deep.equal([...topKns].sort((a, b) => a - b))
+        })
+    })
+  })
+
+  it('never offers 0 kN or non-integer kN as a pill', () => {
+    cy.get('[data-cy="filter-group"][data-group="stretch"]')
+      .find('[data-cy="stretch-kn-pill"]').each(($pill) => {
+        const kn = Number($pill.attr('data-kn'))
+        expect(kn).to.not.equal(0)
+        expect(Number.isInteger(kn)).to.equal(true)
       })
+  })
+
+  it('each pill shows the number of webbings with data at that kN', () => {
+    cy.fetchAllItems('webbing').then((all) => {
+      const counts = new Map(topKnPoints(all as Record<string, unknown>[]).map(p => [p.kn, p.count]))
+      cy.get('[data-cy="filter-group"][data-group="stretch"]')
+        .find('[data-cy="stretch-kn-pill"]').each(($pill) => {
+          const kn = Number($pill.attr('data-kn'))
+          expect(Number($pill.attr('data-count'))).to.equal(counts.get(kn))
+          expect($pill.text()).to.contain(`(${counts.get(kn)})`)
+        })
     })
   })
 
   // ── Default selected kN ───────────────────────────────────────────────────
 
-  it('defaults to the most common kN value pre-selected', () => {
+  it('defaults to the most common (top) kN value pre-selected', () => {
     cy.fetchAllItems('webbing').then((all) => {
-      // Count occurrences of each kN across all stretch arrays
-      const freq: Record<number, number> = {}
-      ;(all as Record<string, unknown>[]).forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const mostCommonKn = Number(
-        Object.entries(freq).sort(([, a], [, b]) => b - a)[0][0]
-      )
+      // The default is the highest-count top point.
+      const mostCommonKn = topKnPoints(all as Record<string, unknown>[])[0].kn
 
       cy.get('[data-cy="filter-group"][data-group="stretch"]')
         .find('[data-cy="stretch-kn-pill"][data-active="true"]')
-        .should('contain.text', `${mostCommonKn}`)
+        .should('have.attr', 'data-kn', `${mostCommonKn}`)
     })
   })
 
@@ -574,6 +666,12 @@ describe('Webbing stretch filter', () => {
   })
 
   it('clicking the active kN pill deselects it (widget goes inactive)', () => {
+    // The default pre-selection is a non-filtering hint; the first click on any
+    // pill engages it. Engage a pill, then click that engaged pill to toggle the
+    // widget off.
+    cy.get('[data-cy="filter-group"][data-group="stretch"]')
+      .find('[data-cy="stretch-kn-pill"]').first().click()
+
     cy.get('[data-cy="filter-group"][data-group="stretch"]')
       .find('[data-cy="stretch-kn-pill"][data-active="true"]').click()
 
@@ -588,27 +686,17 @@ describe('Webbing stretch filter', () => {
     cy.fetchAllItems('webbing').then((all) => {
       const webbings = all as Record<string, unknown>[]
 
-      // Find a kN value that some (but not all) webbings have data for
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
+      // Find a TOP-5 kN that some (but not all) webbings have data for — only
+      // top points are offered as pills now.
+      const partial = topKnPoints(webbings)
+        .find(({ count }) => count > 0 && count < webbings.length)
 
-      const partialKn = Object.entries(freq)
-        .find(([, count]) => count > 0 && count < webbings.length)
-
-      if (!partialKn) return // skip if all webbings have data at every kN (unlikely)
-
-      const kn = Number(partialKn[0])
-      const expectedCount = partialKn[1]
+      if (!partial) return // skip if every top kN is present on every webbing (unlikely)
 
       cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]')
-        .contains(`${kn}`).click()
+        .find(`[data-cy="stretch-kn-pill"][data-kn="${partial.kn}"]`).click()
 
-      cy.get('[data-cy="gear-card"]').should('have.length', expectedCount)
+      cy.get('[data-cy="gear-card"]').should('have.length', partial.count)
     })
   })
 
@@ -641,13 +729,10 @@ describe('Webbing stretch filter', () => {
         .find('[data-cy="stretch-kn-pill"]')
         .contains(`${mostCommonKn}`).click()
 
-      const eligibleCount = percents.length // items with this kN
-
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="range-min"]').clear().type(String(median))
+      setSlider('stretch', 'min', median)
 
       cy.get('[data-cy="gear-card"]')
-        .its('length').should('be.lte', eligibleCount)
+        .its('length').should('be.lte', percents.length)
     })
   })
 
@@ -678,8 +763,7 @@ describe('Webbing stretch filter', () => {
         .find('[data-cy="stretch-kn-pill"]')
         .contains(`${mostCommonKn}`).click()
 
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="range-max"]').clear().type(String(median))
+      setSlider('stretch', 'max', median)
 
       cy.get('[data-cy="gear-card"]')
         .its('length').should('be.lte', percents.length)
@@ -698,18 +782,19 @@ describe('Webbing stretch filter', () => {
   // ── Clearing ──────────────────────────────────────────────────────────────
 
   it('clear-filters deselects the kN pill and clears the % range', () => {
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="range-min"]').type('5')
+    const stretch = '[data-cy="filter-group"][data-group="stretch"]'
+    cy.get(stretch).find('[data-cy="stretch-kn-pill"]').first().click()
+    // Move the % min thumb off its floor (up to the domain ceiling).
+    cy.get(stretch).find('[data-cy="range-max"]').invoke('attr', 'max').then((hi) => {
+      setSlider('stretch', 'min', Number(hi))
+    })
 
     cy.get('[data-cy="clear-filters"]').first().click()
 
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"][data-active="true"]')
-      .should('not.exist')
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="range-min"]').should('have.value', '')
+    cy.get(stretch).find('[data-cy="stretch-kn-pill"][data-active="true"]').should('not.exist')
+    // The % min thumb returns to its domain floor.
+    cy.get(stretch).find('[data-cy="range-min"]')
+      .should(($el) => expect($el.val()).to.eq($el.attr('min')))
   })
 
   it('restores the full webbing list when the stretch filter is cleared', () => {
@@ -721,48 +806,144 @@ describe('Webbing stretch filter', () => {
     })
   })
 
-  // ── Sort by stretch at selected kN ────────────────────────────────────────
+  // ── Sort by stretch at a top-5 kN (decoupled from the filter pill) ─────────
 
-  it('the sort dropdown exposes Stretch % Low→High when a kN is selected', () => {
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()
+  it('the sort dropdown exposes a Stretch sort row without needing a filter pill', () => {
     cy.get('[data-cy="sort-dropdown"]').click()
-    cy.get('[data-cy="sort-option"]').contains(/stretch.*low|low.*stretch/i).should('exist')
+    cy.get('[data-cy="sort-stretch-row"]').should('exist')
+    cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+      .should('exist')
+    cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="desc"]')
+      .should('exist')
   })
 
-  it('the sort dropdown exposes Stretch % High→Low when a kN is selected', () => {
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()
-    cy.get('[data-cy="sort-dropdown"]').click()
-    cy.get('[data-cy="sort-option"]').contains(/stretch.*high|high.*stretch/i).should('exist')
-  })
-
-  it('sorting by Stretch % Low→High orders cards ascending by % at the selected kN', () => {
+  it('the stretch kN secondary dropdown lists exactly the top-5 kN points', () => {
     cy.fetchAllItems('webbing').then((all) => {
-      const webbings = all as Record<string, unknown>[]
-
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const mostCommonKn = Number(
-        Object.entries(freq).sort(([, a], [, b]) => b - a)[0][0]
-      )
-
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]')
-        .contains(`${mostCommonKn}`).click()
-
+      const topKns = topKnPoints(all as Record<string, unknown>[]).map(p => p.kn)
       cy.get('[data-cy="sort-dropdown"]').click()
-      cy.get('[data-cy="sort-option"]').contains(/stretch.*low/i).click()
+      cy.get('[data-cy="stretch-sort-kn"]').click()
+      cy.get('[data-cy="stretch-sort-kn-option"]').then(($opts) => {
+        const shown = [...$opts].map(o => Number(o.getAttribute('data-kn')))
+        expect([...shown].sort((a, b) => a - b)).to.deep.equal([...topKns].sort((a, b) => a - b))
+      })
+    })
+  })
 
-      // Read the stretch % values shown on the cards (via data attribute)
-      cy.get('[data-cy="gear-card"][data-stretch-percent]').then(($cards) => {
-        const percents = [...$cards].map(c => parseFloat(c.getAttribute('data-stretch-percent') ?? '0'))
-        const sorted = [...percents].sort((a, b) => a - b)
-        expect(percents).to.deep.equal(sorted)
+  it('sorting by Stretch Low→High orders cards ascending by % at the chosen kN', () => {
+    // The default stretch-sort kN equals the default filter kN, so each card's
+    // own data-stretch-percent is the value being sorted on (reliable per-card,
+    // unlike mapping by webbing name — names are not unique).
+    cy.get('[data-cy="sort-dropdown"]').click()
+    cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+      .click()
+
+    cy.get('[data-cy="gear-card"][data-stretch-percent]').should(($cards) => {
+      const percents = [...$cards]
+        .map(c => c.getAttribute('data-stretch-percent'))
+        .filter((v): v is string => v != null && v !== '')
+        .map(Number)
+      expect(percents).to.deep.equal([...percents].sort((a, b) => a - b))
+    })
+  })
+})
+
+// ── ISA Certified visibility (data-driven) ────────────────────────────────────
+// The ISA Certified toggle is dropped for gear types where nothing is certified
+// (a lone "No" is useless), and shown where at least one item is certified.
+
+describe('ISA Certified filter visibility', () => {
+  it('is HIDDEN for a type with no certified gear (rollers)', () => {
+    cy.visit('/rollers')
+    cy.get('[data-cy="filter-sidebar"]').should('be.visible')
+    cy.get('[data-cy="filter-group"][data-group="isa_certified"]').should('not.exist')
+  })
+
+  it('is HIDDEN for starter kits and trickline kits (none certified)', () => {
+    cy.visit('/starterkits')
+    cy.get('[data-cy="filter-group"][data-group="isa_certified"]').should('not.exist')
+    cy.visit('/tricklinekits')
+    cy.get('[data-cy="filter-group"][data-group="isa_certified"]').should('not.exist')
+  })
+
+  it('is SHOWN for types that have certified gear (webbings, leash rings)', () => {
+    cy.visit('/webbings')
+    cy.get('[data-cy="filter-group"][data-group="isa_certified"]').should('exist')
+    cy.visit('/leashrings')
+    cy.get('[data-cy="filter-group"][data-group="isa_certified"]').should('exist')
+  })
+})
+
+// ── TreePro "Sold As" label capitalization ────────────────────────────────────
+
+describe('TreePro Sold As labels', () => {
+  it('capitalizes the pair / single pill labels', () => {
+    cy.visit('/treepros')
+    cy.get('[data-cy="filter-group"][data-group="price_unit"]')
+      .find('[data-cy="filter-pill"]').then(($pills) => {
+        const labels = [...$pills].map(p => (p.textContent ?? '').trim())
+        expect(labels.length).to.be.gte(1)
+        labels.forEach(l => expect(l).to.match(/^[A-Z]/)) // each starts uppercase
+        expect(labels).to.include.members(['Pair', 'Single'])
+      })
+  })
+})
+
+// ── Trickline kit weight is not filterable ────────────────────────────────────
+
+describe('Trickline kit weight filter', () => {
+  it('trickline kits have NO Kit Weight range filter (only 2 of 9 have data)', () => {
+    cy.visit('/tricklinekits')
+    cy.get('[data-cy="filter-sidebar"]').should('be.visible')
+    cy.get('[data-cy="filter-group"][data-group="weight"]').should('not.exist')
+  })
+
+  it('starter kits DO keep the Kit Weight filter', () => {
+    cy.visit('/starterkits')
+    cy.get('[data-cy="filter-group"][data-group="weight"]').should('exist')
+  })
+})
+
+// ── Editable range-slider bound labels ────────────────────────────────────────
+// The min/max value labels below each slider are click-to-edit: one click turns
+// the value into a numeric input; typing a value and committing moves the thumb.
+
+describe('Editable slider bounds — Webbing width', () => {
+  beforeEach(() => {
+    cy.visit('/webbings')
+  })
+
+  it('clicking the min value label reveals an editable number input', () => {
+    const scope = '[data-cy="filter-group"][data-group="width"]'
+    cy.get(scope).find('[data-cy="range-min-value"]').should('have.attr', 'data-editing', 'false').click()
+    cy.get(scope).find('[data-cy="range-min-value"]').should('have.attr', 'data-editing', 'true')
+    cy.get(scope).find('input[data-cy="range-min-value"]').should('be.visible')
+  })
+
+  it('typing a new min value moves the min thumb to that value', () => {
+    const scope = '[data-cy="filter-group"][data-group="width"]'
+    // Wait for the data-driven domain to load.
+    cy.get(scope).find('[data-cy="range-max"]').should(($el) => {
+      expect(Number($el.attr('max'))).to.be.greaterThan(Number($el.attr('min')))
+    })
+    cy.get(scope).find('[data-cy="range-min"]').invoke('attr', 'min').then((lo) => {
+      const target = Number(lo) + 2
+      cy.get(scope).find('[data-cy="range-min-value"]').click()
+      cy.get(scope).find('input[data-cy="range-min-value"]').clear().type(`${target}{enter}`)
+      cy.get(scope).find('[data-cy="range-min"]').should('have.value', `${target}`)
+    })
+  })
+
+  it('committing an out-of-range min value is clamped, not rejected', () => {
+    const scope = '[data-cy="filter-group"][data-group="width"]'
+    cy.get(scope).find('[data-cy="range-max"]').should(($el) => {
+      expect(Number($el.attr('max'))).to.be.greaterThan(Number($el.attr('min')))
+    })
+    cy.get(scope).find('[data-cy="range-min-value"]').click()
+    cy.get(scope).find('input[data-cy="range-min-value"]').clear().type('99999{enter}')
+    // Clamped to at most the current max thumb value.
+    cy.get(scope).find('[data-cy="range-min"]').then(($min) => {
+      cy.get(scope).find('[data-cy="range-max"]').then(($max) => {
+        expect(Number($min.val())).to.be.lte(Number($max.val()))
       })
     })
   })

--- a/frontend/cypress/e2e/gear_cards.cy.ts
+++ b/frontend/cypress/e2e/gear_cards.cy.ts
@@ -8,8 +8,12 @@ GEAR_TYPES.forEach(({ slug, apiPath, label, hasISA }) => {
     let firstItem: Record<string, unknown>
 
     before(() => {
-      cy.request(`${Cypress.env('apiUrl')}/${apiPath}/?limit=1`).then(({ body }) => {
-        firstItem = body[0]
+      // The listing defaults to alphabetical-by-name order, so the first card is
+      // the name-first item across the whole dataset — not the API's first row.
+      cy.fetchAllItems(apiPath).then((all) => {
+        firstItem = [...(all as Record<string, unknown>[])].sort((a, b) =>
+          String(a.name).localeCompare(String(b.name)),
+        )[0]
       })
     })
 
@@ -32,12 +36,6 @@ GEAR_TYPES.forEach(({ slug, apiPath, label, hasISA }) => {
         .should('be.visible')
         .and('contain.text', firstItem.name as string)
         .and('have.attr', 'href')
-    })
-
-    it('shows a category badge in the image area', () => {
-      cy.get('[data-cy="gear-card"]').first()
-        .find('[data-cy="gear-card-badge"]')
-        .should('be.visible')
     })
 
     it('shows an inline specs row', () => {

--- a/frontend/cypress/e2e/search_sort.cy.ts
+++ b/frontend/cypress/e2e/search_sort.cy.ts
@@ -198,6 +198,17 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
       cy.get('[data-cy="sort-dropdown"]').should('be.visible')
     })
 
+    // ── Default order ─────────────────────────────────────────────────────────
+    // A fresh load (no sort chosen) must be alphabetical by name — name is the
+    // default sort as well as the universal tie-breaker.
+
+    it('defaults to ascending alphabetical order on first load', () => {
+      cy.get('[data-cy="gear-card-name"]').then(($els) => {
+        const names = [...$els].map(el => el.textContent ?? '')
+        expect(names).to.deep.equal([...names].sort((a, b) => a.localeCompare(b)))
+      })
+    })
+
     it('always contains Name A→Z and Name Z→A', () => {
       cy.get('[data-cy="sort-dropdown"]').click()
       cy.get('[data-cy="sort-option"]').contains(/name.*a.*z|a.*z/i).should('exist')
@@ -273,6 +284,26 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
         })
       })
 
+      it(`${fieldLabel} Low→High: equal values are broken alphabetically by name`, () => {
+        cy.get('[data-cy="sort-dropdown"]').click()
+        cy.get('[data-cy="sort-option"]')
+          .filter(`[data-field="${field}"][data-direction="asc"]`).click()
+
+        cy.get('[data-cy="gear-card"]').then(($cards) => {
+          const rows = [...$cards].map(c => ({
+            value: c.getAttribute(`data-${field.replace(/_/g, '-')}`) ?? '',
+            name: c.querySelector('[data-cy="gear-card-name"]')?.textContent ?? '',
+          }))
+          // Within every run of cards sharing the same numeric value, names must
+          // be in ascending alphabetical order.
+          for (let i = 1; i < rows.length; i++) {
+            if (rows[i].value !== '' && rows[i].value === rows[i - 1].value) {
+              expect(rows[i - 1].name.localeCompare(rows[i].name)).to.be.at.most(0)
+            }
+          }
+        })
+      })
+
       it(`${fieldLabel} High→Low: cards are in descending numeric order (nulls last)`, () => {
         cy.get('[data-cy="sort-dropdown"]').click()
         cy.get('[data-cy="sort-option"]')
@@ -315,18 +346,13 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
   })
 })
 
-// ── Webbing stretch sort (context-driven) ─────────────────────────────────────
+// ── Webbing stretch sort (top-5 kN, secondary dropdown) ───────────────────────
 //
-// Stretch sort options appear in the dropdown ONLY when a kN is selected in
-// the stretch filter widget. The selected kN determines which stretch % values
-// are used for ordering.
-//
-// Null-last: webbings without stretch data at the selected kN sort to the
-// bottom regardless of direction — they are NOT excluded from results unless
-// a % range filter is also active.
-//
-// Cards carry data-stretch-percent="<value>" when they have data at the
-// selected kN, and data-stretch-percent="" when they do not.
+// Stretch sorting is decoupled from the filter widget: the sort dropdown always
+// carries ONE "Stretch at <kN>" row for webbings, where the kN is a nested
+// secondary dropdown offering the top-5 stretch points. Low→High / High→Low then
+// order by the % at the chosen kN (nulls last, ties alphabetical). No filter kN
+// pill needs to be selected.
 
 describe('Webbing stretch sort', () => {
   function parseKnValues(json: string | null): number[] {
@@ -343,163 +369,146 @@ describe('Webbing stretch sort', () => {
     } catch { return null }
   }
 
+  // Mirror of src/utils/stretch.ts topKnPoints: 0 dropped, integers only, top-5
+  // by webbing count (ties toward smaller kN).
+  function topKnPoints(webbings: Record<string, unknown>[], n = 5): { kn: number; count: number }[] {
+    const freq = new Map<number, number>()
+    webbings.forEach(w => {
+      new Set(parseKnValues(w.stretch as string | null)).forEach(k => {
+        freq.set(k, (freq.get(k) ?? 0) + 1)
+      })
+    })
+    return [...freq.entries()]
+      .filter(([kn]) => kn !== 0 && Number.isInteger(kn))
+      .sort((a, b) => b[1] - a[1] || a[0] - b[0])
+      .slice(0, n)
+      .map(([kn, count]) => ({ kn, count }))
+  }
+
+  // Read the visible cards' item ids top-to-bottom, from the detail-link href
+  // (/webbings/<id>). Ids are unique — webbing NAMES are not, so map by id.
+  function cardIds($cards: JQuery<HTMLElement>): string[] {
+    return [...$cards].map(c => {
+      const href = c.querySelector('[data-cy="gear-card-name"]')?.getAttribute('href') ?? ''
+      return href.split('/').pop() ?? ''
+    })
+  }
+
+  function pctByIdAt(webbings: Record<string, unknown>[], kn: number): Map<string, number | null> {
+    return new Map(webbings.map(w => [String(w.id), percentAtKn(w.stretch as string | null, kn)]))
+  }
+
   beforeEach(() => {
     cy.visit('/webbings')
   })
 
-  it('stretch sort options are NOT in the dropdown before a kN is selected', () => {
+  it('exposes a stretch sort row in the dropdown WITHOUT a filter kN selected', () => {
     cy.get('[data-cy="sort-dropdown"]').click()
-    cy.get('[data-cy="sort-option"][data-field="stretch"]').should('not.exist')
+    cy.get('[data-cy="sort-stretch-row"]').should('exist')
+    cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+      .should('exist')
+    cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="desc"]')
+      .should('exist')
     cy.get('body').type('{esc}')
   })
 
-  it('stretch Low→High and High→Low options appear after selecting a kN', () => {
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()
-
-    cy.get('[data-cy="sort-dropdown"]').click()
-    cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="asc"]').should('exist')
-    cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="desc"]').should('exist')
-    cy.get('body').type('{esc}')
+  it('the kN secondary dropdown offers only the top-5 stretch points', () => {
+    cy.fetchAllItems('webbing').then((all) => {
+      const topKns = topKnPoints(all as Record<string, unknown>[]).map(p => p.kn)
+      cy.get('[data-cy="sort-dropdown"]').click()
+      cy.get('[data-cy="stretch-sort-kn"]').click()
+      cy.get('[data-cy="stretch-sort-kn-option"]').should('have.length', topKns.length)
+      cy.get('[data-cy="stretch-sort-kn-option"]').then(($opts) => {
+        const shown = [...$opts].map(o => Number(o.getAttribute('data-kn')))
+        expect([...shown].sort((a, b) => a - b)).to.deep.equal([...topKns].sort((a, b) => a - b))
+      })
+    })
   })
 
-  it('stretch sort options disappear when the kN pill is deselected', () => {
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()  // select
-    cy.get('[data-cy="filter-group"][data-group="stretch"]')
-      .find('[data-cy="stretch-kn-pill"]').first().click()  // deselect
-
-    cy.get('[data-cy="sort-dropdown"]').click()
-    cy.get('[data-cy="sort-option"][data-field="stretch"]').should('not.exist')
-    cy.get('body').type('{esc}')
+  it('defaults the stretch sort kN to the most common (top) point', () => {
+    cy.fetchAllItems('webbing').then((all) => {
+      const defaultKn = topKnPoints(all as Record<string, unknown>[])[0].kn
+      cy.get('[data-cy="sort-dropdown"]').click()
+      cy.get('[data-cy="stretch-sort-kn"]').should('have.attr', 'data-kn', `${defaultKn}`)
+      cy.get('body').type('{esc}')
+    })
   })
 
-  it('Stretch Low→High orders by % ascending at the selected kN, nulls last', () => {
+  it('Stretch Low→High orders by % ascending at the chosen kN, nulls last', () => {
     cy.fetchAllItems('webbing').then((all) => {
       const webbings = all as Record<string, unknown>[]
-
-      // Find the most common kN
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const kn = Number(Object.entries(freq).sort(([, a], [, b]) => b - a)[0][0])
-
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]').contains(`${kn}`).click()
+      const kn = topKnPoints(webbings)[0].kn
+      const pctById = pctByIdAt(webbings, kn)
 
       cy.get('[data-cy="sort-dropdown"]').click()
-      cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="asc"]').click()
+      cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+        .click()
 
-      cy.get('[data-cy="gear-card"]').then(($cards) => {
-        const raw     = [...$cards].map(c => c.getAttribute('data-stretch-percent') ?? '')
-        const nums    = raw.filter(v => v !== '').map(Number)
-        const firstNull = raw.indexOf('')
-        const lastNum   = raw.map((v, i) => v !== '' ? i : -1).filter(i => i >= 0).pop() ?? -1
-
-        // Non-null values are ascending
+      cy.get('[data-cy="gear-card"]').should(($cards) => {
+        const pcts = cardIds($cards).map(id => pctById.get(id) ?? null)
+        const nums = pcts.filter((p): p is number => p != null)
         expect(nums).to.deep.equal([...nums].sort((a, b) => a - b))
-
-        // Nulls (no data at this kN) are after all real values
-        if (firstNull !== -1 && lastNum !== -1) {
-          expect(firstNull).to.be.gt(lastNum)
-        }
+        const firstNull = pcts.indexOf(null)
+        const lastNum = pcts.map((p, i) => (p != null ? i : -1)).filter(i => i >= 0).pop() ?? -1
+        if (firstNull !== -1 && lastNum !== -1) expect(firstNull).to.be.gt(lastNum)
       })
     })
   })
 
-  it('Stretch High→Low orders by % descending at the selected kN, nulls last', () => {
+  it('Stretch High→Low orders by % descending at the chosen kN, nulls last', () => {
     cy.fetchAllItems('webbing').then((all) => {
       const webbings = all as Record<string, unknown>[]
-
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const kn = Number(Object.entries(freq).sort(([, a], [, b]) => b - a)[0][0])
-
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]').contains(`${kn}`).click()
+      const kn = topKnPoints(webbings)[0].kn
+      const pctById = pctByIdAt(webbings, kn)
 
       cy.get('[data-cy="sort-dropdown"]').click()
-      cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="desc"]').click()
+      cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="desc"]')
+        .click()
 
-      cy.get('[data-cy="gear-card"]').then(($cards) => {
-        const raw     = [...$cards].map(c => c.getAttribute('data-stretch-percent') ?? '')
-        const nums    = raw.filter(v => v !== '').map(Number)
-        const firstNull = raw.indexOf('')
-        const lastNum   = raw.map((v, i) => v !== '' ? i : -1).filter(i => i >= 0).pop() ?? -1
-
+      cy.get('[data-cy="gear-card"]').should(($cards) => {
+        const pcts = cardIds($cards).map(id => pctById.get(id) ?? null)
+        const nums = pcts.filter((p): p is number => p != null)
         expect(nums).to.deep.equal([...nums].sort((a, b) => b - a))
-
-        if (firstNull !== -1 && lastNum !== -1) {
-          expect(firstNull).to.be.gt(lastNum)
-        }
+        const firstNull = pcts.indexOf(null)
+        const lastNum = pcts.map((p, i) => (p != null ? i : -1)).filter(i => i >= 0).pop() ?? -1
+        if (firstNull !== -1 && lastNum !== -1) expect(firstNull).to.be.gt(lastNum)
       })
     })
   })
 
-  it('changing the selected kN updates both the visible cards and the sort', () => {
+  it('all webbings stay visible when sorting by stretch (nulls sink, not excluded)', () => {
     cy.fetchAllItems('webbing').then((all) => {
-      const webbings = all as Record<string, unknown>[]
-
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const sortedKns = Object.entries(freq).sort(([, a], [, b]) => b - a)
-      if (sortedKns.length < 2) return
-
-      const kn1 = Number(sortedKns[0][0])
-      const kn2 = Number(sortedKns[1][0])
-
-      // Select first kN and sort
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]').contains(`${kn1}`).click()
       cy.get('[data-cy="sort-dropdown"]').click()
-      cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="asc"]').click()
-
-      cy.get('[data-cy="gear-card"]').its('length').then((count1) => {
-        // Switch to second kN
-        cy.get('[data-cy="filter-group"][data-group="stretch"]')
-          .find('[data-cy="stretch-kn-pill"]').contains(`${kn2}`).click()
-
-        // Sort option should still be stretch asc but now driven by kn2
-        cy.get('[data-cy="sort-dropdown"]')
-          .should('contain.text', `${kn2}`)
-
-        // Card count may differ since different kN values are present in different webbings
-        cy.get('[data-cy="gear-card"]').its('length').should('be.gte', 1)
-      })
+      cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+        .click()
+      cy.get('[data-cy="gear-card"]').should('have.length', all.length)
     })
   })
 
-  it('stretch sort without a % range filter shows all webbings (not just those with data)', () => {
+  it('choosing a different kN in the secondary dropdown re-sorts by that kN', () => {
     cy.fetchAllItems('webbing').then((all) => {
       const webbings = all as Record<string, unknown>[]
+      const top = topKnPoints(webbings)
+      if (top.length < 2) return
+      const kn2 = top[1].kn
+      const pctById = pctByIdAt(webbings, kn2)
 
-      const freq: Record<number, number> = {}
-      webbings.forEach(w => {
-        parseKnValues(w.stretch as string | null).forEach(k => {
-          freq[k] = (freq[k] ?? 0) + 1
-        })
-      })
-      const kn = Number(Object.entries(freq).sort(([, a], [, b]) => b - a)[0][0])
-
-      // Select kN and sort — no % range set
-      cy.get('[data-cy="filter-group"][data-group="stretch"]')
-        .find('[data-cy="stretch-kn-pill"]').contains(`${kn}`).click()
       cy.get('[data-cy="sort-dropdown"]').click()
-      cy.get('[data-cy="sort-option"][data-field="stretch"][data-direction="asc"]').click()
+      // Sort ascending at the default kN first.
+      cy.get('[data-cy="sort-stretch-row"] [data-cy="sort-option"][data-field="stretch"][data-direction="asc"]')
+        .click()
+      // Reopen, switch the secondary kN to the second top point.
+      cy.get('[data-cy="sort-dropdown"]').click()
+      cy.get('[data-cy="stretch-sort-kn"]').click()
+      cy.get(`[data-cy="stretch-sort-kn-option"][data-kn="${kn2}"]`).click()
 
-      // All webbings are visible (those without data at this kN appear at the bottom)
-      cy.get('[data-cy="gear-card"]').should('have.length', webbings.length)
+      cy.get('[data-cy="sort-dropdown"]').should('contain.text', `${kn2}`)
+      cy.get('[data-cy="gear-card"]').should(($cards) => {
+        const nums = cardIds($cards)
+          .map(id => pctById.get(id) ?? null)
+          .filter((p): p is number => p != null)
+        expect(nums).to.deep.equal([...nums].sort((a, b) => a - b))
+      })
     })
   })
 })

--- a/frontend/src/components/gear/FilterGroup.tsx
+++ b/frontend/src/components/gear/FilterGroup.tsx
@@ -1,0 +1,45 @@
+// A collapsible sidebar filter section: teal dot accent, small-caps label, and a
+// collapse/expand toggle. Body stays mounted when collapsed (hidden via CSS) so
+// tests can assert its controls are `not.be.visible` rather than absent.
+
+import { useState, type ReactNode } from 'react'
+
+export default function FilterGroup({
+  group,
+  label,
+  children,
+}: {
+  group: string
+  label: string
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <div
+      data-cy="filter-group"
+      data-group={group}
+      className="border-b border-gray-100 py-3 last:border-b-0"
+    >
+      <button
+        data-cy="filter-group-toggle"
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center gap-2"
+        aria-expanded={open}
+      >
+        <span
+          data-cy="filter-group-dot"
+          className="h-2 w-2 shrink-0 rounded-full"
+          style={{ background: '#00897B' }}
+        />
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+          {label}
+        </span>
+        <span className="ml-auto text-sm leading-none text-gray-400">{open ? '−' : '+'}</span>
+      </button>
+
+      <div className={open ? 'mt-2' : 'hidden'}>{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/gear/FilterSidebar.tsx
+++ b/frontend/src/components/gear/FilterSidebar.tsx
@@ -1,18 +1,202 @@
-// Left filter sidebar. Phase 3 renders the container + header; the filter groups
-// (pills, ranges, stretch widget) are built in Phase 4.
+// Left filter sidebar. Renders one collapsible group per entry in the per-type
+// filter config: pill groups (values derived from the loaded dataset) and range
+// groups (min/max inputs). All state lives in the URL via useUrlState, so the
+// listing page re-derives the visible list from it. The webbing stretch widget
+// is appended separately (StretchFilter).
 
+import { useMemo } from 'react'
 import type { GearTypeMeta } from '@/config/gearTypes'
+import { filterGroupsFor, type FilterGroupMeta } from '@/config/filterGroups'
+import { derivePillOptions } from '@/utils/filter'
+import type { useUrlState } from '@/hooks/useUrlState'
+import type { AnyItem } from '@/utils/format'
+import FilterGroup from './FilterGroup'
+import RangeSlider from './RangeSlider'
 
-export default function FilterSidebar({ meta }: { meta: GearTypeMeta }) {
+type UrlState = ReturnType<typeof useUrlState>
+
+// A boolean pill group is hidden when nothing in the data is `true` — e.g. no
+// ISA-certified rollers means the whole "ISA Certified" toggle is dropped rather
+// than showing a lone, useless "No". Enum groups are left as-is even when empty
+// (isa_warning currently has no data but is still a valid, forthcoming field).
+function pillGroupVisible(meta: FilterGroupMeta, items: AnyItem[]): boolean {
+  if (meta.type !== 'pill' || meta.pillKind !== 'bool') return true
+  const options = derivePillOptions(items, meta.group, meta.pillKind, meta.capitalize)
+  return options.some(o => o.value === 'true')
+}
+
+// Pill filter group. Groups with exactly two options are single-select (a radio
+// with a clear): picking one replaces the other, re-picking the active one clears
+// back to "all". Groups with 3+ options are multi-select (OR within the group)
+// and get subtle All / None shortcuts.
+function PillGroup({ meta, url, items }: { meta: FilterGroupMeta; url: UrlState; items: AnyItem[] }) {
+  const options = derivePillOptions(items, meta.group, meta.pillKind, meta.capitalize)
+  const single = options.length === 2
+  const selected = url.getPillValues(meta.group)
+
+  const onPick = (value: string) => {
+    if (single) {
+      const isOnly = selected.length === 1 && selected[0] === value
+      url.setPillValues(meta.group, isOnly ? [] : [value])
+    } else {
+      url.togglePill(meta.group, value)
+    }
+  }
+
+  return (
+    <div data-cy="pill-group" data-select={single ? 'single' : 'multi'}>
+      {options.length >= 3 && (
+        <div className="mb-1.5 flex gap-2 text-[10px] font-medium uppercase tracking-wide text-gray-400">
+          <button
+            data-cy="pill-select-all"
+            type="button"
+            onClick={() => url.setPillValues(meta.group, options.map(o => o.value))}
+            className="hover:text-teal-primary hover:underline"
+          >
+            All
+          </button>
+          <span aria-hidden>·</span>
+          <button
+            data-cy="pill-select-none"
+            type="button"
+            onClick={() => url.setPillValues(meta.group, [])}
+            className="hover:text-teal-primary hover:underline"
+          >
+            None
+          </button>
+        </div>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {options.map(opt => (
+          <Pill
+            key={opt.value}
+            active={selected.includes(opt.value)}
+            label={opt.label}
+            onClick={() => onPick(opt.value)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Pill({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      data-cy="filter-pill"
+      type="button"
+      data-active={active ? 'true' : 'false'}
+      onClick={onClick}
+      className={
+        'rounded-full border px-3 py-1 text-xs transition-colors ' +
+        (active
+          ? 'border-teal-primary bg-teal-50 text-teal-primary'
+          : 'border-gray-300 bg-white text-gray-600 hover:border-gray-400 hover:text-gray-800')
+      }
+      style={active ? { background: '#E0F2F1' } : undefined}
+    >
+      {label}
+    </button>
+  )
+}
+
+// A URL-backed range slider for a numeric group. The slider domain is the
+// data's [min, max]; the current thumbs come from the URL (or the domain bounds
+// when unset). A thumb at a domain bound means "no constraint" (param deleted),
+// so clear-all — which empties the URL — restores the full span automatically.
+function RangeControl({
+  group,
+  unit,
+  url,
+  items,
+}: {
+  group: string
+  unit?: string
+  url: UrlState
+  items: AnyItem[]
+}) {
+  const domain = useMemo(() => {
+    const vals = items
+      .map(i => i[group])
+      .filter(v => v != null && v !== '')
+      .map(Number)
+      .filter(v => Number.isFinite(v))
+    // No data yet (still loading) → a zero-width domain so consumers can tell it
+    // isn't ready. Integer-only fields step by 1, otherwise 0.5 (no 0.1 noise).
+    if (!vals.length) return { lo: 0, hi: 0, step: 1 }
+    const lo = Math.min(...vals)
+    const hi = Math.max(...vals)
+    const step = vals.every(Number.isInteger) ? 1 : 0.5
+    return { lo, hi: hi > lo ? hi : lo + 1, step }
+  }, [items, group])
+
+  const rawMin = url.params.get(`${group}_min`)
+  const rawMax = url.params.get(`${group}_max`)
+  const lo = rawMin != null && rawMin !== '' ? Number(rawMin) : domain.lo
+  const hi = rawMax != null && rawMax !== '' ? Number(rawMax) : domain.hi
+
+  // A thumb at its domain bound means "no constraint" → delete that param. Each
+  // write touches only its own key, preserving the other via the URL.
+  return (
+    <RangeSlider
+      domainLo={domain.lo}
+      domainHi={domain.hi}
+      lo={lo}
+      hi={hi}
+      unit={unit}
+      step={domain.step}
+      onMinChange={v => url.setRangeBound(group, 'min', v <= domain.lo ? '' : String(v))}
+      onMaxChange={v => url.setRangeBound(group, 'max', v >= domain.hi ? '' : String(v))}
+    />
+  )
+}
+
+export default function FilterSidebar({
+  meta,
+  items,
+  url,
+  children,
+}: {
+  meta: GearTypeMeta
+  items: AnyItem[]
+  url: UrlState
+  children?: React.ReactNode // webbing stretch widget slots in here
+}) {
+  const groups = filterGroupsFor(meta.slug)
+
   return (
     <aside data-cy="filter-sidebar" className="w-[280px] shrink-0">
-      <div
-        data-cy="filter-sidebar-header"
-        className="mb-4 text-xs font-semibold uppercase tracking-wide text-gray-500"
-      >
-        Find your {meta.label.toUpperCase()}
+      <div className="mb-3 flex items-center justify-between">
+        <div
+          data-cy="filter-sidebar-header"
+          className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+        >
+          Find your {meta.label.toUpperCase()}
+        </div>
+        <button
+          data-cy="clear-filters"
+          type="button"
+          onClick={url.clearAll}
+          className="text-[11px] font-medium text-teal-primary hover:underline"
+        >
+          Clear all
+        </button>
       </div>
-      {/* filter groups added in Phase 4 */}
+
+      <div className="rounded-xl border border-gray-200 bg-white px-4">
+        {groups
+          .filter(g => pillGroupVisible(g, items))
+          .map(g => (
+            <FilterGroup key={g.group} group={g.group} label={g.label}>
+              {g.type === 'pill' ? (
+                <PillGroup meta={g} url={url} items={items} />
+              ) : (
+                <RangeControl group={g.group} unit={g.unit} url={url} items={items} />
+              )}
+            </FilterGroup>
+          ))}
+        {children}
+      </div>
     </aside>
   )
 }

--- a/frontend/src/components/gear/GearCard.tsx
+++ b/frontend/src/components/gear/GearCard.tsx
@@ -31,10 +31,17 @@ export default function GearCard({ item, meta }: { item: AnyItem; meta: GearType
     .map(s => formatValue(item[s.field], s.unit))
     .filter(v => v !== '')
 
+  // Webbing stretch % at the active kN (set by the listing page). Emitted only
+  // when present — an empty attribute would still match the [data-stretch-percent]
+  // selector the sort-order test uses.
+  const stretchAttr =
+    item.stretch_percent != null ? { 'data-stretch-percent': String(item.stretch_percent) } : {}
+
   return (
     <article
       data-cy="gear-card"
       {...dataAttrs(item, CARD_DATA_FIELDS[slug] ?? [])}
+      {...stretchAttr}
       className="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
     >
       <div

--- a/frontend/src/components/gear/RangeSlider.tsx
+++ b/frontend/src/components/gear/RangeSlider.tsx
@@ -1,0 +1,185 @@
+// Dual-thumb range slider — the modern replacement for min/max text boxes, used
+// by every numeric min/max filter (and the webbing stretch %). Two overlaid
+// native range inputs keep it accessible and easy for tests to drive; the min
+// thumb is data-cy="range-min", the max thumb data-cy="range-max". step="any"
+// preserves exact float values (breaking strength etc.).
+//
+// Presentational + controlled: callers supply the domain, the current [lo, hi],
+// and an onChange. This component clamps the thumbs so they can't cross.
+//
+// The two bound labels below the track are click-to-edit: a single click turns
+// the value into a numeric input you can type into (committed on Enter/blur,
+// reverted on Escape), so the exact bound can be set without dragging a thumb.
+
+import { useEffect, useRef, useState } from 'react'
+
+export default function RangeSlider({
+  domainLo,
+  domainHi,
+  lo,
+  hi,
+  unit,
+  step = 1,
+  onMinChange,
+  onMaxChange,
+}: {
+  domainLo: number
+  domainHi: number
+  lo: number
+  hi: number
+  unit?: string
+  step?: number // 1 for integer-only fields, 0.5 when the data has fractional values
+  // Per-thumb so a single change only writes its own bound — writing both would
+  // let a stale `lo`/`hi` prop (async URL echo) clobber the other thumb.
+  onMinChange: (v: number) => void
+  onMaxChange: (v: number) => void
+}) {
+  // Degenerate domain (all values equal / no data): render disabled thumbs.
+  const span = domainHi - domainLo || 1
+  const pct = (v: number) => `${((v - domainLo) / span) * 100}%`
+
+  const thumb =
+    'pointer-events-none absolute inset-0 h-1.5 w-full appearance-none bg-transparent ' +
+    '[&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-3.5 ' +
+    '[&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:appearance-none ' +
+    '[&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border ' +
+    '[&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-teal-primary ' +
+    '[&::-webkit-slider-thumb]:shadow [&::-moz-range-thumb]:pointer-events-auto ' +
+    '[&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:rounded-full ' +
+    '[&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-teal-primary'
+
+  return (
+    <div>
+      <div className="relative h-4">
+        {/* track */}
+        <div className="absolute top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full bg-gray-200" />
+        {/* selected span */}
+        <div
+          className="absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full"
+          style={{ left: pct(lo), right: `calc(100% - ${pct(hi)})`, background: '#00897B' }}
+        />
+        <input
+          data-cy="range-min"
+          type="range"
+          min={domainLo}
+          max={domainHi}
+          step={step}
+          value={lo}
+          onChange={e => onMinChange(Math.min(Number(e.target.value), hi))}
+          className={`${thumb} top-1/2 -translate-y-1/2`}
+          aria-label="minimum"
+        />
+        <input
+          data-cy="range-max"
+          type="range"
+          min={domainLo}
+          max={domainHi}
+          step={step}
+          value={hi}
+          onChange={e => onMaxChange(Math.max(Number(e.target.value), lo))}
+          className={`${thumb} top-1/2 -translate-y-1/2`}
+          aria-label="maximum"
+        />
+      </div>
+      <div className="mt-1 flex justify-between text-[11px] text-gray-500">
+        <EditableBound
+          cy="range-min-value"
+          value={lo}
+          unit={unit}
+          min={domainLo}
+          max={hi}
+          step={step}
+          onCommit={v => onMinChange(Math.min(Math.max(v, domainLo), hi))}
+        />
+        <EditableBound
+          cy="range-max-value"
+          value={hi}
+          unit={unit}
+          min={lo}
+          max={domainHi}
+          step={step}
+          onCommit={v => onMaxChange(Math.max(Math.min(v, domainHi), lo))}
+        />
+      </div>
+    </div>
+  )
+}
+
+// A single bound label that swaps to a numeric input on click. Controlled by the
+// parent for its resting value; owns only the transient draft string while being
+// edited so keystrokes don't fight the async URL echo (same race the sliders avoid).
+function EditableBound({
+  cy,
+  value,
+  unit,
+  min,
+  max,
+  step,
+  onCommit,
+}: {
+  cy: string
+  value: number
+  unit?: string
+  min: number
+  max: number
+  step: number
+  onCommit: (v: number) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus()
+  }, [editing])
+
+  const start = () => {
+    setDraft(String(value))
+    setEditing(true)
+  }
+
+  const commit = () => {
+    setEditing(false)
+    const n = Number(draft)
+    if (draft.trim() !== '' && Number.isFinite(n)) onCommit(n)
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        data-cy={cy}
+        data-editing="true"
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={e => {
+          if (e.key === 'Enter') commit()
+          else if (e.key === 'Escape') setEditing(false)
+        }}
+        className="w-14 rounded border border-teal-primary px-1 py-0.5 text-[11px] text-gray-700 focus:outline-none"
+        aria-label={cy}
+      />
+    )
+  }
+
+  return (
+    <button
+      data-cy={cy}
+      data-editing="false"
+      type="button"
+      onClick={start}
+      className="cursor-text rounded px-1 hover:bg-gray-100"
+    >
+      {formatBound(value)}{unit ? ` ${unit}` : ''}
+    </button>
+  )
+}
+
+function formatBound(v: number): string {
+  return Number.isInteger(v) ? String(v) : v.toFixed(1)
+}

--- a/frontend/src/components/gear/SortDropdown.tsx
+++ b/frontend/src/components/gear/SortDropdown.tsx
@@ -2,18 +2,31 @@
 // present. The button label reflects the current sort; options carry
 // data-field / data-direction for the tests.
 //
-// Phase 3 scope: functional dropdown that writes the sort. The Name-A→Z-as-
-// default (no URL param) nuance and the contextual stretch options are refined
-// in Phase 5.
+// Webbing stretch sort is special: it is available for the TOP-5 stretch kN
+// points (passed in as `stretchKns`) and is decoupled from the filter widget.
+// Rather than listing ten "Stretch at N kN" rows, the menu shows ONE stretch row
+// whose kN is a nested secondary dropdown; the two Low→High / High→Low options
+// sort by the % at the chosen kN. The sort field encodes that kN as `stretch@N`.
 
 import { Fragment, useEffect, useRef, useState } from 'react'
 import type { SortSpec } from '@/hooks/useUrlState'
 import { sortFieldsFor } from '@/config/sortFields'
 import type { GearSlug } from '@/types'
 
+const STRETCH_PREFIX = 'stretch@'
+
+function stretchKnOf(sort: SortSpec | null): number | null {
+  if (!sort || !sort.field.startsWith(STRETCH_PREFIX)) return null
+  return Number(sort.field.slice(STRETCH_PREFIX.length))
+}
+
 function labelFor(sort: SortSpec | null, slug: GearSlug): string {
   if (!sort) return 'Sort by'
   if (sort.field === 'name') return sort.direction === 'asc' ? 'Name: A→Z' : 'Name: Z→A'
+  const kn = stretchKnOf(sort)
+  if (kn != null) {
+    return `Stretch at ${kn} kN: ${sort.direction === 'asc' ? 'Low→High' : 'High→Low'}`
+  }
   const meta = sortFieldsFor(slug).find(f => f.field === sort.field)
   const name = meta?.label ?? sort.field
   return `${name}: ${sort.direction === 'asc' ? 'Low→High' : 'High→Low'}`
@@ -23,14 +36,25 @@ export default function SortDropdown({
   slug,
   sort,
   onChange,
+  stretchKns = [],
 }: {
   slug: GearSlug
   sort: SortSpec | null
   onChange: (spec: SortSpec | null) => void
+  // Top-5 webbing stretch reference kN, RANKED by webbing count (most common
+  // first) so stretchKns[0] is the default sort kN. Empty for non-webbing types.
+  stretchKns?: number[]
 }) {
   const [open, setOpen] = useState(false)
+  const [knOpen, setKnOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const fields = sortFieldsFor(slug)
+
+  // The kN currently targeted by the stretch row: the active stretch sort's kN if
+  // one is set, otherwise the first (most-common) top point.
+  const [pickedKn, setPickedKn] = useState<number | null>(null)
+  const activeKn = stretchKnOf(sort)
+  const stretchKn = activeKn ?? pickedKn ?? stretchKns[0] ?? null
 
   useEffect(() => {
     if (!open) return
@@ -49,7 +73,11 @@ export default function SortDropdown({
   const pick = (spec: SortSpec | null) => {
     onChange(spec)
     setOpen(false)
+    setKnOpen(false)
   }
+
+  const pickStretch = (kn: number, direction: 'asc' | 'desc') =>
+    pick({ field: `${STRETCH_PREFIX}${kn}`, direction })
 
   const optionClass =
     'block w-full px-3 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50'
@@ -108,6 +136,67 @@ export default function SortDropdown({
               </button>
             </Fragment>
           ))}
+
+          {stretchKn != null && (
+            <div data-cy="sort-stretch-row" className="border-t border-gray-100 mt-1 pt-1">
+              <div className="flex items-center gap-1 px-3 py-1 text-xs uppercase tracking-wide text-gray-400">
+                <span>Stretch at</span>
+                {/* Secondary dropdown: the kN number is itself clickable. */}
+                <div className="relative">
+                  <button
+                    data-cy="stretch-sort-kn"
+                    data-kn={stretchKn}
+                    type="button"
+                    onClick={() => setKnOpen(o => !o)}
+                    className="rounded border border-gray-300 px-1.5 py-0.5 text-xs font-semibold text-gray-600 hover:border-gray-400"
+                  >
+                    {stretchKn} kN ▾
+                  </button>
+                  {knOpen && (
+                    <div className="absolute left-0 z-40 mt-1 min-w-[80px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+                      {[...stretchKns].sort((a, b) => a - b).map(kn => (
+                        <button
+                          key={kn}
+                          data-cy="stretch-sort-kn-option"
+                          data-kn={kn}
+                          type="button"
+                          className="block w-full px-3 py-1 text-left text-xs text-gray-700 hover:bg-gray-50"
+                          onClick={() => {
+                            setPickedKn(kn)
+                            setKnOpen(false)
+                            // If a stretch sort is already active, retarget it.
+                            if (activeKn != null) pickStretch(kn, sort!.direction)
+                          }}
+                        >
+                          {kn} kN
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <button
+                data-cy="sort-option"
+                data-field="stretch"
+                data-kn={stretchKn}
+                data-direction="asc"
+                className={optionClass}
+                onClick={() => pickStretch(stretchKn, 'asc')}
+              >
+                Low→High
+              </button>
+              <button
+                data-cy="sort-option"
+                data-field="stretch"
+                data-kn={stretchKn}
+                data-direction="desc"
+                className={optionClass}
+                onClick={() => pickStretch(stretchKn, 'desc')}
+              >
+                High→Low
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/gear/StretchFilter.tsx
+++ b/frontend/src/components/gear/StretchFilter.tsx
@@ -1,0 +1,99 @@
+// Webbing-only "Stretch at X kN" widget. Single-select kN pills (populated from
+// the dataset) pick a reference point on the stretch curve; a dual-thumb %
+// slider narrows within it. State is owned by GearListingPage (it also drives
+// filtering, the contextual sort options, and the cards' data-stretch-percent),
+// so this is a controlled component. See the "Webbing stretch filter" block in
+// filters.cy.ts.
+
+import { useMemo } from 'react'
+import { percentAtKn, topKnPoints } from '@/utils/stretch'
+import type { AnyItem } from '@/utils/format'
+import FilterGroup from './FilterGroup'
+import RangeSlider from './RangeSlider'
+
+export default function StretchFilter({
+  items,
+  displayKn,
+  onSelectKn,
+  min,
+  max,
+  onMinChange,
+  onMaxChange,
+}: {
+  items: AnyItem[]
+  displayKn: number | null // the pill shown active (default or engaged)
+  onSelectKn: (kn: number) => void
+  min: string
+  max: string
+  onMinChange: (v: string) => void
+  onMaxChange: (v: string) => void
+}) {
+  // Top-5 integer kN points (excluding 0), each with its webbing count, shown in
+  // ascending kN order for a stable left-to-right pill layout.
+  const points = useMemo(
+    () => [...topKnPoints(items)].sort((a, b) => a.kn - b.kn),
+    [items],
+  )
+
+  // % domain = spread of stretch % across webbings at the selected kN.
+  const domain = useMemo(() => {
+    if (displayKn == null) return { lo: 0, hi: 0, step: 1 }
+    const ps = items
+      .map(i => percentAtKn(i.stretch, displayKn))
+      .filter((p): p is number => p != null)
+    if (!ps.length) return { lo: 0, hi: 0, step: 1 }
+    const lo = Math.min(...ps)
+    const hi = Math.max(...ps)
+    const step = ps.every(Number.isInteger) ? 1 : 0.5
+    return { lo, hi: hi > lo ? hi : lo + 1, step }
+  }, [items, displayKn])
+
+  const lo = min !== '' ? Number(min) : domain.lo
+  const hi = max !== '' ? Number(max) : domain.hi
+
+  return (
+    <FilterGroup group="stretch" label="Stretch at kN">
+      <div className="flex flex-wrap gap-1.5">
+        {points.map(({ kn, count }) => {
+          const active = kn === displayKn
+          return (
+            <button
+              key={kn}
+              data-cy="stretch-kn-pill"
+              type="button"
+              data-kn={kn}
+              data-count={count}
+              data-active={active ? 'true' : 'false'}
+              onClick={() => onSelectKn(kn)}
+              className={
+                'rounded-full border px-2.5 py-1 text-xs transition-colors ' +
+                (active
+                  ? 'border-teal-primary text-teal-primary'
+                  : 'border-gray-300 bg-white text-gray-600 hover:border-gray-400')
+              }
+              style={active ? { background: '#E0F2F1' } : undefined}
+            >
+              {kn} kN{' '}
+              <span className="text-gray-400" data-cy="stretch-kn-count">
+                ({count})
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="mt-3">
+        <RangeSlider
+          domainLo={domain.lo}
+          domainHi={domain.hi}
+          lo={lo}
+          hi={hi}
+          unit="%"
+          step={domain.step}
+          onMinChange={v => onMinChange(v <= domain.lo ? '' : String(v))}
+          onMaxChange={v => onMaxChange(v >= domain.hi ? '' : String(v))}
+        />
+      </div>
+    </FilterGroup>
+  )
+}

--- a/frontend/src/config/filterGroups.ts
+++ b/frontend/src/config/filterGroups.ts
@@ -1,0 +1,127 @@
+// Per-gear-type filter group configuration for the left sidebar.
+//
+// Mirrors the FILTER_GROUPS map in cypress/e2e/filters.cy.ts, which was verified
+// against slack_data/models/*.py + utilities/. RENDER FROM THIS CONFIG, not from
+// model field presence: treepro has an isa_warning model field but no ISA filter
+// group here, and kits have isa_certified but no isa_warning — matching the spec.
+//
+//   'pill'  — enum / boolean / discrete-int field → multi-select toggle buttons
+//   'range' — numeric field → a min + max input pair with a unit label
+//
+// `data-group` MUST equal the Python field name (width_min, breaking_strength,
+// isa_certified, …); the tests select groups by it.
+//
+// Webbing `stretch` is NOT here — it's a bespoke widget (StretchFilter) handled
+// separately, because it's a JSON curve of {kn, percent} pairs, not a scalar.
+
+import type { GearSlug } from '@/types'
+
+export type FilterType = 'pill' | 'range'
+
+// How a pill group's values are derived + displayed. Values themselves are
+// always pulled from the loaded dataset (no phantom options), but the kind
+// controls display: booleans render Yes/No, ints/enums render their raw value.
+export type PillKind = 'enum' | 'int' | 'bool'
+
+export interface FilterGroupMeta {
+  group: string        // == Python field name, and the data-group attribute
+  label: string        // human label shown in the sidebar (asserted by tests)
+  type: FilterType
+  unit?: string        // shown next to range inputs / int pills (mm, kN, g, …)
+  pillKind?: PillKind  // pills only; defaults to 'enum'
+  capitalize?: boolean // pills only; title-case the display labels (e.g. pair→Pair)
+}
+
+export const FILTER_GROUPS: Record<GearSlug, FilterGroupMeta[]> = {
+  webbings: [
+    { group: 'material',          label: 'Material Type',     type: 'pill', pillKind: 'enum' },
+    { group: 'width',             label: 'Width',             type: 'range', unit: 'mm' },
+    { group: 'classification',    label: 'Classification',    type: 'pill', pillKind: 'enum' },
+    { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    { group: 'isa_warning',       label: 'ISA Warning',       type: 'pill', pillKind: 'enum' },
+    { group: 'weight',            label: 'Weight',            type: 'range', unit: 'g/m' },
+    { group: 'breaking_strength', label: 'Breaking Strength', type: 'range', unit: 'kN' },
+    // + the Stretch widget (StretchFilter), appended in the sidebar for webbings
+  ],
+
+  weblocks: [
+    { group: 'material',          label: 'Material',          type: 'pill', pillKind: 'enum' },
+    { group: 'width_min',         label: 'Min Width',         type: 'range', unit: 'mm' },
+    { group: 'front_pin',         label: 'Front Pin',         type: 'pill', pillKind: 'enum' },
+    { group: 'attachment_point',  label: 'Attachment Point',  type: 'pill', pillKind: 'enum' },
+    { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    { group: 'isa_warning',       label: 'ISA Warning',       type: 'pill', pillKind: 'enum' },
+    { group: 'weight',            label: 'Weight',            type: 'range', unit: 'g' },
+    { group: 'breaking_strength', label: 'Breaking Strength', type: 'range', unit: 'kN' },
+  ],
+
+  leashrings: [
+    { group: 'material',          label: 'Material',          type: 'pill', pillKind: 'enum' },
+    { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    { group: 'isa_warning',       label: 'ISA Warning',       type: 'pill', pillKind: 'enum' },
+    { group: 'inner_diameter',    label: 'Inner Diameter',    type: 'range', unit: 'mm' },
+    { group: 'outer_diameter',    label: 'Outer Diameter',    type: 'range', unit: 'mm' },
+    { group: 'weight',            label: 'Weight',            type: 'range', unit: 'g' },
+    { group: 'breaking_strength', label: 'Breaking Strength', type: 'range', unit: 'kN' },
+  ],
+
+  grips: [
+    { group: 'material',                  label: 'Material',           type: 'pill', pillKind: 'enum' },
+    { group: 'width_min',                 label: 'Min Width',          type: 'pill', pillKind: 'int', unit: 'mm' },
+    { group: 'connection_type',           label: 'Connection Type',    type: 'pill', pillKind: 'enum' },
+    { group: 'isa_certified',             label: 'ISA Certified',      type: 'pill', pillKind: 'bool' },
+    { group: 'isa_warning',               label: 'ISA Warning',        type: 'pill', pillKind: 'enum' },
+    { group: 'weight',                    label: 'Weight',             type: 'range', unit: 'g' },
+    { group: 'wll',                       label: 'WLL',                type: 'range', unit: 'kN' },
+    { group: 'mbs',                       label: 'MBS',                type: 'range', unit: 'kN' },
+    { group: 'common_slipping_threshold', label: 'Slipping Threshold', type: 'range', unit: 'kN' },
+  ],
+
+  rollers: [
+    { group: 'material',          label: 'Frame Material',    type: 'pill', pillKind: 'enum' },
+    { group: 'roller_material',   label: 'Roller Material',   type: 'pill', pillKind: 'enum' },
+    { group: 'slider_type',       label: 'Slider Type',       type: 'pill', pillKind: 'enum' },
+    { group: 'lock_type',         label: 'Lock Type',         type: 'pill', pillKind: 'enum' },
+    { group: 'bearing_material',  label: 'Bearing Material',  type: 'pill', pillKind: 'enum' },
+    { group: 'isa_certified',     label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    { group: 'isa_warning',       label: 'ISA Warning',       type: 'pill', pillKind: 'enum' },
+    { group: 'weight',            label: 'Weight',            type: 'range', unit: 'g' },
+    { group: 'breaking_strength', label: 'Breaking Strength', type: 'range', unit: 'kN' },
+  ],
+
+  treepros: [
+    { group: 'has_sling_attachment', label: 'Sling Attachment', type: 'pill', pillKind: 'bool' },
+    { group: 'price_unit',           label: 'Sold As',          type: 'pill', pillKind: 'enum', capitalize: true },
+    { group: 'weight',               label: 'Weight',           type: 'range', unit: 'g' },
+    { group: 'width',                label: 'Width',            type: 'range', unit: 'cm' },
+    { group: 'length',               label: 'Length',           type: 'range', unit: 'cm' },
+    { group: 'thickness',            label: 'Thickness',        type: 'range', unit: 'mm' },
+  ],
+
+  starterkits: [
+    { group: 'tensioning_type',  label: 'Tensioning',        type: 'pill', pillKind: 'enum' },
+    { group: 'webbing_width',    label: 'Webbing Width',     type: 'pill', pillKind: 'int', unit: 'mm' },
+    { group: 'webbing_length',   label: 'Webbing Length',    type: 'pill', pillKind: 'int', unit: 'm' },
+    { group: 'includes_treepro', label: 'Includes Tree Pro', type: 'pill', pillKind: 'bool' },
+    { group: 'isa_certified',    label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    { group: 'weight',           label: 'Kit Weight',        type: 'range', unit: 'g' },
+  ],
+
+  tricklinekits: [
+    { group: 'tensioning_type',  label: 'Tensioning',        type: 'pill', pillKind: 'enum' },
+    { group: 'webbing_width',    label: 'Webbing Width',     type: 'pill', pillKind: 'int', unit: 'mm' },
+    { group: 'webbing_length',   label: 'Webbing Length',    type: 'pill', pillKind: 'int', unit: 'm' },
+    { group: 'includes_treepro', label: 'Includes Tree Pro', type: 'pill', pillKind: 'bool' },
+    { group: 'isa_certified',    label: 'ISA Certified',     type: 'pill', pillKind: 'bool' },
+    // Kit Weight is intentionally NOT filterable for trickline kits: only 2 of 9
+    // carry weight data, so a slider would be misleading.
+  ],
+
+  // Upcoming types have no data / no listing yet.
+  bungees: [],
+  leashringpro: [],
+}
+
+export function filterGroupsFor(slug: GearSlug): FilterGroupMeta[] {
+  return FILTER_GROUPS[slug] ?? []
+}

--- a/frontend/src/hooks/useUrlState.ts
+++ b/frontend/src/hooks/useUrlState.ts
@@ -10,7 +10,7 @@
 // The hook is generic: `q` and `sort` are fixed keys; pill/range accessors take
 // the field name, and the calling page supplies those from its filter config.
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 export type SortDirection = 'asc' | 'desc'
@@ -21,6 +21,19 @@ export interface SortSpec {
 
 export function useUrlState() {
   const [params, setParams] = useSearchParams()
+  // Bumped on clearAll so inputs holding local state can reset themselves without
+  // reacting to every async param echo (which would race in-progress typing).
+  const [resetNonce, setResetNonce] = useState(0)
+
+  // Mirror of the latest INTENDED params. react-router does not compose rapid
+  // functional setParams calls — each `prev` is the last committed location, so
+  // back-to-back writes (two slider thumbs, fast typing) clobber each other.
+  // Building each mutation from this ref instead composes correctly; the effect
+  // resyncs it after every commit (covers clear-all / back-forward).
+  const pendingRef = useRef(params)
+  useEffect(() => {
+    pendingRef.current = params
+  }, [params])
 
   const q = params.get('q') ?? ''
 
@@ -38,14 +51,10 @@ export function useUrlState() {
   // back button) and operate on a copy of the current params.
   const mutate = useCallback(
     (fn: (next: URLSearchParams) => void) => {
-      setParams(
-        prev => {
-          const next = new URLSearchParams(prev)
-          fn(next)
-          return next
-        },
-        { replace: true },
-      )
+      const next = new URLSearchParams(pendingRef.current)
+      fn(next)
+      pendingRef.current = next
+      setParams(next, { replace: true })
     },
     [setParams],
   )
@@ -113,14 +122,33 @@ export function useUrlState() {
     [mutate],
   )
 
-  // Clears search + all filters but stays on the current route.
-  const clearAll = useCallback(
-    () => setParams(new URLSearchParams(), { replace: true }),
-    [setParams],
+  // Sets both bounds of a range in a single write. react-router does not compose
+  // rapid functional setParams calls, so writing min and max separately lets one
+  // clobber the other while typing; writing both at once (from local state) is
+  // clobber-safe.
+  const setRange = useCallback(
+    (field: string, min: string, max: string) =>
+      mutate(next => {
+        const minKey = `${field}_min`
+        const maxKey = `${field}_max`
+        if (min !== '') next.set(minKey, min)
+        else next.delete(minKey)
+        if (max !== '') next.set(maxKey, max)
+        else next.delete(maxKey)
+      }),
+    [mutate],
   )
+
+  // Clears search + all filters but stays on the current route.
+  const clearAll = useCallback(() => {
+    pendingRef.current = new URLSearchParams()
+    setParams(new URLSearchParams(), { replace: true })
+    setResetNonce(n => n + 1)
+  }, [setParams])
 
   return {
     params,
+    resetNonce,
     q,
     setQ,
     sort,
@@ -130,6 +158,7 @@ export function useUrlState() {
     togglePill,
     getRange,
     setRangeBound,
+    setRange,
     clearAll,
   }
 }

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -5,15 +5,19 @@
 // hidden (display:none) so the view toggle just flips visibility. When there are
 // no results, an empty state with a clear-filters action replaces both.
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { getGearType } from '@/config/gearTypes'
 import { useGearList } from '@/hooks/useGearList'
 import { useUrlState } from '@/hooks/useUrlState'
 import { filterBySearch } from '@/utils/search'
 import { sortItems } from '@/utils/sort'
+import { filterGroupsFor } from '@/config/filterGroups'
+import { applyFilters, type RangeBounds } from '@/utils/filter'
+import { mostCommonKn, percentAtKn, topKnPoints } from '@/utils/stretch'
 import type { AnyItem } from '@/utils/format'
 import FilterSidebar from '@/components/gear/FilterSidebar'
+import StretchFilter from '@/components/gear/StretchFilter'
 import SortDropdown from '@/components/gear/SortDropdown'
 import GearGrid from '@/components/gear/GearGrid'
 import GearTable from '@/components/gear/GearTable'
@@ -55,13 +59,93 @@ export default function GearListingPage() {
   const meta = slug ? getGearType(slug) : undefined
   const available = !!meta?.available
   const { items, loading } = useGearList(meta?.slug ?? '', available)
-  const { q, setQ, sort, setSort, clearAll } = useUrlState()
+  const url = useUrlState()
+  const { q, setQ, sort, setSort } = url
   const [view, setView] = useState<View>('cards')
 
+  // Webbing stretch widget state (owned here so it also drives filtering, the
+  // contextual sort option, and the cards' data-stretch-percent). The default kN
+  // is pre-selected for DISPLAY but does not filter until a pill is engaged, so a
+  // fresh load still shows all webbings (keeps gear_listing/gear_cards green).
+  const isWebbing = meta?.slug === 'webbings'
+  const [stretchKn, setStretchKn] = useState<number | null>(null)
+  const [stretchTouched, setStretchTouched] = useState(false)
+  const [stretchMin, setStretchMin] = useState('')
+  const [stretchMax, setStretchMax] = useState('')
+  const defaultKn = useMemo(
+    () => (isWebbing ? mostCommonKn(items as unknown as { stretch?: unknown }[]) : null),
+    [isWebbing, items],
+  )
+  const displayKn = isWebbing ? (stretchTouched ? stretchKn : defaultKn) : null
+  const filterKn = isWebbing && stretchTouched ? stretchKn : null
+
+  // Reset the stretch widget only when clear-all actually bumps the nonce.
+  // Comparing the previous value (not a mounted flag) survives StrictMode's
+  // double-invoked mount effect, which would otherwise fire the reset on load
+  // and deselect the default kN pill.
+  const prevNonce = useRef(url.resetNonce)
+  useEffect(() => {
+    if (prevNonce.current === url.resetNonce) return
+    prevNonce.current = url.resetNonce
+    // clear-all: deselect the kN (no pill active) and clear the % range.
+    setStretchTouched(true)
+    setStretchKn(null)
+    setStretchMin('')
+    setStretchMax('')
+  }, [url.resetNonce])
+
+  const selectKn = (kn: number) => {
+    // Clicking the currently-engaged pill toggles the widget off; clicking any
+    // other pill — including the non-filtering default hint — engages it. (The
+    // default is only engaged after the first explicit click, so it never filters
+    // on load.)
+    if (stretchTouched && stretchKn === kn) {
+      setStretchKn(null)
+    } else {
+      setStretchTouched(true)
+      setStretchKn(kn)
+    }
+  }
+
+  const { activePills, activeRanges } = useMemo(() => {
+    const activePills: Record<string, string[]> = {}
+    const activeRanges: Record<string, RangeBounds> = {}
+    if (meta) {
+      for (const g of filterGroupsFor(meta.slug)) {
+        if (g.type === 'pill') {
+          const values = url.getPillValues(g.group)
+          if (values.length) activePills[g.group] = values
+        } else {
+          const r = url.getRange(g.group)
+          if (r.min != null || r.max != null) activeRanges[g.group] = r
+        }
+      }
+    }
+    return { activePills, activeRanges }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url.params, meta])
+
   const visible = useMemo(() => {
-    const filtered = filterBySearch(items, q)
-    return sortItems(filtered as unknown as AnyItem[], sort)
-  }, [items, q, sort])
+    const searched = filterBySearch(items, q) as unknown as AnyItem[]
+    let filtered = applyFilters(searched, activePills, activeRanges)
+    if (displayKn != null) {
+      // Attach stretch % at the reference kN for the cards + stretch sort.
+      filtered = filtered.map(it => ({ ...it, stretch_percent: percentAtKn(it.stretch, displayKn) }))
+      // Exclusion only once a pill is engaged (filterKn), not on the default.
+      if (filterKn != null) {
+        const lo = stretchMin === '' ? null : Number(stretchMin)
+        const hi = stretchMax === '' ? null : Number(stretchMax)
+        filtered = filtered.filter(it => {
+          const p = it.stretch_percent as number | null
+          if (p == null) return false
+          if (lo != null && p < lo) return false
+          if (hi != null && p > hi) return false
+          return true
+        })
+      }
+    }
+    return sortItems(filtered, sort)
+  }, [items, q, activePills, activeRanges, displayKn, filterKn, stretchMin, stretchMax, sort])
 
   if (!meta) return <NotFoundPage />
 
@@ -81,7 +165,19 @@ export default function GearListingPage() {
       <h1 className="mb-6 text-2xl font-bold text-gray-900">{meta.label}</h1>
 
       <div className="flex gap-8">
-        <FilterSidebar meta={meta} />
+        <FilterSidebar meta={meta} items={items as unknown as AnyItem[]} url={url}>
+          {isWebbing && (
+            <StretchFilter
+              items={items as unknown as AnyItem[]}
+              displayKn={displayKn}
+              onSelectKn={selectKn}
+              min={stretchMin}
+              max={stretchMax}
+              onMinChange={setStretchMin}
+              onMaxChange={setStretchMax}
+            />
+          )}
+        </FilterSidebar>
 
         <div className="min-w-0 flex-1">
           {/* Toolbar */}
@@ -119,7 +215,18 @@ export default function GearListingPage() {
                   Chart
                 </button>
               </div>
-              <SortDropdown slug={meta.slug} sort={sort} onChange={setSort} />
+              <SortDropdown
+                slug={meta.slug}
+                sort={sort}
+                onChange={setSort}
+                stretchKns={
+                  isWebbing
+                    ? // Ranked by count (most common first) so the dropdown's default
+                      // stretch-sort kN matches the filter's default reference kN.
+                      topKnPoints(items as unknown as { stretch?: unknown }[]).map(p => p.kn)
+                    : []
+                }
+              />
             </div>
           </div>
 
@@ -127,7 +234,7 @@ export default function GearListingPage() {
           {loading ? (
             <LoadingSkeleton />
           ) : visible.length === 0 ? (
-            <EmptyState onClear={clearAll} />
+            <EmptyState onClear={url.clearAll} />
           ) : (
             <>
               <div className={view === 'chart' ? 'hidden' : ''}>

--- a/frontend/src/utils/filter.ts
+++ b/frontend/src/utils/filter.ts
@@ -1,0 +1,105 @@
+// Client-side filtering for the listing, plus derivation of pill options from
+// the loaded dataset (so every pill matches >=1 item — no phantom values).
+//
+// Semantics (see filters.cy.ts):
+//   - Pills: OR within a group, AND across groups. An item with a null value in
+//     an actively-filtered field is excluded.
+//   - Ranges: [min, max] inclusive. When any bound is set, items with a
+//     null/blank value are excluded (null-last philosophy).
+
+import type { AnyItem } from '@/utils/format'
+import type { PillKind } from '@/config/filterGroups'
+
+export interface PillOption {
+  value: string // raw value used in the URL + for matching (String(item[field]))
+  label: string // display text (booleans render Yes/No)
+}
+
+export interface RangeBounds {
+  min?: number
+  max?: number
+}
+
+// Distinct, present-in-data options for a pill group. `kind` only affects
+// ordering + display, never which values appear.
+// Title-case a raw value for display (pair → Pair, "tree pro" → "Tree Pro").
+// Only the label changes; the option `value` stays the raw string used for
+// URL encoding + matching.
+function titleCase(s: string): string {
+  return s.replace(/\b\w/g, c => c.toUpperCase())
+}
+
+export function derivePillOptions(
+  items: AnyItem[],
+  field: string,
+  kind: PillKind = 'enum',
+  capitalize = false,
+): PillOption[] {
+  const seen = new Set<string>()
+  for (const item of items) {
+    const v = item[field]
+    if (v == null || v === '') continue
+    // Multi-valued fields (e.g. roller `material` is list[MetalMaterial]) get one
+    // pill per distinct element, not one pill for the whole array — otherwise the
+    // comma in "Aluminum,Steel" collides with the comma-delimited URL encoding.
+    if (Array.isArray(v)) {
+      for (const el of v) if (el != null && el !== '') seen.add(String(el))
+    } else {
+      seen.add(String(v))
+    }
+  }
+  const values = [...seen]
+  if (kind === 'int') {
+    values.sort((a, b) => Number(a) - Number(b))
+  } else if (kind === 'bool') {
+    values.sort((a, b) => (a === 'true' ? 0 : 1) - (b === 'true' ? 0 : 1)) // Yes before No
+  } else {
+    values.sort((a, b) => a.localeCompare(b))
+  }
+  return values.map(value => ({
+    value,
+    label:
+      kind === 'bool'
+        ? value === 'true' ? 'Yes' : 'No'
+        : capitalize ? titleCase(value) : value,
+  }))
+}
+
+function passesPills(item: AnyItem, activePills: Record<string, string[]>): boolean {
+  for (const field in activePills) {
+    const values = activePills[field]
+    if (!values || values.length === 0) continue
+    const iv = item[field]
+    if (iv == null || iv === '') return false
+    // Array field: match if the item's list shares any selected value.
+    if (Array.isArray(iv)) {
+      if (!iv.some(el => values.includes(String(el)))) return false
+    } else if (!values.includes(String(iv))) {
+      return false
+    }
+  }
+  return true
+}
+
+function passesRanges(item: AnyItem, activeRanges: Record<string, RangeBounds>): boolean {
+  for (const field in activeRanges) {
+    const { min, max } = activeRanges[field]
+    if (min == null && max == null) continue
+    const raw = item[field]
+    const n = raw == null || raw === '' ? null : Number(raw)
+    if (n == null || Number.isNaN(n)) return false // bound set, no value → excluded
+    if (min != null && n < min) return false
+    if (max != null && n > max) return false
+  }
+  return true
+}
+
+export function applyFilters(
+  items: AnyItem[],
+  activePills: Record<string, string[]>,
+  activeRanges: Record<string, RangeBounds>,
+): AnyItem[] {
+  return items.filter(
+    item => passesPills(item, activePills) && passesRanges(item, activeRanges),
+  )
+}

--- a/frontend/src/utils/sort.ts
+++ b/frontend/src/utils/sort.ts
@@ -1,22 +1,55 @@
 // Client-side sorting for the listing.
 //
-// A null/absent sort = the backend's own order (the gear_cards tests assert the
-// first card matches the API's first item, so the default must NOT reorder).
-// Name sorts use locale compare; numeric sorts put nulls/blanks last in both
-// directions.
+// Name is the default AND the universal tie-breaker:
+//   - A null/absent sort sorts alphabetically by name (ascending). A fresh load
+//     of the listing is therefore alphabetical.
+//   - Numeric sorts (e.g. mbs) break ties on equal values — and order among
+//     null/blank values — alphabetically by name, always ascending regardless of
+//     the numeric direction.
+// Numeric sorts put nulls/blanks last in both directions.
 
 import type { SortSpec } from '@/hooks/useUrlState'
 import type { AnyItem } from '@/utils/format'
+import { percentAtKn } from '@/utils/stretch'
+
+// Secondary/tie-break comparator: alphabetical by name, always ascending.
+function byName(a: AnyItem, b: AnyItem): number {
+  return String(a.name).localeCompare(String(b.name))
+}
+
+// Compare two nullable numbers with the shared listing rules: nulls last in both
+// directions, ties (incl. both-null) fall back to name ascending.
+function compareNumeric(
+  a: AnyItem,
+  b: AnyItem,
+  an: number | null,
+  bn: number | null,
+  factor: number,
+): number {
+  if (an === null && bn === null) return byName(a, b)
+  if (an === null) return 1
+  if (bn === null) return -1
+  if (an === bn) return byName(a, b)
+  return factor * (an - bn)
+}
 
 export function sortItems(items: AnyItem[], sort: SortSpec | null): AnyItem[] {
-  if (!sort) return items // default: backend order
+  // Default (no sort) and explicit Name sort are both alphabetical by name.
+  if (!sort || sort.field === 'name') {
+    const factor = sort && sort.direction === 'desc' ? -1 : 1
+    return [...items].sort((a, b) => factor * byName(a, b))
+  }
 
   const { field, direction } = sort
   const factor = direction === 'asc' ? 1 : -1
 
-  if (field === 'name') {
-    return [...items].sort(
-      (a, b) => factor * String(a.name).localeCompare(String(b.name)),
+  // Webbing stretch sort. The field carries the reference kN (`stretch@10`), so
+  // sorting by stretch is self-contained — it reads the % at that kN straight off
+  // each item's curve, independent of whichever kN the filter widget is showing.
+  if (field.startsWith('stretch@')) {
+    const kn = Number(field.slice('stretch@'.length))
+    return [...items].sort((a, b) =>
+      compareNumeric(a, b, percentAtKn(a.stretch, kn), percentAtKn(b.stretch, kn), factor),
     )
   }
 
@@ -25,9 +58,6 @@ export function sortItems(items: AnyItem[], sort: SortSpec | null): AnyItem[] {
     const bv = b[field]
     const an = av == null || av === '' ? null : Number(av)
     const bn = bv == null || bv === '' ? null : Number(bv)
-    if (an === null && bn === null) return 0
-    if (an === null) return 1 // nulls last, regardless of direction
-    if (bn === null) return -1
-    return factor * (an - bn)
+    return compareNumeric(a, b, an, bn, factor)
   })
 }

--- a/frontend/src/utils/stretch.ts
+++ b/frontend/src/utils/stretch.ts
@@ -1,0 +1,72 @@
+// Helpers for the webbing `stretch` field — a JSON string encoding a curve of
+// {kn, percent} points, e.g. '[{"kn":0,"percent":0},{"kn":10,"percent":5.9}]'.
+// See models/webbing.py and the Stretch widget in filters.cy.ts.
+
+export interface StretchPoint {
+  kn: number
+  percent: number
+}
+
+export function parseStretch(json: unknown): StretchPoint[] {
+  if (typeof json !== 'string' || json === '') return []
+  try {
+    const pts = JSON.parse(json)
+    if (!Array.isArray(pts)) return []
+    return pts.filter(
+      (p): p is StretchPoint =>
+        p && typeof p === 'object' && typeof p.kn === 'number' && typeof p.percent === 'number',
+    )
+  } catch {
+    return []
+  }
+}
+
+// Distinct kN values present in one item's curve.
+export function knValues(json: unknown): number[] {
+  return parseStretch(json).map(p => p.kn)
+}
+
+// The stretch % at an exact kN, or null if the curve has no point there.
+export function percentAtKn(json: unknown, kn: number): number | null {
+  const match = parseStretch(json).find(p => p.kn === kn)
+  return match ? match.percent : null
+}
+
+// Across a set of webbings: the sorted union of every kN present (for the pills)
+// and the kN appearing in the most curves (the default reference).
+export function knFrequency(items: { stretch?: unknown }[]): Map<number, number> {
+  const freq = new Map<number, number>()
+  for (const item of items) {
+    for (const kn of new Set(knValues(item.stretch))) {
+      freq.set(kn, (freq.get(kn) ?? 0) + 1)
+    }
+  }
+  return freq
+}
+
+export function allKnValues(items: { stretch?: unknown }[]): number[] {
+  return [...knFrequency(items).keys()].sort((a, b) => a - b)
+}
+
+// The reference kN points offered in the UI (filter pills + stretch sort).
+// Rules: 0 kN is dropped (every curve reads 0% there — a useless data point);
+// only integer kN values qualify; and we keep the TOP `n` by how many webbings
+// carry a data point at that kN. Ties in count break toward the smaller kN so
+// the set is deterministic. Each entry carries that webbing `count`.
+export function topKnPoints(
+  items: { stretch?: unknown }[],
+  n = 5,
+): { kn: number; count: number }[] {
+  return [...knFrequency(items).entries()]
+    .filter(([kn]) => kn !== 0 && Number.isInteger(kn))
+    .sort((a, b) => b[1] - a[1] || a[0] - b[0])
+    .slice(0, n)
+    .map(([kn, count]) => ({ kn, count }))
+}
+
+// The default reference kN: the most common among the top points (or null if
+// there are none). Kept in sync with topKnPoints so the default is always a
+// point the UI actually renders.
+export function mostCommonKn(items: { stretch?: unknown }[]): number | null {
+  return topKnPoints(items, 1)[0]?.kn ?? null
+}


### PR DESCRIPTION
## Phase 4 + 4.5: the left filter sidebar and sorting for the gear listing.

The main feature of this stack — a filterable, sortable sidebar for all 8 gear types, built TDD against the real backend via the Cypress suite.

> **Stack:** based on `feat/frontend-gear-images` (#C), which is based on `feat/frontend-groundwork` (#B). GitHub retargets this to `main` as the lower PRs merge. **Merge order: #B → #C → this.**

### Phase 4 — the filter sidebar
- **Left sidebar (~280px)** rendered from a per-type config (`config/filterGroups.ts`) — collapsible groups, small-caps labels with colored dot accents, pill/chip toggles (not checkboxes).
- **Pill filters** — OR within a group, AND across groups. Options are **derived from the loaded data** (`utils/filter.ts` `derivePillOptions`) so every pill matches ≥1 item (no phantom values). Array-valued fields (roller `material`) expand to one pill per element and match by membership.
- **Dual-thumb range sliders** (`RangeSlider.tsx`) — replaced free-text min/max inputs, which raced Cypress's fast typing against the async URL echo. Integer `step` for whole-number fields, `0.5` when the data is fractional.
- **Webbing stretch widget** (`StretchFilter.tsx`) — `stretch` is a JSON curve `[{kn, percent}]`, not a scalar. Single-select kN pills + a % range at the selected kN. The default pre-selected pill is a **non-filtering hint** — it doesn't exclude anything until the user engages a pill (otherwise the default kN, present in only ~167/209 webbings, would silently shrink the listing).
- **URL state** (`useUrlState.ts`) — pill/range selections live in the query string; `clearAll` + a `resetNonce` (StrictMode-safe reset).

### Phase 4.5 — sort + filter UX refinement
1. **Name is the default sort + universal tie-breaker** — fresh load is alphabetical; numeric sorts break ties (and order among nulls) by name asc.
2. **Editable slider bounds** — the value labels under each track are click-to-edit number inputs (Enter/blur to commit, Esc to cancel, out-of-range clamped).
3. **Stretch kN pills = top-5 by webbing count**, shown with their count (`10 kN (167)`).
4. **Stretch sort decoupled into a secondary dropdown** — always available for webbings (encoded `stretch@<kn>`), reading % straight off each item's curve independent of the filter widget.
5. **Boolean pill groups hide when nothing qualifies** — e.g. ISA Certified is dropped for rollers / starter kits / trickline kits (0 certified). Enum groups still render.
6. **TreePro "Sold As" labels title-cased** (value stays raw for URL/matching).
7. **2-option groups are single-select** (radio-with-clear); **3+ get All / None** shortcuts.
8. **Trickline Kit weight not filterable** (only 2 of 9 have weight data).

### Card integration (`GearCard.tsx`)
The listing page augments each webbing with `stretch_percent` at the active kN; the card emits it as `data-stretch-percent` (only when present) for the sort-order tests. (The image-rendering half of this file lands in the images PR below it in the stack — this PR adds only the stretch attribute.)

### Docs
`DESIGN.md` and `PLAN.md` updated for the filter-control spec, per-type filter lists, the stretch widget, and the sort options.

### Test status (per the Phase 4 handoff — re-run before merge)
- `filters.cy.ts` — **328/328** green (incl. all 4.5 changes)
- `gear_cards.cy.ts` — **119/119** green
- `gear_listing.cy.ts` — 168/168, `navigation.cy.ts` — 13/13
- `search_sort.cy.ts` — the **Phase 5 red-first spec** (~52 failing, never green). These are pre-existing Phase-5 gaps (normalized/brand search, sort-persistence, and some flaky `.then` assertions), **not regressions** — the 4.5 work reduced the count. See the handoff for the exact breakdown.

Run: `cd frontend && npm run build && npm run lint` (tsc + vite + oxlint), then the Cypress specs with both servers up.
