### PR TITLE
feat(frontend): Phase 7 — compare bar + side-by-side compare view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -69,7 +69,7 @@ npx cypress run --spec cypress/e2e/<spec>.cy.ts
 | 4 | Filters | `filters.cy.ts` | ✅ 308/308 (gear_listing/gear_cards still green) |
 | 5 | Search & sort refinement | `search_sort.cy.ts` | ✅ 306/306 |
 | 6 | Detail page | `gear_detail.cy.ts` + `isa_certification`(detail) | ✅ 201/201 + isa 69/69 |
-| 7 | Compare | `compare.cy.ts` | ⬜ |
+| 7 | Compare | `compare.cy.ts` | ✅ 20/20 |
 | 8 | Manufacturers | `manufacturers.cy.ts` | ⬜ |
 | 9 | URL-state sweep | `url_state.cy.ts` | ⬜ |
 | 10 | Full green + cleanup | (whole suite) | ⬜ |
@@ -300,8 +300,42 @@ silently. Likely a corrupt/partial binary download; `npx cypress install --force
 fix but re-downloads ~200MB, so it wasn't run unprompted. What **was** verified: `tsc -b` and a full
 `vite build` pass clean. **The suite must be run before this phase is closed.**
 
-### ⬜ Phase 7 — Compare
-Sticky compare bar (chips, count, max 4, same-type, CTA disabled < 2, clears on gear-type switch) + side-by-side `ComparePage` (columns per item, spec rows, back link, deep-linkable `?ids=`).
+### ✅ Phase 7 — Compare — DONE
+**Result:** `compare.cy.ts` **20/20**. `gear_listing` 192/192 confirmed no-regression; `gear_cards`
+198/1-fail/3-skip — the one failure (`Card classification bubble — Webbings` before-all) reproduces
+**identically on the clean pre-Phase-7 tree**, so it's a pre-existing spec-infra bug, not a
+regression: that describe's `cy.request` hits `http://localhost:8000//webbing/` (double slash from a
+leading-slash `apiPath`) → 404. `npm run build` + `npm run lint` clean.
+
+Built:
+- **`components/gear/CompareBar.tsx`** — sticky bottom bar; renders only at ≥1 selection.
+  `compare-bar-count`, a `compare-bar-item` chip (with `compare-bar-item-name` + `compare-bar-remove`
+  ×) per item, `compare-bar-clear`, and `compare-bar-view-btn` **disabled below 2 items**.
+- **`GearCard`** — the `btn-compare` stub is now live: `data-active`, `disabled` (when the 4-cap is
+  full and this card isn't selected), toggles selection. Teal fill when active.
+- **`GearGrid`** — threads `selectedIds` / `compareFull` / `onToggleCompare` to cards.
+- **`GearListingPage`** — owns the selection: an ordered `selectedIds` list, capped at 4, **cleared
+  on slug change** (the gear-type-switch signal, since the component stays mounted across `:slug`).
+  The CTA navigates to `/${slug}/compare?ids=…`.
+- **`ComparePage`** — the real side-by-side table. Reads `?ids=` (URL is the only source of truth →
+  deep-linkable), fetches the type via `useGearList`, picks ids in URL order. `compare-col[data-id]`
+  per item, `compare-row[data-field]` per SPEC_ROWS entry with a `compare-field-label`, and a
+  `compare-back-link` → `/${slug}`.
+
+Decisions worth remembering:
+- **Selection state is local to the listing page, NOT in the URL.** It only has to survive within one
+  listing page and hand off to the compare page. The handoff is the `?ids=` query param, which is
+  also exactly what makes `ComparePage` deep-linkable on its own — no shared context/store needed,
+  and no lag-a-render URL-read trap (handoff trap #1) because nothing reads selection back from the
+  URL on the listing side.
+- **Clears on gear-type switch via a `prevSlug` ref effect**, mirroring the existing search-box
+  resync — a slug change is the switch signal.
+- **The compare table renders every SPEC_ROWS row** (blank cells show "—") rather than dropping
+  all-empty rows — a comparison reads more honestly with the full field set aligned.
+- Rows **reuse `SPEC_ROWS`** from Phase 6 (that's why Phase 6 came first); labels/formatting can't
+  drift from the detail page.
+- The Detailed-view `btn-compare` in `GearDetailBody` is still a dead stub — that view isn't in
+  `compare.cy.ts`'s scope and isn't mounted by default. Left as-is to keep Phase 7 tight.
 
 ### ⬜ Phase 8 — Manufacturers
 Replace `ManufacturersPage` stub: brand cards, View Gear, per-type gear counts (`data-count-*`), search, graceful country/continent filter, list toggle. `BrandPublic` only serializes `webbings` reliably — read the model. Layout: **DESIGN.md → "Manufacturers Page".**

--- a/frontend/src/components/gear/CompareBar.tsx
+++ b/frontend/src/components/gear/CompareBar.tsx
@@ -1,0 +1,77 @@
+// Sticky bottom bar summarising the current compare selection. Rendered only
+// when ≥1 item is selected (the parent guards on that — the bar's very existence
+// is part of the contract: compare.cy.ts asserts it does NOT exist at 0).
+//
+// Selection state (and the 4-item cap) lives in GearListingPage; this component
+// is presentational. The "Compare" CTA is disabled below 2 items — you can't
+// compare a single thing.
+
+import type { AnyItem } from '@/utils/format'
+
+export default function CompareBar({
+  items,
+  onRemove,
+  onClear,
+  onView,
+}: {
+  items: AnyItem[]
+  onRemove: (id: number) => void
+  onClear: () => void
+  onView: () => void
+}) {
+  if (items.length === 0) return null
+
+  return (
+    <div
+      data-cy="compare-bar"
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-gray-200 bg-white shadow-[0_-2px_10px_rgba(0,0,0,0.06)]"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-3 px-4 py-3">
+        <span data-cy="compare-bar-count" className="text-sm font-medium text-gray-700">
+          {items.length} {items.length === 1 ? 'item' : 'items'}
+        </span>
+
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          {items.map(item => (
+            <span
+              key={String(item.id)}
+              data-cy="compare-bar-item"
+              className="flex items-center gap-1.5 rounded-full border border-gray-300 bg-gray-50 py-1 pl-3 pr-1.5 text-xs text-gray-700"
+            >
+              <span data-cy="compare-bar-item-name" className="max-w-[10rem] truncate">
+                {String(item.name)}
+              </span>
+              <button
+                data-cy="compare-bar-remove"
+                type="button"
+                aria-label={`Remove ${String(item.name)}`}
+                onClick={() => onRemove(Number(item.id))}
+                className="flex h-4 w-4 items-center justify-center rounded-full text-gray-500 hover:bg-gray-200 hover:text-gray-800"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+
+        <button
+          data-cy="compare-bar-clear"
+          type="button"
+          onClick={onClear}
+          className="text-sm text-gray-500 hover:text-gray-800 hover:underline"
+        >
+          Clear all
+        </button>
+        <button
+          data-cy="compare-bar-view-btn"
+          type="button"
+          disabled={items.length < 2}
+          onClick={onView}
+          className="rounded-full bg-teal-primary px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Compare
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/gear/GearCard.tsx
+++ b/frontend/src/components/gear/GearCard.tsx
@@ -6,8 +6,8 @@
 //   Save / Alert / Compare buttons.
 //
 // The card root carries data-{field} attributes (numeric fields) so sort/filter
-// tests can read raw values. Save/Alert/Compare are non-functional stubs here
-// (Compare is wired in Phase 7).
+// tests can read raw values. Save/Alert are non-functional stubs; Compare toggles
+// the item into the sticky compare bar (state owned by GearListingPage).
 
 import { Link } from 'react-router-dom'
 import type { GearTypeMeta } from '@/config/gearTypes'
@@ -19,9 +19,26 @@ import ClassificationBubble from './ClassificationBubble'
 import IsaApprovedBadge from './IsaApprovedBadge'
 
 const pillBtn =
-  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors'
+  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600'
+// Selected compare button: teal fill, matching the active filter-pill treatment.
+const pillBtnActive =
+  'rounded-full border border-teal-primary bg-teal-primary px-3 py-1 text-xs font-medium text-white transition-colors'
 
-export default function GearCard({ item, meta }: { item: AnyItem; meta: GearTypeMeta }) {
+export default function GearCard({
+  item,
+  meta,
+  compareSelected = false,
+  compareDisabled = false,
+  onToggleCompare,
+}: {
+  item: AnyItem
+  meta: GearTypeMeta
+  compareSelected?: boolean
+  // The 4-item cap is full and this card isn't one of the selected — its button
+  // is disabled so a 5th can't be added.
+  compareDisabled?: boolean
+  onToggleCompare?: (id: number) => void
+}) {
   const { slug, hasISA } = meta
   const price = formatPrice(item.price, item.currency)
   const specs = INLINE_SPECS[slug] ?? []
@@ -95,7 +112,16 @@ export default function GearCard({ item, meta }: { item: AnyItem; meta: GearType
         <div className="flex gap-2 pt-2">
           <button data-cy="btn-save" type="button" className={pillBtn}>Save</button>
           <button data-cy="btn-alert" type="button" className={pillBtn}>Alert</button>
-          <button data-cy="btn-compare" type="button" className={pillBtn}>Compare</button>
+          <button
+            data-cy="btn-compare"
+            type="button"
+            data-active={compareSelected ? 'true' : 'false'}
+            disabled={compareDisabled}
+            onClick={() => onToggleCompare?.(Number(item.id))}
+            className={compareSelected ? pillBtnActive : pillBtn}
+          >
+            Compare
+          </button>
         </div>
       </div>
     </article>

--- a/frontend/src/components/gear/GearGrid.tsx
+++ b/frontend/src/components/gear/GearGrid.tsx
@@ -9,19 +9,35 @@ export default function GearGrid({
   items,
   meta,
   className = '',
+  selectedIds = [],
+  compareFull = false,
+  onToggleCompare,
 }: {
   items: AnyItem[]
   meta: GearTypeMeta
   className?: string
+  selectedIds?: number[]
+  compareFull?: boolean
+  onToggleCompare?: (id: number) => void
 }) {
   return (
     <div
       data-cy="gear-grid"
       className={`grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 ${className}`}
     >
-      {items.map(item => (
-        <GearCard key={String(item.id)} item={item} meta={meta} />
-      ))}
+      {items.map(item => {
+        const selected = selectedIds.includes(Number(item.id))
+        return (
+          <GearCard
+            key={String(item.id)}
+            item={item}
+            meta={meta}
+            compareSelected={selected}
+            compareDisabled={compareFull && !selected}
+            onToggleCompare={onToggleCompare}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -1,18 +1,117 @@
-// Compare view (stub — built out in Phase 7).
+// Side-by-side compare view. The selection is carried entirely in the URL
+// (?ids=1,2,3) so this page is deep-linkable and independent of the listing
+// page's in-memory state: it fetches the gear type and picks out the requested
+// ids, preserving their URL order for the columns.
+//
+// Rows reuse SPEC_ROWS (Phase 6) so the compared fields, labels and formatting
+// match the detail page exactly. Every configured row renders — a blank cell
+// (·"—") reads more honestly across a comparison than a dropped row would.
 
-import { useParams } from 'react-router-dom'
+import { useMemo } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { getGearType } from '@/config/gearTypes'
+import { useGearList } from '@/hooks/useGearList'
+import { SPEC_ROWS } from '@/config/specRows'
+import type { AnyItem } from '@/utils/format'
 import NotFoundPage from './NotFoundPage'
 
 export default function ComparePage() {
   const { slug } = useParams()
   const meta = slug ? getGearType(slug) : undefined
+  const [params] = useSearchParams()
+  const { items, loading } = useGearList(meta?.slug ?? '', !!meta?.available)
+
+  const ids = useMemo(() => {
+    const raw = params.get('ids')
+    if (!raw) return []
+    return raw
+      .split(',')
+      .map(s => Number(s))
+      .filter(n => Number.isFinite(n))
+  }, [params])
+
+  // The requested items, in URL order, dropping any id that isn't in the dataset.
+  const columns = useMemo(() => {
+    const byId = new Map((items as unknown as AnyItem[]).map(it => [Number(it.id), it]))
+    return ids.map(id => byId.get(id)).filter((it): it is AnyItem => it != null)
+  }, [items, ids])
+
   if (!meta) return <NotFoundPage />
+
+  const rows = SPEC_ROWS[meta.slug] ?? []
 
   return (
     <div data-cy="compare-page">
-      <h1 className="text-xl font-bold text-gray-900">Compare {meta.label}</h1>
-      <p className="mt-2 text-gray-400 text-sm">Comparison coming soon.</p>
+      <Link
+        data-cy="compare-back-link"
+        to={`/${meta.slug}`}
+        className="inline-flex items-center gap-1 text-sm text-teal-primary hover:underline"
+      >
+        ← {meta.label}
+      </Link>
+
+      <h1 className="mb-6 mt-3 text-2xl font-bold text-gray-900">Compare {meta.label}</h1>
+
+      {loading ? (
+        <p className="text-gray-500">Loading…</p>
+      ) : columns.length === 0 ? (
+        <p className="text-gray-500">Nothing to compare — pick items from the listing.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table data-cy="compare-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                {/* Empty top-left corner above the field-label column. */}
+                <th className="sticky left-0 z-10 bg-white" />
+                {columns.map(item => (
+                  <th
+                    key={String(item.id)}
+                    data-cy="compare-col"
+                    data-id={String(item.id)}
+                    className="min-w-[10rem] border-b border-gray-200 px-4 py-3 text-left align-bottom"
+                  >
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+                      {String(item.brand_name)}
+                    </div>
+                    <Link
+                      data-cy="compare-col-name"
+                      to={`/${meta.slug}/${item.id}`}
+                      className="font-bold text-gray-900 hover:text-teal-primary"
+                    >
+                      {String(item.name)}
+                    </Link>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => (
+                <tr key={row.field} data-cy="compare-row" data-field={row.field}>
+                  <th
+                    data-cy="compare-field-label"
+                    scope="row"
+                    className="sticky left-0 z-10 whitespace-nowrap border-b border-gray-100 bg-white px-4 py-2.5 text-left font-normal text-gray-500"
+                  >
+                    {row.label}
+                    {row.unit ? ` (${row.unit})` : ''}
+                  </th>
+                  {columns.map(item => {
+                    const text = row.value(item)
+                    return (
+                      <td
+                        key={String(item.id)}
+                        className="border-b border-gray-100 px-4 py-2.5 align-top text-gray-900"
+                      >
+                        {text === '' ? <span className="text-gray-300">—</span> : text}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -7,7 +7,7 @@
 // replaces both.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { getGearType } from '@/config/gearTypes'
 import { useGearList } from '@/hooks/useGearList'
 import { useUrlState } from '@/hooks/useUrlState'
@@ -22,9 +22,12 @@ import StretchFilter from '@/components/gear/StretchFilter'
 import SortDropdown from '@/components/gear/SortDropdown'
 import GearGrid from '@/components/gear/GearGrid'
 import GearDetailedList from '@/components/gear/GearDetailedList'
+import CompareBar from '@/components/gear/CompareBar'
 import NotFoundPage from './NotFoundPage'
 
 type View = 'cards' | 'detailed'
+
+const COMPARE_MAX = 4
 
 function LoadingSkeleton() {
   return (
@@ -63,6 +66,32 @@ export default function GearListingPage() {
   const url = useUrlState()
   const { q, setQ, sort, setSort } = url
   const [view, setView] = useState<View>('cards')
+  const navigate = useNavigate()
+
+  // Compare selection: an ordered list of item ids (order = the columns/chips
+  // order downstream). Lives in local state, capped at COMPARE_MAX. It clears on
+  // a gear-type switch — the component stays mounted across the same :slug route,
+  // so a slug change is the signal (see the effect below). The compare page is
+  // reached by handing these ids off through the ?ids= query param, which is what
+  // makes that page deep-linkable independent of this state.
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const prevCompareSlug = useRef(slug)
+  useEffect(() => {
+    if (prevCompareSlug.current === slug) return
+    prevCompareSlug.current = slug
+    setSelectedIds([])
+  }, [slug])
+
+  const toggleCompare = (id: number) =>
+    setSelectedIds(prev =>
+      prev.includes(id)
+        ? prev.filter(x => x !== id)
+        : prev.length >= COMPARE_MAX
+          ? prev
+          : [...prev, id],
+    )
+  const removeCompare = (id: number) => setSelectedIds(prev => prev.filter(x => x !== id))
+  const clearCompare = () => setSelectedIds([])
 
   // Search box holds LOCAL state and drives filtering directly; the URL is kept
   // in sync for bookmarking but is NOT the input's value. Binding value={q}
@@ -175,6 +204,16 @@ export default function GearListingPage() {
     return sortItems(filtered, sort)
   }, [contextItems, selectedKn, stretchMin, stretchMax, sort])
 
+  // The selected items, in selection order, resolved from the FULL list (not
+  // `visible`) so a chip survives the item being filtered out of the grid.
+  const selectedItems = useMemo(() => {
+    const byId = new Map((items as unknown as AnyItem[]).map(it => [Number(it.id), it]))
+    return selectedIds.map(id => byId.get(id)).filter((it): it is AnyItem => it != null)
+  }, [items, selectedIds])
+
+  const viewComparison = () =>
+    navigate(`/${meta?.slug}/compare?ids=${selectedIds.join(',')}`)
+
   if (!meta) return <NotFoundPage />
 
   if (!available) {
@@ -276,13 +315,26 @@ export default function GearListingPage() {
                   behind display:none would both cost real work and double the
                   element counts gear_cards.cy.ts reads off the grid. */}
               <div className={view === 'detailed' ? 'hidden' : ''}>
-                <GearGrid items={visible} meta={meta} />
+                <GearGrid
+                  items={visible}
+                  meta={meta}
+                  selectedIds={selectedIds}
+                  compareFull={selectedIds.length >= COMPARE_MAX}
+                  onToggleCompare={toggleCompare}
+                />
               </div>
               {view === 'detailed' && <GearDetailedList items={visible} meta={meta} />}
             </>
           )}
         </div>
       </div>
+
+      <CompareBar
+        items={selectedItems}
+        onRemove={removeCompare}
+        onClear={clearCompare}
+        onView={viewComparison}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Wires the previously-dead `btn-compare` stub into a real compare flow. This is Phase 7 of the frontend roadmap in [PLAN.md](PLAN.md).

## What's in it

- **`CompareBar`** — sticky bottom bar, rendered only at ≥1 selection. Shows the count, a removable chip per item, "Clear all", and a CTA that stays disabled below 2 items.
- **`GearCard`** — `btn-compare` now toggles selection, carries `data-active`, and goes disabled once the 4-item cap is full and the card isn't itself selected.
- **`GearGrid`** — threads `selectedIds` / `compareFull` / `onToggleCompare` through.
- **`GearListingPage`** — owns an ordered, 4-capped `selectedIds` list, cleared on slug change (the gear-type-switch signal, since the page stays mounted across `:slug`). The CTA navigates to `/:slug/compare?ids=…`.
- **`ComparePage`** — real side-by-side table. `?ids=` is the only source of truth, so the view is deep-linkable on its own; columns follow URL order and rows reuse Phase 6's `SPEC_ROWS` so labels and formatting can't drift from the detail page.

## Design note

Selection lives in local state rather than the URL on purpose. It only has to survive within one listing page and hand off via `?ids=`, which keeps it clear of the lag-a-render URL-read trap that bit Phases 4–5.

## Tests

`compare.cy.ts` 20/20, re-verified green on a fresh reseed as part of the current full-suite run. `gear_listing` 192/192 no-regression at the time of authoring. Build and lint clean.

One caveat carried from the original commit message: `gear_cards` showed 198 passing / 1 failing / 3 skipped, but that failure reproduces identically on the clean pre-Phase-7 tree (a spec-infra double-slash 404 in the classification-bubble `before-all`), so it is pre-existing rather than a regression. On the current tree `gear_cards` runs 212/212.

## Stacking

This is the first of two PRs split out of a single local branch. Phase 8 (manufacturers directory + brand detail) builds directly on this and will be opened against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)