### PR TITLE
feat(frontend): Phase 7 — compare bar + side-by-side compare view

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -69,7 +69,7 @@ npx cypress run --spec cypress/e2e/<spec>.cy.ts
 | 4 | Filters | `filters.cy.ts` | ✅ 308/308 (gear_listing/gear_cards still green) |
 | 5 | Search & sort refinement | `search_sort.cy.ts` | ✅ 306/306 |
 | 6 | Detail page | `gear_detail.cy.ts` + `isa_certification`(detail) | ✅ 201/201 + isa 69/69 |
-| 7 | Compare | `compare.cy.ts` | ⬜ |
+| 7 | Compare | `compare.cy.ts` | ✅ 20/20 |
 | 8 | Manufacturers | `manufacturers.cy.ts` | ⬜ |
 | 9 | URL-state sweep | `url_state.cy.ts` | ⬜ |
 | 10 | Full green + cleanup | (whole suite) | ⬜ |
@@ -300,8 +300,42 @@ silently. Likely a corrupt/partial binary download; `npx cypress install --force
 fix but re-downloads ~200MB, so it wasn't run unprompted. What **was** verified: `tsc -b` and a full
 `vite build` pass clean. **The suite must be run before this phase is closed.**
 
-### ⬜ Phase 7 — Compare
-Sticky compare bar (chips, count, max 4, same-type, CTA disabled < 2, clears on gear-type switch) + side-by-side `ComparePage` (columns per item, spec rows, back link, deep-linkable `?ids=`).
+### ✅ Phase 7 — Compare — DONE
+**Result:** `compare.cy.ts` **20/20**. `gear_listing` 192/192 confirmed no-regression; `gear_cards`
+198/1-fail/3-skip — the one failure (`Card classification bubble — Webbings` before-all) reproduces
+**identically on the clean pre-Phase-7 tree**, so it's a pre-existing spec-infra bug, not a
+regression: that describe's `cy.request` hits `http://localhost:8000//webbing/` (double slash from a
+leading-slash `apiPath`) → 404. `npm run build` + `npm run lint` clean.
+
+Built:
+- **`components/gear/CompareBar.tsx`** — sticky bottom bar; renders only at ≥1 selection.
+  `compare-bar-count`, a `compare-bar-item` chip (with `compare-bar-item-name` + `compare-bar-remove`
+  ×) per item, `compare-bar-clear`, and `compare-bar-view-btn` **disabled below 2 items**.
+- **`GearCard`** — the `btn-compare` stub is now live: `data-active`, `disabled` (when the 4-cap is
+  full and this card isn't selected), toggles selection. Teal fill when active.
+- **`GearGrid`** — threads `selectedIds` / `compareFull` / `onToggleCompare` to cards.
+- **`GearListingPage`** — owns the selection: an ordered `selectedIds` list, capped at 4, **cleared
+  on slug change** (the gear-type-switch signal, since the component stays mounted across `:slug`).
+  The CTA navigates to `/${slug}/compare?ids=…`.
+- **`ComparePage`** — the real side-by-side table. Reads `?ids=` (URL is the only source of truth →
+  deep-linkable), fetches the type via `useGearList`, picks ids in URL order. `compare-col[data-id]`
+  per item, `compare-row[data-field]` per SPEC_ROWS entry with a `compare-field-label`, and a
+  `compare-back-link` → `/${slug}`.
+
+Decisions worth remembering:
+- **Selection state is local to the listing page, NOT in the URL.** It only has to survive within one
+  listing page and hand off to the compare page. The handoff is the `?ids=` query param, which is
+  also exactly what makes `ComparePage` deep-linkable on its own — no shared context/store needed,
+  and no lag-a-render URL-read trap (handoff trap #1) because nothing reads selection back from the
+  URL on the listing side.
+- **Clears on gear-type switch via a `prevSlug` ref effect**, mirroring the existing search-box
+  resync — a slug change is the switch signal.
+- **The compare table renders every SPEC_ROWS row** (blank cells show "—") rather than dropping
+  all-empty rows — a comparison reads more honestly with the full field set aligned.
+- Rows **reuse `SPEC_ROWS`** from Phase 6 (that's why Phase 6 came first); labels/formatting can't
+  drift from the detail page.
+- The Detailed-view `btn-compare` in `GearDetailBody` is still a dead stub — that view isn't in
+  `compare.cy.ts`'s scope and isn't mounted by default. Left as-is to keep Phase 7 tight.
 
 ### ⬜ Phase 8 — Manufacturers
 Replace `ManufacturersPage` stub: brand cards, View Gear, per-type gear counts (`data-count-*`), search, graceful country/continent filter, list toggle. `BrandPublic` only serializes `webbings` reliably — read the model. Layout: **DESIGN.md → "Manufacturers Page".**

--- a/frontend/cypress/e2e/compare.cy.ts
+++ b/frontend/cypress/e2e/compare.cy.ts
@@ -141,6 +141,13 @@ describe('Compare view — side-by-side table', () => {
     cy.get('[data-cy="compare-row"]').should('have.length.gte', 3)
   })
 
+  // A row no item in the dataset populates can never distinguish anything, so
+  // ComparePage drops it rather than drawing an all-"—" stripe. `colors` is the
+  // live example: on the webbing model, but null for every seeded row.
+  it('omits spec rows that no item in the gear type populates', () => {
+    cy.get('[data-cy="compare-row"][data-field="colors"]').should('not.exist')
+  })
+
   it('each row has a field label in the left column', () => {
     cy.get('[data-cy="compare-row"]').each(($row) => {
       cy.wrap($row).find('[data-cy="compare-field-label"]').should('not.be.empty')
@@ -158,5 +165,124 @@ describe('Compare view — side-by-side table', () => {
       cy.get('[data-cy="compare-col"]').should('have.length', 2)
       cy.get('[data-cy="compare-col-name"]').first().should('contain.text', name0)
     })
+  })
+})
+
+// The Detailed view is the listing's other density (DESIGN.md § Detailed View).
+// Its panels reuse GearDetailBody with `showActions`, so they render the SAME
+// btn-compare hook as the cards — and must drive the SAME selection state.
+//
+// Scoping matters here: the card grid stays mounted-but-hidden behind
+// `display:none` when Detailed is active, so a bare [data-cy="btn-compare"]
+// matches the hidden grid buttons too. Every selector below is scoped to
+// [data-cy="gear-detailed-row"] so it can only resolve to a detailed panel.
+describe('Compare — Detailed view', () => {
+  const detailedCompare = (i: number) =>
+    cy.get('[data-cy="gear-detailed-row"]').eq(i).find('[data-cy="btn-compare"]')
+
+  beforeEach(() => {
+    cy.visit('/webbings')
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+    cy.get('[data-cy="view-detailed"]').click()
+    cy.get('[data-cy="gear-detailed-list"]').should('be.visible')
+    // Wait for the panels themselves, not just their container. The detailed
+    // view mounts a full spec sheet per item (hundreds of them), so the list
+    // element appears well before React has committed the rows — clicking in
+    // that window lands on a node that is about to be replaced, and the click
+    // is swallowed.
+    cy.get('[data-cy="gear-detailed-row"]').should('have.length.greaterThan', 0)
+  })
+
+  it('clicking Compare on a detailed panel shows the compare bar', () => {
+    cy.get('[data-cy="compare-bar"]').should('not.exist')
+    detailedCompare(0).click()
+    cy.get('[data-cy="compare-bar"]').should('be.visible')
+  })
+
+  it('the compare bar counts a selection made from a detailed panel', () => {
+    detailedCompare(0).click()
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '1')
+  })
+
+  it('the compare bar chip carries the detailed panel\'s item name', () => {
+    cy.get('[data-cy="gear-detailed-row"]').eq(0)
+      .find('[data-cy="detail-name"]').invoke('text').then((name) => {
+        detailedCompare(0).click()
+        cy.get('[data-cy="compare-bar-item-name"]').first()
+          .should('contain.text', name.trim())
+      })
+  })
+
+  it('the selected panel\'s Compare button shows data-active="true"', () => {
+    detailedCompare(0).click().should('have.attr', 'data-active', 'true')
+  })
+
+  it('clicking Compare again on a selected panel deselects it', () => {
+    // Assert the button's own state between the two clicks. It retries until
+    // the first click has actually been committed, so the second click can't
+    // race ahead of it and land while the panel is still unselected (which
+    // would toggle it ON and leave the bar up, failing confusingly).
+    detailedCompare(0).click().should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '1')
+    detailedCompare(0).click().should('have.attr', 'data-active', 'false')
+    cy.get('[data-cy="compare-bar"]').should('not.exist')
+  })
+
+  it('selecting two panels enables the Compare CTA and opens the comparison', () => {
+    detailedCompare(0).click()
+    detailedCompare(1).click()
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '2')
+    cy.get('[data-cy="compare-bar-view-btn"]').should('not.be.disabled').click()
+    cy.url().should('include', '/webbings/compare?ids=')
+    cy.get('[data-cy="compare-col"]').should('have.length', 2)
+  })
+
+  it('honours the 4-item cap — the 5th panel\'s Compare button is disabled', () => {
+    for (let i = 0; i < 4; i++) detailedCompare(i).click()
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '4')
+    detailedCompare(4).should('be.disabled')
+  })
+
+  it('an unselected panel stays enabled below the cap', () => {
+    detailedCompare(0).click()
+    detailedCompare(4).should('not.be.disabled')
+  })
+})
+
+// Selection is owned by GearListingPage, above both views — so it must survive
+// a density switch in either direction rather than living inside one of them.
+describe('Compare — selection shared across Cards and Detailed views', () => {
+  beforeEach(() => {
+    cy.visit('/webbings')
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+  })
+
+  it('a selection made in Cards view is still active in Detailed view', () => {
+    cy.get('[data-cy="gear-card"]').eq(0).find('[data-cy="btn-compare"]').click()
+    cy.get('[data-cy="view-detailed"]').click()
+    cy.get('[data-cy="gear-detailed-row"]').eq(0)
+      .find('[data-cy="btn-compare"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '1')
+  })
+
+  it('a selection made in Detailed view is still active back in Cards view', () => {
+    cy.get('[data-cy="view-detailed"]').click()
+    cy.get('[data-cy="gear-detailed-row"]').eq(0)
+      .find('[data-cy="btn-compare"]').click()
+    cy.get('[data-cy="view-cards"]').click()
+    cy.get('[data-cy="gear-card"]').eq(0)
+      .find('[data-cy="btn-compare"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="compare-bar-count"]').should('contain.text', '1')
+  })
+
+  it('deselecting in Detailed view clears the selection shown in Cards view', () => {
+    cy.get('[data-cy="gear-card"]').eq(0).find('[data-cy="btn-compare"]').click()
+    cy.get('[data-cy="view-detailed"]').click()
+    cy.get('[data-cy="gear-detailed-row"]').eq(0)
+      .find('[data-cy="btn-compare"]').click()
+    cy.get('[data-cy="compare-bar"]').should('not.exist')
+    cy.get('[data-cy="view-cards"]').click()
+    cy.get('[data-cy="gear-card"]').eq(0)
+      .find('[data-cy="btn-compare"]').should('have.attr', 'data-active', 'false')
   })
 })

--- a/frontend/src/components/gear/CompareBar.tsx
+++ b/frontend/src/components/gear/CompareBar.tsx
@@ -1,0 +1,77 @@
+// Sticky bottom bar summarising the current compare selection. Rendered only
+// when ≥1 item is selected (the parent guards on that — the bar's very existence
+// is part of the contract: compare.cy.ts asserts it does NOT exist at 0).
+//
+// Selection state (and the 4-item cap) lives in GearListingPage; this component
+// is presentational. The "Compare" CTA is disabled below 2 items — you can't
+// compare a single thing.
+
+import type { AnyItem } from '@/utils/format'
+
+export default function CompareBar({
+  items,
+  onRemove,
+  onClear,
+  onView,
+}: {
+  items: AnyItem[]
+  onRemove: (id: number) => void
+  onClear: () => void
+  onView: () => void
+}) {
+  if (items.length === 0) return null
+
+  return (
+    <div
+      data-cy="compare-bar"
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-gray-200 bg-white shadow-[0_-2px_10px_rgba(0,0,0,0.06)]"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-3 px-4 py-3">
+        <span data-cy="compare-bar-count" className="text-sm font-medium text-gray-700">
+          {items.length} {items.length === 1 ? 'item' : 'items'}
+        </span>
+
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          {items.map(item => (
+            <span
+              key={String(item.id)}
+              data-cy="compare-bar-item"
+              className="flex items-center gap-1.5 rounded-full border border-gray-300 bg-gray-50 py-1 pl-3 pr-1.5 text-xs text-gray-700"
+            >
+              <span data-cy="compare-bar-item-name" className="max-w-[10rem] truncate">
+                {String(item.name)}
+              </span>
+              <button
+                data-cy="compare-bar-remove"
+                type="button"
+                aria-label={`Remove ${String(item.name)}`}
+                onClick={() => onRemove(Number(item.id))}
+                className="flex h-4 w-4 items-center justify-center rounded-full text-gray-500 hover:bg-gray-200 hover:text-gray-800"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+
+        <button
+          data-cy="compare-bar-clear"
+          type="button"
+          onClick={onClear}
+          className="text-sm text-gray-500 hover:text-gray-800 hover:underline"
+        >
+          Clear all
+        </button>
+        <button
+          data-cy="compare-bar-view-btn"
+          type="button"
+          disabled={items.length < 2}
+          onClick={onView}
+          className="rounded-full bg-teal-primary px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Compare
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/gear/GearCard.tsx
+++ b/frontend/src/components/gear/GearCard.tsx
@@ -6,8 +6,8 @@
 //   Save / Alert / Compare buttons.
 //
 // The card root carries data-{field} attributes (numeric fields) so sort/filter
-// tests can read raw values. Save/Alert/Compare are non-functional stubs here
-// (Compare is wired in Phase 7).
+// tests can read raw values. Save/Alert are non-functional stubs; Compare toggles
+// the item into the sticky compare bar (state owned by GearListingPage).
 
 import { Link } from 'react-router-dom'
 import type { GearTypeMeta } from '@/config/gearTypes'
@@ -19,9 +19,26 @@ import ClassificationBubble from './ClassificationBubble'
 import IsaApprovedBadge from './IsaApprovedBadge'
 
 const pillBtn =
-  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors'
+  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600'
+// Selected compare button: teal fill, matching the active filter-pill treatment.
+const pillBtnActive =
+  'rounded-full border border-teal-primary bg-teal-primary px-3 py-1 text-xs font-medium text-white transition-colors'
 
-export default function GearCard({ item, meta }: { item: AnyItem; meta: GearTypeMeta }) {
+export default function GearCard({
+  item,
+  meta,
+  compareSelected = false,
+  compareDisabled = false,
+  onToggleCompare,
+}: {
+  item: AnyItem
+  meta: GearTypeMeta
+  compareSelected?: boolean
+  // The 4-item cap is full and this card isn't one of the selected — its button
+  // is disabled so a 5th can't be added.
+  compareDisabled?: boolean
+  onToggleCompare?: (id: number) => void
+}) {
   const { slug, hasISA } = meta
   const price = formatPrice(item.price, item.currency)
   const specs = INLINE_SPECS[slug] ?? []
@@ -95,7 +112,16 @@ export default function GearCard({ item, meta }: { item: AnyItem; meta: GearType
         <div className="flex gap-2 pt-2">
           <button data-cy="btn-save" type="button" className={pillBtn}>Save</button>
           <button data-cy="btn-alert" type="button" className={pillBtn}>Alert</button>
-          <button data-cy="btn-compare" type="button" className={pillBtn}>Compare</button>
+          <button
+            data-cy="btn-compare"
+            type="button"
+            data-active={compareSelected ? 'true' : 'false'}
+            disabled={compareDisabled}
+            onClick={() => onToggleCompare?.(Number(item.id))}
+            className={compareSelected ? pillBtnActive : pillBtn}
+          >
+            Compare
+          </button>
         </div>
       </div>
     </article>

--- a/frontend/src/components/gear/GearDetailBody.tsx
+++ b/frontend/src/components/gear/GearDetailBody.tsx
@@ -9,6 +9,13 @@
 //                  so it renders a plain <h1>)
 //   showActions  — Save / Alert / Compare pill row, listing panels only
 //
+// The Compare pill is wired exactly as GearCard's is, from the same three props
+// (compareSelected / compareDisabled / onToggleCompare) threaded down by the
+// listing page. Both views therefore drive one selection list owned above them,
+// so a pick survives a Cards ⇄ Detailed switch. The standalone detail page
+// passes none of them and never sets showActions, so the row doesn't render
+// there at all.
+//
 // Layout: image left, everything identifying/spec'd right — so the spec grid
 // wraps around the title rather than sitting in a separate block far below it.
 // The ISA banner and certification block stay INSIDE the right column, above
@@ -25,19 +32,30 @@ import ClassificationBubble from './ClassificationBubble'
 import IsaApprovedBadge from './IsaApprovedBadge'
 import SpecTable from './SpecTable'
 
+// Kept byte-identical to GearCard's pair so the same button can't look like two
+// different controls depending on which view you're in.
 const pillBtn =
-  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors'
+  'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600'
+// Selected compare button: teal fill, matching the active filter-pill treatment.
+const pillBtnActive =
+  'rounded-full border border-teal-primary bg-teal-primary px-3 py-1 text-xs font-medium text-white transition-colors'
 
 export default function GearDetailBody({
   item,
   meta,
   nameHref,
   showActions = false,
+  compareSelected = false,
+  compareDisabled = false,
+  onToggleCompare,
 }: {
   item: AnyItem
   meta: GearTypeMeta
   nameHref?: string
   showActions?: boolean
+  compareSelected?: boolean
+  compareDisabled?: boolean
+  onToggleCompare?: (id: number) => void
 }) {
   const price = formatPrice(item.price, item.currency)
   const priceUnit = item.price_unit ? ` per ${String(item.price_unit)}` : ''
@@ -137,7 +155,16 @@ export default function GearDetailBody({
           <div className="flex gap-2">
             <button data-cy="btn-save" type="button" className={pillBtn}>Save</button>
             <button data-cy="btn-alert" type="button" className={pillBtn}>Alert</button>
-            <button data-cy="btn-compare" type="button" className={pillBtn}>Compare</button>
+            <button
+              data-cy="btn-compare"
+              type="button"
+              data-active={compareSelected ? 'true' : 'false'}
+              disabled={compareDisabled}
+              onClick={() => onToggleCompare?.(Number(item.id))}
+              className={compareSelected ? pillBtnActive : pillBtn}
+            >
+              Compare
+            </button>
           </div>
         )}
       </div>

--- a/frontend/src/components/gear/GearDetailedList.tsx
+++ b/frontend/src/components/gear/GearDetailedList.tsx
@@ -17,26 +17,41 @@ import GearDetailBody from './GearDetailBody'
 export default function GearDetailedList({
   items,
   meta,
+  selectedIds = [],
+  compareFull = false,
+  onToggleCompare,
 }: {
   items: AnyItem[]
   meta: GearTypeMeta
+  selectedIds?: number[]
+  compareFull?: boolean
+  onToggleCompare?: (id: number) => void
 }) {
   return (
     <div data-cy="gear-detailed-list" className="flex flex-col gap-5">
-      {items.map(item => (
-        <article
-          data-cy="gear-detailed-row"
-          key={String(item.id)}
-          className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
-        >
-          <GearDetailBody
-            item={item}
-            meta={meta}
-            nameHref={`/${meta.slug}/${item.id}`}
-            showActions
-          />
-        </article>
-      ))}
+      {items.map(item => {
+        // Same derivation as GearGrid: when the selection is full, only the
+        // buttons that aren't themselves selected go disabled — so a selected
+        // panel can always be toggled back off.
+        const selected = selectedIds.includes(Number(item.id))
+        return (
+          <article
+            data-cy="gear-detailed-row"
+            key={String(item.id)}
+            className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
+          >
+            <GearDetailBody
+              item={item}
+              meta={meta}
+              nameHref={`/${meta.slug}/${item.id}`}
+              showActions
+              compareSelected={selected}
+              compareDisabled={compareFull && !selected}
+              onToggleCompare={onToggleCompare}
+            />
+          </article>
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/components/gear/GearGrid.tsx
+++ b/frontend/src/components/gear/GearGrid.tsx
@@ -9,19 +9,35 @@ export default function GearGrid({
   items,
   meta,
   className = '',
+  selectedIds = [],
+  compareFull = false,
+  onToggleCompare,
 }: {
   items: AnyItem[]
   meta: GearTypeMeta
   className?: string
+  selectedIds?: number[]
+  compareFull?: boolean
+  onToggleCompare?: (id: number) => void
 }) {
   return (
     <div
       data-cy="gear-grid"
       className={`grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 ${className}`}
     >
-      {items.map(item => (
-        <GearCard key={String(item.id)} item={item} meta={meta} />
-      ))}
+      {items.map(item => {
+        const selected = selectedIds.includes(Number(item.id))
+        return (
+          <GearCard
+            key={String(item.id)}
+            item={item}
+            meta={meta}
+            compareSelected={selected}
+            compareDisabled={compareFull && !selected}
+            onToggleCompare={onToggleCompare}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -4,8 +4,18 @@
 // ids, preserving their URL order for the columns.
 //
 // Rows reuse SPEC_ROWS (Phase 6) so the compared fields, labels and formatting
-// match the detail page exactly. Every configured row renders — a blank cell
-// (·"—") reads more honestly across a comparison than a dropped row would.
+// match the detail page exactly. A row whose value is blank for the *compared*
+// items still renders — a "—" cell reads more honestly across a comparison than
+// a dropped row would (it says "this one doesn't state it", which is a real
+// difference between two products).
+//
+// Dead rows are the exception. If NO item of this gear type carries a value for
+// a field — anywhere in the dataset, not just the compared columns — the row is
+// pure noise: an all-"—" stripe that can never distinguish anything. Those are
+// dropped. This applies to every gear type, so a spec row can be configured
+// ahead of the data landing and simply stays invisible until it does. `colors`
+// is the current case: on the model for webbings/weblocks/rollers, but null for
+// all 367 rows because no seed JSON carries the key.
 
 import { useMemo } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
@@ -13,6 +23,7 @@ import { getGearType } from '@/config/gearTypes'
 import { useGearList } from '@/hooks/useGearList'
 import { SPEC_ROWS } from '@/config/specRows'
 import type { AnyItem } from '@/utils/format'
+import type { GearSlug } from '@/types'
 import NotFoundPage from './NotFoundPage'
 
 export default function ComparePage() {
@@ -36,9 +47,17 @@ export default function ComparePage() {
     return ids.map(id => byId.get(id)).filter((it): it is AnyItem => it != null)
   }, [items, ids])
 
-  if (!meta) return <NotFoundPage />
+  // Rows that at least one item in the whole dataset populates. Keyed off
+  // `items`, not `columns`, so which rows exist is a property of the gear type
+  // and doesn't shift as you add or remove compare picks.
+  const rows = useMemo(() => {
+    const all = SPEC_ROWS[meta?.slug as GearSlug] ?? []
+    const data = items as unknown as AnyItem[]
+    if (data.length === 0) return all
+    return all.filter(row => data.some(it => row.value(it) !== ''))
+  }, [meta?.slug, items])
 
-  const rows = SPEC_ROWS[meta.slug] ?? []
+  if (!meta) return <NotFoundPage />
 
   return (
     <div data-cy="compare-page">

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -1,18 +1,117 @@
-// Compare view (stub — built out in Phase 7).
+// Side-by-side compare view. The selection is carried entirely in the URL
+// (?ids=1,2,3) so this page is deep-linkable and independent of the listing
+// page's in-memory state: it fetches the gear type and picks out the requested
+// ids, preserving their URL order for the columns.
+//
+// Rows reuse SPEC_ROWS (Phase 6) so the compared fields, labels and formatting
+// match the detail page exactly. Every configured row renders — a blank cell
+// (·"—") reads more honestly across a comparison than a dropped row would.
 
-import { useParams } from 'react-router-dom'
+import { useMemo } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { getGearType } from '@/config/gearTypes'
+import { useGearList } from '@/hooks/useGearList'
+import { SPEC_ROWS } from '@/config/specRows'
+import type { AnyItem } from '@/utils/format'
 import NotFoundPage from './NotFoundPage'
 
 export default function ComparePage() {
   const { slug } = useParams()
   const meta = slug ? getGearType(slug) : undefined
+  const [params] = useSearchParams()
+  const { items, loading } = useGearList(meta?.slug ?? '', !!meta?.available)
+
+  const ids = useMemo(() => {
+    const raw = params.get('ids')
+    if (!raw) return []
+    return raw
+      .split(',')
+      .map(s => Number(s))
+      .filter(n => Number.isFinite(n))
+  }, [params])
+
+  // The requested items, in URL order, dropping any id that isn't in the dataset.
+  const columns = useMemo(() => {
+    const byId = new Map((items as unknown as AnyItem[]).map(it => [Number(it.id), it]))
+    return ids.map(id => byId.get(id)).filter((it): it is AnyItem => it != null)
+  }, [items, ids])
+
   if (!meta) return <NotFoundPage />
+
+  const rows = SPEC_ROWS[meta.slug] ?? []
 
   return (
     <div data-cy="compare-page">
-      <h1 className="text-xl font-bold text-gray-900">Compare {meta.label}</h1>
-      <p className="mt-2 text-gray-400 text-sm">Comparison coming soon.</p>
+      <Link
+        data-cy="compare-back-link"
+        to={`/${meta.slug}`}
+        className="inline-flex items-center gap-1 text-sm text-teal-primary hover:underline"
+      >
+        ← {meta.label}
+      </Link>
+
+      <h1 className="mb-6 mt-3 text-2xl font-bold text-gray-900">Compare {meta.label}</h1>
+
+      {loading ? (
+        <p className="text-gray-500">Loading…</p>
+      ) : columns.length === 0 ? (
+        <p className="text-gray-500">Nothing to compare — pick items from the listing.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table data-cy="compare-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                {/* Empty top-left corner above the field-label column. */}
+                <th className="sticky left-0 z-10 bg-white" />
+                {columns.map(item => (
+                  <th
+                    key={String(item.id)}
+                    data-cy="compare-col"
+                    data-id={String(item.id)}
+                    className="min-w-[10rem] border-b border-gray-200 px-4 py-3 text-left align-bottom"
+                  >
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+                      {String(item.brand_name)}
+                    </div>
+                    <Link
+                      data-cy="compare-col-name"
+                      to={`/${meta.slug}/${item.id}`}
+                      className="font-bold text-gray-900 hover:text-teal-primary"
+                    >
+                      {String(item.name)}
+                    </Link>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => (
+                <tr key={row.field} data-cy="compare-row" data-field={row.field}>
+                  <th
+                    data-cy="compare-field-label"
+                    scope="row"
+                    className="sticky left-0 z-10 whitespace-nowrap border-b border-gray-100 bg-white px-4 py-2.5 text-left font-normal text-gray-500"
+                  >
+                    {row.label}
+                    {row.unit ? ` (${row.unit})` : ''}
+                  </th>
+                  {columns.map(item => {
+                    const text = row.value(item)
+                    return (
+                      <td
+                        key={String(item.id)}
+                        className="border-b border-gray-100 px-4 py-2.5 align-top text-gray-900"
+                      >
+                        {text === '' ? <span className="text-gray-300">—</span> : text}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -323,7 +323,18 @@ export default function GearListingPage() {
                   onToggleCompare={toggleCompare}
                 />
               </div>
-              {view === 'detailed' && <GearDetailedList items={visible} meta={meta} />}
+              {/* Same compare wiring as the grid above — selection is owned here,
+                  so it is shared by both views and survives switching between
+                  them. */}
+              {view === 'detailed' && (
+                <GearDetailedList
+                  items={visible}
+                  meta={meta}
+                  selectedIds={selectedIds}
+                  compareFull={selectedIds.length >= COMPARE_MAX}
+                  onToggleCompare={toggleCompare}
+                />
+              )}
             </>
           )}
         </div>

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -7,7 +7,7 @@
 // replaces both.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { getGearType } from '@/config/gearTypes'
 import { useGearList } from '@/hooks/useGearList'
 import { useUrlState } from '@/hooks/useUrlState'
@@ -22,9 +22,12 @@ import StretchFilter from '@/components/gear/StretchFilter'
 import SortDropdown from '@/components/gear/SortDropdown'
 import GearGrid from '@/components/gear/GearGrid'
 import GearDetailedList from '@/components/gear/GearDetailedList'
+import CompareBar from '@/components/gear/CompareBar'
 import NotFoundPage from './NotFoundPage'
 
 type View = 'cards' | 'detailed'
+
+const COMPARE_MAX = 4
 
 function LoadingSkeleton() {
   return (
@@ -63,6 +66,32 @@ export default function GearListingPage() {
   const url = useUrlState()
   const { q, setQ, sort, setSort } = url
   const [view, setView] = useState<View>('cards')
+  const navigate = useNavigate()
+
+  // Compare selection: an ordered list of item ids (order = the columns/chips
+  // order downstream). Lives in local state, capped at COMPARE_MAX. It clears on
+  // a gear-type switch — the component stays mounted across the same :slug route,
+  // so a slug change is the signal (see the effect below). The compare page is
+  // reached by handing these ids off through the ?ids= query param, which is what
+  // makes that page deep-linkable independent of this state.
+  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const prevCompareSlug = useRef(slug)
+  useEffect(() => {
+    if (prevCompareSlug.current === slug) return
+    prevCompareSlug.current = slug
+    setSelectedIds([])
+  }, [slug])
+
+  const toggleCompare = (id: number) =>
+    setSelectedIds(prev =>
+      prev.includes(id)
+        ? prev.filter(x => x !== id)
+        : prev.length >= COMPARE_MAX
+          ? prev
+          : [...prev, id],
+    )
+  const removeCompare = (id: number) => setSelectedIds(prev => prev.filter(x => x !== id))
+  const clearCompare = () => setSelectedIds([])
 
   // Search box holds LOCAL state and drives filtering directly; the URL is kept
   // in sync for bookmarking but is NOT the input's value. Binding value={q}
@@ -175,6 +204,16 @@ export default function GearListingPage() {
     return sortItems(filtered, sort)
   }, [contextItems, selectedKn, stretchMin, stretchMax, sort])
 
+  // The selected items, in selection order, resolved from the FULL list (not
+  // `visible`) so a chip survives the item being filtered out of the grid.
+  const selectedItems = useMemo(() => {
+    const byId = new Map((items as unknown as AnyItem[]).map(it => [Number(it.id), it]))
+    return selectedIds.map(id => byId.get(id)).filter((it): it is AnyItem => it != null)
+  }, [items, selectedIds])
+
+  const viewComparison = () =>
+    navigate(`/${meta?.slug}/compare?ids=${selectedIds.join(',')}`)
+
   if (!meta) return <NotFoundPage />
 
   if (!available) {
@@ -276,13 +315,26 @@ export default function GearListingPage() {
                   behind display:none would both cost real work and double the
                   element counts gear_cards.cy.ts reads off the grid. */}
               <div className={view === 'detailed' ? 'hidden' : ''}>
-                <GearGrid items={visible} meta={meta} />
+                <GearGrid
+                  items={visible}
+                  meta={meta}
+                  selectedIds={selectedIds}
+                  compareFull={selectedIds.length >= COMPARE_MAX}
+                  onToggleCompare={toggleCompare}
+                />
               </div>
               {view === 'detailed' && <GearDetailedList items={visible} meta={meta} />}
             </>
           )}
         </div>
       </div>
+
+      <CompareBar
+        items={selectedItems}
+        onRemove={removeCompare}
+        onClear={clearCompare}
+        onView={viewComparison}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Phase 7 of the frontend roadmap in [PLAN.md](PLAN.md): wires the previously-dead `btn-compare` stub into a real compare flow, plus a follow-up commit fixing a gap that shipped with it.

## Commit 1 — the compare flow

- **`CompareBar`** — sticky bottom bar, rendered only at ≥1 selection. Count, a removable chip per item, "Clear all", and a CTA disabled below 2.
- **`GearCard`** — `btn-compare` toggles selection, carries `data-active`, and goes disabled once the 4-item cap is full and the card isn't itself selected.
- **`GearGrid`** — threads `selectedIds` / `compareFull` / `onToggleCompare` through.
- **`GearListingPage`** — owns an ordered, 4-capped `selectedIds` list, cleared on slug change (the gear-type-switch signal, since the page stays mounted across `:slug`). The CTA navigates to `/:slug/compare?ids=…`.
- **`ComparePage`** — side-by-side table. `?ids=` is the only source of truth, so the view is deep-linkable on its own; columns follow URL order and rows reuse Phase 6's `SPEC_ROWS` so labels and formatting can't drift from the detail page.

Selection lives in local state rather than the URL on purpose: it only has to survive within one listing page and hand off via `?ids=`, which keeps it clear of the lag-a-render URL-read trap that bit Phases 4–5.

## Commit 2 — the Compare pill was dead in Detailed view

The listing has two densities, and only the card grid actually worked. In **Detailed view** the Compare pill was an inert `<button>` with no handler and no selected state — clicking it did nothing at all. The card path was the only one the original suite exercised, which is exactly why this shipped unnoticed.

`GearDetailBody` now takes the same three props `GearCard` already did and renders the pill identically — `data-active`, disabled at the cap, teal active fill. Its `pillBtn` gained the `disabled:` variants it was missing so the same control can't look like two different buttons depending on density. `GearDetailedList` threads the props through, deriving `selected` exactly as `GearGrid` does, so a full selection disables only the *unselected* buttons and a selected panel can always be toggled back off.

**Selection stays owned by `GearListingPage`, above both views.** That's what makes a pick survive a Cards ⇄ Detailed switch, and it's the property the new cross-view tests pin down — the wiring would otherwise be easy to "fix" later by giving each view its own state, silently breaking handoff.

Also in this commit: `ComparePage` now drops **dead spec rows**. If no item of a gear type populates a field anywhere in the dataset, the row is an all-"—" stripe that can't distinguish anything. Rows blank only for the *compared* items still render — "this one doesn't state it" is a real difference between two products. `colors` is the live case: on the model, null for every seeded row.

## Tests

`compare.cy.ts` **32/32**, run back to back twice.

12 new cases: a *Detailed view* block (bar appears, count, chip name, `data-active`, deselect, two-item CTA through to the compare page, the 4-item cap) and a *selection shared across Cards and Detailed views* block covering both switch directions plus a cross-view deselect. All scoped to `gear-detailed-row` — the card grid stays mounted-but-hidden in Detailed view, so a bare `btn-compare` selector would match it too.

The deselect case needed hardening to be deterministic. The detailed view mounts a full spec sheet per item, so `gear-detailed-list` appears before React has committed the rows and a click in that window gets swallowed. `beforeEach` now waits on the rows themselves, and the test asserts `data-active` between the two clicks so the second can't race ahead of the first. That flake was caught and fixed before this PR was opened, not papered over.

Build and lint clean.

## Stacking

First of two PRs split out of a single local branch. Phase 8 (manufacturers directory + brand detail) builds on this and will be opened against this branch once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)