### PR TITLE
fix(sort): Name A→Z is the default sort and carries no ?sort= param

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -71,7 +71,7 @@ npx cypress run --spec cypress/e2e/<spec>.cy.ts
 | 6 | Detail page | `gear_detail.cy.ts` + `isa_certification`(detail) | ✅ 201/201 + isa 69/69 |
 | 7 | Compare | `compare.cy.ts` | ✅ 20/20 |
 | 8 | Manufacturers | `manufacturers.cy.ts` | ✅ 18/18 |
-| 9 | URL-state sweep | `url_state.cy.ts` | ⬜ |
+| 9 | URL-state sweep | `url_state.cy.ts` | ✅ 18/18 |
 | 10 | Full green + cleanup | (whole suite) | ⬜ |
 
 ### ✅ Phase 1 — Foundation
@@ -388,8 +388,29 @@ Decisions worth remembering:
   resolves through the Brand relationship and so always equals the Brand row's `name`.
 - Route ranking puts `/manufacturers/:id` above `:slug/:id`, so brand detail wins over gear detail.
 
-### ⬜ Phase 9 — URL-state sweep
-`url_state.cy.ts`: q / sort / pill / range / combined round-trips, clear-all, 404.
+### ✅ Phase 9 — URL-state sweep — DONE
+`url_state.cy.ts` **18/18** — q / sort / pill / range / combined round-trips, clear-all, 404.
+`search_sort.cy.ts` re-run **306/306** (no regression from the sort-default fix below).
+
+The infrastructure (`useUrlState`, routes, `NotFoundPage`) already existed from Phases 1–8, so
+this was mostly a verification sweep. One real app fix + three stale-spec fixes:
+
+- **App fix — Name A→Z carries no `?sort=`.** The contract (top of `useUrlState`, DESIGN "Name is
+  the default sort") is that Name A→Z is the default and produces no param. The dropdown was writing
+  `sort=name-asc`. Fixed in `SortDropdown` — the Name A→Z option now `pick(null)` (clears sort to the
+  default state); Name Z→A still writes `sort=name-desc`. Default sort was already null→name-asc, so
+  card order is unchanged and `search_sort.cy.ts` stays green.
+- **Spec — `contain.text` with a RegExp never matches** (a RegExp is coerced to its literal source).
+  Two sort assertions used `/weight.*low/i`; switched to the plain string `'Weight: Low→High'`,
+  matching the convention already documented at `search_sort.cy.ts:347`.
+- **Spec — range bounds are dual-thumb sliders, not text boxes** (the Phase-4 change). Three tests
+  typed into the `range-min`/`range-max` thumbs, which have `pointer-events:none`. Rewrote them to the
+  established click-to-edit `range-{min,max}-value` label pattern from `filters.cy.ts`, reading domain
+  edges off the thumb `min` attr rather than hardcoding, and added a `have.value` guard so the URL
+  assertion can't race the async param write.
+- **Spec — multi-select comma is `%2C` in the raw URL.** `URLSearchParams` percent-encodes the
+  separator; the round-trip still decodes to a comma. Assertion now reads the decoded `material` value
+  and checks for the `a,b` shape instead of grepping the raw URL for a literal comma.
 
 ### ⬜ Phase 10 — Full green + cleanup
 Whole suite green; simplify/dedupe.

--- a/frontend/cypress/e2e/url_state.cy.ts
+++ b/frontend/cypress/e2e/url_state.cy.ts
@@ -51,7 +51,9 @@ describe('URL state — sort', () => {
 
   it('visiting a URL with ?sort= applies that sort and marks it active in the dropdown', () => {
     cy.visit('/webbings?sort=weight-asc')
-    cy.get('[data-cy="sort-dropdown"]').should('contain.text', /weight.*low|low.*weight/i)
+    // contain.text needs a plain string — a RegExp is coerced to its literal
+    // source and never matches (see search_sort.cy.ts). Button shows "Weight: Low→High".
+    cy.get('[data-cy="sort-dropdown"]').should('contain.text', 'Weight: Low→High')
     cy.get('[data-cy="gear-card"]').then(($cards) => {
       const weights = [...$cards].map(c => {
         const v = c.getAttribute('data-weight')
@@ -105,7 +107,12 @@ describe('URL state — pill filters', () => {
       .find('[data-cy="filter-pill"]').eq(0).click()
     cy.get('[data-cy="filter-group"][data-group="material"]')
       .find('[data-cy="filter-pill"]').eq(1).click()
-    cy.url().should('match', /material=[^&].*,[^&]/)
+    // URLSearchParams encodes the comma separator as %2C in the raw URL; assert on
+    // the decoded value, which is what round-trips back into the filter.
+    cy.location('search').should((search) => {
+      const material = new URLSearchParams(search).get('material')
+      expect(material).to.match(/[^,]+,[^,]+/)
+    })
   })
 
   it('deselecting the last pill for a filter removes that param from the URL', () => {
@@ -119,18 +126,27 @@ describe('URL state — pill filters', () => {
 // ── Range filter → URL ────────────────────────────────────────────────────────
 
 describe('URL state — range filters', () => {
+  // Range bounds are dual-thumb sliders (the thumbs have pointer-events:none and
+  // can't be typed into). An exact bound is set via the click-to-edit value label
+  // (data-cy="range-{min,max}-value"), which is the Phase-4 contract in filters.cy.ts.
+  const weight = '[data-cy="filter-group"][data-group="weight"]'
+
   it('entering a weight min writes ?weight_min= to the URL', () => {
     cy.visit('/webbings')
-    cy.get('[data-cy="filter-group"][data-group="weight"]')
-      .find('[data-cy="range-min"]').type('50')
+    cy.get(weight).find('[data-cy="range-min-value"]').click()
+    cy.get(weight).find('input[data-cy="range-min-value"]').clear().type('50{enter}')
+    // Wait for the commit to round-trip through the URL back onto the thumb before
+    // asserting on the URL — otherwise the assertion can race the async param write.
+    cy.get(weight).find('[data-cy="range-min"]').should('have.value', '50')
     cy.url().should('include', 'weight_min=50')
   })
 
   it('entering a weight max writes ?weight_max= to the URL', () => {
     cy.visit('/webbings')
-    cy.get('[data-cy="filter-group"][data-group="weight"]')
-      .find('[data-cy="range-max"]').type('200')
-    cy.url().should('include', 'weight_max=200')
+    cy.get(weight).find('[data-cy="range-max-value"]').click()
+    cy.get(weight).find('input[data-cy="range-max-value"]').clear().type('150{enter}')
+    cy.get(weight).find('[data-cy="range-max"]').should('have.value', '150')
+    cy.url().should('include', 'weight_max=150')
   })
 
   it('visiting a URL with range params restores the inputs and filters cards', () => {
@@ -160,11 +176,15 @@ describe('URL state — range filters', () => {
     })
   })
 
-  it('clearing a range input removes its param from the URL', () => {
+  it('resetting a range bound to its domain edge removes its param from the URL', () => {
     cy.visit('/webbings?weight_min=50')
-    cy.get('[data-cy="filter-group"][data-group="weight"]')
-      .find('[data-cy="range-min"]').clear()
-    cy.url().should('not.include', 'weight_min=')
+    // A thumb parked at its domain bound means "no constraint" — setting the min
+    // back to the domain low drops the param. Read the low off the thumb's min attr.
+    cy.get(weight).find('[data-cy="range-min"]').invoke('attr', 'min').then((lo) => {
+      cy.get(weight).find('[data-cy="range-min-value"]').click()
+      cy.get(weight).find('input[data-cy="range-min-value"]').clear().type(`${lo}{enter}`)
+      cy.url().should('not.include', 'weight_min=')
+    })
   })
 })
 
@@ -182,7 +202,7 @@ describe('URL state — combined params', () => {
       cy.visit(url)
 
       cy.get('[data-cy="search-input"]').should('have.value', 'Gibbon')
-      cy.get('[data-cy="sort-dropdown"]').should('contain.text', /weight.*low|low.*weight/i)
+      cy.get('[data-cy="sort-dropdown"]').should('contain.text', 'Weight: Low→High')
       cy.get('[data-cy="filter-group"][data-group="material"]')
         .find(`[data-cy="filter-pill"][data-value="${material}"]`)
         .should('have.attr', 'data-active', 'true')

--- a/frontend/src/components/gear/SortDropdown.tsx
+++ b/frontend/src/components/gear/SortDropdown.tsx
@@ -114,7 +114,11 @@ export default function SortDropdown({
             data-field="name"
             data-direction="asc"
             className={optionClass}
-            onClick={() => pick({ field: 'name', direction: 'asc' })}
+            // Name A→Z is the default sort, so it carries NO ?sort= param — picking
+            // it clears the sort back to the null (default) state rather than
+            // writing sort=name-asc. Name Z→A is a real, non-default choice and is
+            // written normally. See url_state.cy.ts / the useUrlState contract.
+            onClick={() => pick(null)}
           >
             Name: A→Z
           </button>


### PR DESCRIPTION
Phase 9 of the frontend roadmap — the URL-state sweep. Stacks on #36.

The infrastructure (`useUrlState`, routes, `NotFoundPage`) already existed from Phases 1–8, so this was mostly verification. It turned up **one real app bug and three stale specs.**

## The app bug

The contract — stated at the top of `useUrlState` and in DESIGN's "Name is the default sort" — is that **Name A→Z is the default and therefore produces no param.** The dropdown was writing `sort=name-asc` instead. So picking the default left the URL in a non-default state, and a shared link round-tripped differently from the page that produced it.

The Name A→Z option now calls `pick(null)`, clearing sort back to the default. Name Z→A still writes `sort=name-desc` normally. Default sort was already `null → name-asc`, so rendered card order is unchanged and `search_sort.cy.ts` stays green (306/306).

## The three stale specs

Tests asserting against an app that had moved on:

- **`contain.text` with a RegExp never matches** — Cypress coerces the RegExp to its literal source string, so two sort assertions using `/weight.*low/i` were passing vacuously. Switched to the plain string `'Weight: Low→High'`, the convention already documented at `search_sort.cy.ts:347`.
- **Range bounds became dual-thumb sliders in Phase 4.** Three tests still typed into the `range-min`/`range-max` thumbs, which carry `pointer-events: none`. Rewritten to the click-to-edit `range-{min,max}-value` pattern from `filters.cy.ts`, reading domain edges off the thumb's own `min` attribute rather than hardcoding them, plus a `have.value` guard so the URL assertion can't race the async param write.
- **The multi-select separator is `%2C` in the raw URL** — `URLSearchParams` percent-encodes it, though the round-trip still decodes to a comma. The assertion now reads the decoded `material` value and checks for the `a,b` shape instead of grepping the raw URL for a literal comma.

## Tests

`url_state.cy.ts` 18/18. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)