### PR TITLE
feat(cards): show weight in the webbing card's inline spec row

### DIFF
--- a/frontend/cypress/e2e/gear_cards.cy.ts
+++ b/frontend/cypress/e2e/gear_cards.cy.ts
@@ -165,6 +165,80 @@ GEAR_TYPES.forEach(({ slug, apiPath, label, hasISA }) => {
   })
 })
 
+// ── Weight in the inline specs row ────────────────────────────────────────────
+// Webbing only. Weight (g/m) is a primary quick-compare spec for webbing, so it
+// sits in the card's inline row between width and breaking strength. Other types
+// keep weight on the detail spec sheet only. Unit is `g/m` to match specRows.ts
+// and the range filter — the webbing model stores grams per metre.
+
+describe('Card inline weight — Webbings', () => {
+  let withWeight: Record<string, unknown> | undefined
+  let withoutWeight: Record<string, unknown> | undefined
+
+  const cardFor = (id: unknown) =>
+    cy.get(`[data-cy="gear-card"]:has([data-cy="gear-card-name"][href="/webbings/${id}"])`)
+
+  before(() => {
+    cy.fetchAllItems('webbing').then((all) => {
+      const items = all as Record<string, unknown>[]
+      withWeight = items.find(i => i.weight != null)
+      withoutWeight = items.find(i => i.weight == null)
+    })
+  })
+
+  beforeEach(() => {
+    cy.visit('/webbings')
+  })
+
+  it('shows the weight with a g/m unit when the webbing has one', () => {
+    if (!withWeight) return
+    cardFor(withWeight.id)
+      .find('[data-cy="gear-card-specs"]')
+      .should('contain.text', `${withWeight.weight} g/m`)
+  })
+
+  it('omits the weight segment — with no empty separator — when weight is null', () => {
+    if (!withoutWeight) return
+    cardFor(withoutWeight.id)
+      .find('[data-cy="gear-card-specs"]')
+      .should('not.contain.text', 'g/m')
+      .invoke('text')
+      .should('not.match', /·\s*·/)
+  })
+
+  it('orders weight after width and before breaking strength', () => {
+    // Needs an item carrying all three so the relative order is observable.
+    cy.fetchAllItems('webbing').then((all) => {
+      const full = (all as Record<string, unknown>[]).find(
+        i => i.weight != null && i.width != null && i.breaking_strength != null,
+      )
+      if (!full) return
+      cardFor(full.id)
+        .find('[data-cy="gear-card-specs"]')
+        .invoke('text')
+        .then((text) => {
+          expect(text.indexOf(`${full.width} mm`)).to.be.lessThan(text.indexOf(`${full.weight} g/m`))
+          expect(text.indexOf(`${full.weight} g/m`))
+            .to.be.lessThan(text.indexOf(`${full.breaking_strength} kN`))
+        })
+    })
+  })
+})
+
+// Weight stays off the inline row for every other type — it is not a primary
+// quick-compare spec there, and those cards have more relevant specs to show.
+GEAR_TYPES.filter(g => g.slug !== 'webbings').forEach(({ slug, label }) => {
+  describe(`Card inline weight — ${label} (not shown)`, () => {
+    it('does not put a g/m weight in the inline specs row', () => {
+      cy.visit(`/${slug}`)
+      cy.get('[data-cy="gear-card"]').should('exist')
+      cy.get('[data-cy="gear-card-specs"]').each(($row) => {
+        expect($row.text()).to.not.contain('g/m')
+      })
+    })
+  })
+})
+
 // ── Classification bubble on the card ─────────────────────────────────────────
 // Webbing only. The same bubble the detail page shows beside the product name is
 // overlaid on the card's image area, top-right — so the highline class is
@@ -178,7 +252,7 @@ describe('Card classification bubble — Webbings', () => {
     cy.get(`[data-cy="gear-card"]:has([data-cy="gear-card-name"][href="/webbings/${id}"])`)
 
   before(() => {
-    cy.fetchAllItems('/webbing').then((all) => {
+    cy.fetchAllItems('webbing').then((all) => {
       const items = all as Record<string, unknown>[]
       withClass = items.find(i => i.classification != null && i.classification !== '')
       withoutClass = items.find(i => i.classification == null || i.classification === '')
@@ -225,7 +299,7 @@ describe('Card classification bubble — Webbings', () => {
   })
 
   it('stacks the bubble above the ISA stamp when the item is also certified', () => {
-    cy.fetchAllItems('/webbing').then((all) => {
+    cy.fetchAllItems('webbing').then((all) => {
       const both = (all as Record<string, unknown>[]).find(
         i => i.classification != null && i.classification !== '' && i.isa_certified === true,
       )

--- a/frontend/src/config/gearFields.ts
+++ b/frontend/src/config/gearFields.ts
@@ -29,7 +29,7 @@ export interface InlineSpec {
 }
 
 export const INLINE_SPECS: Record<GearSlug, InlineSpec[]> = {
-  webbings:      [{ field: 'material' }, { field: 'width', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
+  webbings:      [{ field: 'material' }, { field: 'width', unit: 'mm' }, { field: 'weight', unit: 'g/m' }, { field: 'breaking_strength', unit: 'kN' }],
   weblocks:      [{ field: 'material' }, { field: 'width_min', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
   leashrings:    [{ field: 'material' }, { field: 'inner_diameter', unit: 'mm' }, { field: 'breaking_strength', unit: 'kN' }],
   grips:         [{ field: 'material' }, { field: 'mbs', unit: 'kN' }],


### PR DESCRIPTION
Stacks on #37.

Weight is one of the specs people actually compare webbings on, and it was only reachable by opening the detail page. Adds it to `INLINE_SPECS` for webbings, between width and breaking strength, so the row reads:

```
material · width · weight · breaking strength
```

Narrowest-to-broadest, and the same left-to-right order the detail page's spec table uses.

**Webbings only.** The other gear types either don't carry a meaningful per-item weight or don't express it in g/m, so their inline rows are untouched.

Nulls were already handled by the existing renderer: a spec with no value is dropped from the row entirely rather than rendering an empty segment, so a webbing with no weight shows no stray separator.

## Tests

`gear_cards.cy.ts` gains a "Card inline weight" block — the `g/m` unit renders when present, the segment *and its separator* are absent when weight is null, and it sits between width and breaking strength. Plus a per-type guard asserting no **other** gear type grew a `g/m` weight in its inline row, so this can't quietly spread.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)