### PR TITLE
feat(gear): add the `active` lifecycle field to all 8 gear types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Per-model enums (e.g. `FiberMaterial`, `ConnectionType`, `TensioningType`) live 
 
 There are **no cross-links between gear types** — kits do not FK to specific webbing/weblock rows; they only link to a brand.
 
+Every gear type carries an **`active: bool | None`** field on its `Base<X>` (so it flows to `Public`/`Create`/`Update`): `True` = still sold, `False` = legacy/discontinued, `None` = unknown. It is baked into each root `<type>s.json` seed (one `"active"` key per item) and mapped through the loaders like any other field — sourced from a one-off web-verification pass (227 active / 271 legacy across 498 items as of 2026-07-31). That pass's working set lives in `gear_status/`, which is **gitignored** — it is local provenance, not tracked input, and nothing at runtime reads it. The frontend shows a red "Legacy" card badge when `active === false`, and scopes the listing with an **ALL / CURRENT / HISTORIC** bubble at the top of the filter sidebar (defaults to ALL — see DESIGN.md § Left Filter Sidebar).
+
 ### Active models (wired into `main.py`)
 
 | Model | Table / router prefix | JSON seed | ~Count |

--- a/grips.json
+++ b/grips.json
@@ -14,7 +14,8 @@
         "currency": "EUR",
         "manufacturer": "Slack Pro!",
         "date_introduced": null,
-        "product_url": "https://www.linegrip.com/shop/custom-color-design-linegrip-g4-sbr/"
+        "product_url": "https://www.linegrip.com/shop/custom-color-design-linegrip-g4-sbr/",
+        "active": false
     },
     {
         "name": "Snatch 2.2",
@@ -31,7 +32,8 @@
         "currency": "RUB",
         "manufacturer": "Souz Slackline",
         "date_introduced": null,
-        "product_url": "https://souzslackline.com/product/stropochvat-2-2/"
+        "product_url": "https://souzslackline.com/product/stropochvat-2-2/",
+        "active": false
     },
     {
         "name": "Wafer",
@@ -48,7 +50,8 @@
         "currency": "USD",
         "manufacturer": "Balance Community: Slackline Outfitters",
         "date_introduced": null,
-        "product_url": "https://www.balancecommunity.com/products/wafer"
+        "product_url": "https://www.balancecommunity.com/products/wafer",
+        "active": false
     },
     {
         "name": "Snatch 2.2T",
@@ -65,7 +68,8 @@
         "currency": "RUB",
         "manufacturer": "Souz Slackline",
         "date_introduced": null,
-        "product_url": "https://souzslackline.com/product/snatch-2-2trickline-50mm/"
+        "product_url": "https://souzslackline.com/product/snatch-2-2trickline-50mm/",
+        "active": false
     },
     {
         "name": "LineGrip nano",
@@ -82,7 +86,8 @@
         "currency": "EUR",
         "manufacturer": "Slack Pro!",
         "date_introduced": null,
-        "product_url": "https://www.linegrip.com/shop/linegrip-nano"
+        "product_url": "https://www.linegrip.com/shop/linegrip-nano",
+        "active": false
     },
     {
         "name": "LineGrip G5",
@@ -99,7 +104,8 @@
         "currency": "EUR",
         "manufacturer": "Slack Pro!",
         "date_introduced": 1512079200000,
-        "product_url": "https://www.linegrip.com/shop/linegrip-g5/"
+        "product_url": "https://www.linegrip.com/shop/linegrip-g5/",
+        "active": true
     },
     {
         "name": "TricklineGrip G1",
@@ -116,7 +122,8 @@
         "currency": "EUR",
         "manufacturer": "Slack Pro!",
         "date_introduced": 1501534800000,
-        "product_url": "https://www.linegrip.com/shop/tricklinegrip-g1-sbr/"
+        "product_url": "https://www.linegrip.com/shop/tricklinegrip-g1-sbr/",
+        "active": false
     },
     {
         "name": "TricklineGrip G2",
@@ -133,7 +140,8 @@
         "currency": "EUR",
         "manufacturer": "Slack Pro!",
         "date_introduced": 1512079200000,
-        "product_url": "https://www.linegrip.com/shop/tricklinegrip-g2/"
+        "product_url": "https://www.linegrip.com/shop/tricklinegrip-g2/",
+        "active": true
     },
     {
         "name": "HighlineGrip G2",
@@ -150,7 +158,8 @@
         "currency": null,
         "manufacturer": "Slack Pro!",
         "date_introduced": null,
-        "product_url": "https://www.linegrip.com/highlinegrip/"
+        "product_url": "https://www.linegrip.com/highlinegrip/",
+        "active": true
     },
     {
         "name": "Grippen",
@@ -167,7 +176,8 @@
         "currency": "EUR",
         "manufacturer": "Equilibrium Slacklines (EQB)",
         "date_introduced": 1580248800000,
-        "product_url": "https://www.slackshop.cz/en/linegrip/166-396-eqb-grippen.html"
+        "product_url": "https://www.slackshop.cz/en/linegrip/166-396-eqb-grippen.html",
+        "active": false
     },
     {
         "name": "Cito",
@@ -184,7 +194,8 @@
         "currency": "EUR",
         "manufacturer": "Petram Slacklines",
         "date_introduced": 1558818000000,
-        "product_url": "https://petramslacklines.site123.me/shop-1/cito-webbing-grip"
+        "product_url": "https://petramslacklines.site123.me/shop-1/cito-webbing-grip",
+        "active": true
     },
     {
         "name": "Line Mitra Webbing Gripper",
@@ -201,6 +212,7 @@
         "currency": "INR",
         "manufacturer": "Slack Mitra",
         "date_introduced": 1577817000000,
-        "product_url": "https://www.instamojo.com/slackmitra/line-mitra-webbing-gripper/?ref=store"
+        "product_url": "https://www.instamojo.com/slackmitra/line-mitra-webbing-gripper/?ref=store",
+        "active": false
     }
 ]

--- a/leashrings.json
+++ b/leashrings.json
@@ -12,7 +12,8 @@
         "notes": null,
         "manufacturer": "Kong",
         "date_introduced": null,
-        "product_url": "http://www.kong.it/en/2-products/items/f17-anchorage/p160-ana"
+        "product_url": "http://www.kong.it/en/2-products/items/f17-anchorage/p160-ana",
+        "active": false
     },
     {
         "name": "Steel Ring",
@@ -27,7 +28,8 @@
         "notes": null,
         "manufacturer": "Slackline tools",
         "date_introduced": null,
-        "product_url": "http://www.slack-shop.de/stahl-ring.html"
+        "product_url": "http://www.slack-shop.de/stahl-ring.html",
+        "active": false
     },
     {
         "name": "Leashring V2.0",
@@ -42,7 +44,8 @@
         "notes": null,
         "manufacturer": "Slack.fr",
         "date_introduced": null,
-        "product_url": "https://laboutique.slack.fr/en/hardware/162-steel-leash-ring-pair.html"
+        "product_url": "https://laboutique.slack.fr/en/hardware/162-steel-leash-ring-pair.html",
+        "active": false
     },
     {
         "name": "Forged steel ring",
@@ -57,7 +60,8 @@
         "notes": null,
         "manufacturer": "Line Spirit",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Arbo Steel Ring L",
@@ -72,7 +76,8 @@
         "notes": null,
         "manufacturer": "Climbing Technology (CT)",
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/rings/202-anello-forgiato-alluminio-ct-46-mm.html"
+        "product_url": "https://spider-slacklines.com/shop/en/rings/202-anello-forgiato-alluminio-ct-46-mm.html",
+        "active": false
     },
     {
         "name": "Bomber Ring",
@@ -87,7 +92,8 @@
         "notes": null,
         "manufacturer": "Landcruising",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Arbo Ring L",
@@ -102,7 +108,8 @@
         "notes": null,
         "manufacturer": "Climbing Technology (CT)",
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/rings/127-322-anello-forgiato-alluminio-ct-46-mm.html"
+        "product_url": "https://spider-slacklines.com/shop/en/rings/127-322-anello-forgiato-alluminio-ct-46-mm.html",
+        "active": false
     },
     {
         "name": "Steel Ring 200kN",
@@ -117,7 +124,8 @@
         "notes": null,
         "manufacturer": "Dakas",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Steel Ring 150kN",
@@ -132,7 +140,8 @@
         "notes": null,
         "manufacturer": "Dakas",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Bomber Steel Ring",
@@ -147,7 +156,8 @@
         "notes": null,
         "manufacturer": "Balance Community: Slackline Outfitters",
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/bomber-steel-ring"
+        "product_url": "http://www.balancecommunity.com/bomber-steel-ring",
+        "active": false
     },
     {
         "name": "Large Steel Ring",
@@ -162,7 +172,8 @@
         "notes": null,
         "manufacturer": "Balance Community: Slackline Outfitters",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Medium Steel Ring",
@@ -177,7 +188,8 @@
         "notes": null,
         "manufacturer": "Balance Community: Slackline Outfitters",
         "date_introduced": null,
-        "product_url": "http://www.balancecommunity.com/medium-steel-ring"
+        "product_url": "http://www.balancecommunity.com/medium-steel-ring",
+        "active": false
     },
     {
         "name": "RING77",
@@ -192,7 +204,8 @@
         "notes": null,
         "manufacturer": "Slack house",
         "date_introduced": null,
-        "product_url": "http://slackhouseshop.pl/produkt/ring77/"
+        "product_url": "http://slackhouseshop.pl/produkt/ring77/",
+        "active": true
     },
     {
         "name": "Access",
@@ -207,7 +220,8 @@
         "notes": null,
         "manufacturer": "Camp",
         "date_introduced": null,
-        "product_url": "https://www.rocknrescue.com/product/camp-safety-access-ring"
+        "product_url": "https://www.rocknrescue.com/product/camp-safety-access-ring",
+        "active": false
     },
     {
         "name": "Leash Ring",
@@ -222,7 +236,8 @@
         "notes": null,
         "manufacturer": "SlackGear",
         "date_introduced": null,
-        "product_url": "http://www.slackgear.co.za/product/leash-rings/"
+        "product_url": "http://www.slackgear.co.za/product/leash-rings/",
+        "active": false
     },
     {
         "name": "Slackisûr",
@@ -237,7 +252,8 @@
         "notes": null,
         "manufacturer": "Slack Inov",
         "date_introduced": null,
-        "product_url": "https://slack-inov.com/shop/en/leashes/315-slackisur-highline-ring.html"
+        "product_url": "https://slack-inov.com/shop/en/leashes/315-slackisur-highline-ring.html",
+        "active": false
     },
     {
         "name": "ZERO Silver",
@@ -252,7 +268,8 @@
         "notes": null,
         "manufacturer": "ZERGE outdoor",
         "date_introduced": null,
-        "product_url": "http://zergeoutdoor.com/product/zero-silver-stainless-ring/"
+        "product_url": "http://zergeoutdoor.com/product/zero-silver-stainless-ring/",
+        "active": false
     },
     {
         "name": "ZERO Black",
@@ -267,7 +284,8 @@
         "notes": null,
         "manufacturer": "ZERGE outdoor",
         "date_introduced": null,
-        "product_url": "http://zergeoutdoor.com/product/zero-black-ultralight-ring/"
+        "product_url": "http://zergeoutdoor.com/product/zero-black-ultralight-ring/",
+        "active": false
     },
     {
         "name": "O-RING",
@@ -282,7 +300,8 @@
         "notes": null,
         "manufacturer": "Fusion Climb",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Stainless Steel Leash Ring",
@@ -297,7 +316,8 @@
         "notes": null,
         "manufacturer": "Equilibrium Slacklines (EQB)",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "Leash Ring",
@@ -312,7 +332,8 @@
         "notes": null,
         "manufacturer": "Equilibrium Slacklines (EQB)",
         "date_introduced": null,
-        "product_url": "http://www.slackgear.co.za/product/leash-rings/"
+        "product_url": "http://www.slackgear.co.za/product/leash-rings/",
+        "active": true
     },
     {
         "name": "ZERO Gold",
@@ -327,7 +348,8 @@
         "notes": null,
         "manufacturer": "ZERGE outdoor",
         "date_introduced": null,
-        "product_url": "http://zergeoutdoor.com/product/zero-gold-ultralight-ring/"
+        "product_url": "http://zergeoutdoor.com/product/zero-gold-ultralight-ring/",
+        "active": false
     },
     {
         "name": "Petram Aluminium ring",
@@ -342,7 +364,8 @@
         "notes": null,
         "manufacturer": "Petram Slacklines",
         "date_introduced": 1505858400000,
-        "product_url": "https://petramslacklines.site123.me/shop-1/aluminium-ring"
+        "product_url": "https://petramslacklines.site123.me/shop-1/aluminium-ring",
+        "active": false
     },
     {
         "name": "Leash Protector",
@@ -357,7 +380,8 @@
         "notes": null,
         "manufacturer": "Souz Slackline",
         "date_introduced": 1533448800000,
-        "product_url": "https://souzslackline.com/product/leasring/?currency=USD"
+        "product_url": "https://souzslackline.com/product/leasring/?currency=USD",
+        "active": false
     },
     {
         "name": "60mm Aluminium Ring",
@@ -372,7 +396,8 @@
         "notes": null,
         "manufacturer": "Spider slacklines",
         "date_introduced": null,
-        "product_url": "https://spider-slacklines.com/shop/en/rings/163-anello-alluminio-forgiato-highline.html"
+        "product_url": "https://spider-slacklines.com/shop/en/rings/163-anello-alluminio-forgiato-highline.html",
+        "active": true
     },
     {
         "name": "HighlineRing",
@@ -387,7 +412,8 @@
         "notes": null,
         "manufacturer": "Slacktivity",
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/highlinering"
+        "product_url": "https://www.slacktivity.com/highlinering",
+        "active": true
     },
     {
         "name": "BC Aluminum Leash Ring",
@@ -402,7 +428,8 @@
         "notes": "Formerly called 'Loop'",
         "manufacturer": "Balance Community: Slackline Outfitters",
         "date_introduced": 1597093200000,
-        "product_url": "https://www.balancecommunity.com/products/bc-aluminum-leash-ring"
+        "product_url": "https://www.balancecommunity.com/products/bc-aluminum-leash-ring",
+        "active": true
     },
     {
         "name": "Vortex",
@@ -417,7 +444,8 @@
         "notes": null,
         "manufacturer": "Slack Inov",
         "date_introduced": null,
-        "product_url": "https://slack-inov.com/shop/en/leashes/314-vortex-highline-ring.html"
+        "product_url": "https://slack-inov.com/shop/en/leashes/314-vortex-highline-ring.html",
+        "active": false
     },
     {
         "name": "Halo",
@@ -432,7 +460,8 @@
         "notes": null,
         "manufacturer": "Raed Slacklines",
         "date_introduced": 1620680400000,
-        "product_url": "https://raed-slacklines.com/halo-titanium-highline-leash-ring"
+        "product_url": "https://raed-slacklines.com/halo-titanium-highline-leash-ring",
+        "active": true
     },
     {
         "name": "SATURN ring",
@@ -447,6 +476,7 @@
         "notes": null,
         "manufacturer": "Space Age Slacklines",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     }
 ]

--- a/rollers.json
+++ b/rollers.json
@@ -16,7 +16,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "http://www.slackshop.cz/en/rigging-equipment/81-kladka-aidman.html"
+        "product_url": "http://www.slackshop.cz/en/rigging-equipment/81-kladka-aidman.html",
+        "active": false
     },
     {
         "name": "Hangover 2.0",
@@ -38,7 +39,8 @@
         "roller_material": "Steel",
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/default/longline-highline/hangover"
+        "product_url": "https://www.slacktivity.com/default/longline-highline/hangover",
+        "active": true
     },
     {
         "name": "HangOver Stainless",
@@ -61,7 +63,8 @@
         "locking_type": "Non-locking",
         "bearing_material": "Stainless Steel",
         "date_introduced": 1507064400000,
-        "product_url": "https://www.slacktivity.com/hangover-stainless"
+        "product_url": "https://www.slacktivity.com/hangover-stainless",
+        "active": true
     },
     {
         "name": "HangOver-S",
@@ -83,7 +86,8 @@
         "roller_material": "Steel",
         "locking_type": "screw lock",
         "date_introduced": null,
-        "product_url": "https://www.slacktivity.com/hangover-s"
+        "product_url": "https://www.slacktivity.com/hangover-s",
+        "active": true
     },
     {
         "name": "HangOver Royal",
@@ -106,7 +110,8 @@
         "bearing_material": "Stainless Steel",
         "locking_type": "non-locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "name": "HighSlide 2.0",
@@ -128,7 +133,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "LineBuggy",
@@ -150,7 +156,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "http://www.slackgear.co.za/product/linebuggy/"
+        "product_url": "http://www.slackgear.co.za/product/linebuggy/",
+        "active": false
     },
     {
         "name": "Motum webbing pulley",
@@ -172,7 +179,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "https://petramslacklines.site123.me/shop-1/motum-pulley"
+        "product_url": "https://petramslacklines.site123.me/shop-1/motum-pulley",
+        "active": false
     },
     {
         "name": "Pulley",
@@ -194,7 +202,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "http://slack-mountain.com/en/pulley-and-tension/61-poulie-de-sangle-slack-mountain.html"
+        "product_url": "http://slack-mountain.com/en/pulley-and-tension/61-poulie-de-sangle-slack-mountain.html",
+        "active": true
     },
     {
         "name": "Rock'n'Roll",
@@ -216,7 +225,8 @@
         "roller_material": "Stainless Steel",
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "ROLLEX SS",
@@ -239,7 +249,8 @@
         "locking_type": "Non-locking",
         "bearing_material": "Stainless Steel",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "name": "ROLLEX SG",
@@ -261,7 +272,8 @@
         "roller_material": "Aluminum",
         "locking_type": "screw locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "name": "ROLLEX",
@@ -283,7 +295,8 @@
         "roller_material": "Aluminum",
         "locking_type": "Non-locking",
         "date_introduced": 1555189200000,
-        "product_url": "https://www.slackshop.cz/en/rollex/157-379-rollex.html"
+        "product_url": "https://www.slackshop.cz/en/rollex/157-379-rollex.html",
+        "active": true
     },
     {
         "name": "SKIP",
@@ -305,7 +318,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "http://zergeoutdoor.com/product/skip-the-high-efficiency-webbing-pulley/"
+        "product_url": "http://zergeoutdoor.com/product/skip-the-high-efficiency-webbing-pulley/",
+        "active": false
     },
     {
         "name": "SKIP UL",
@@ -327,7 +341,8 @@
         "roller_material": null,
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": "http://zergeoutdoor.com/product/skip-ul-the-ultralight-stainless-steel-webbing-pulley/"
+        "product_url": "http://zergeoutdoor.com/product/skip-ul-the-ultralight-stainless-steel-webbing-pulley/",
+        "active": false
     },
     {
         "name": "Webbling Pulley",
@@ -349,7 +364,8 @@
         "roller_material": "Nylon (Polyamide)",
         "locking_type": "Non-locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "name": "BC Roller - Straight Gate",
@@ -369,7 +385,8 @@
         "bearing_material": "Stainless Steel",
         "locking_type": "non-locking",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "name": "BC Roller - 2-Stage Twist Lock",
@@ -389,6 +406,7 @@
         "bearing_material": "Stainless Steel",
         "locking_type": "twist lock",
         "date_introduced": null,
-        "product_url": null
+        "product_url": null,
+        "active": true
     }
 ]

--- a/slack_data/load_data/load_grips.py
+++ b/slack_data/load_data/load_grips.py
@@ -69,6 +69,7 @@ def add_grips_to_db(grips: list[dict], session: SessionDep) -> None:
             isa_certified=grip.get("isa_certified", False),
             price=grip.get("price"),
             currency=currency,
+            active=grip.get("active"),
         )
         db_grip = Grip.model_validate(grip_create)
         db_grip.brand = session.get(Brand, brand_id)

--- a/slack_data/load_data/load_leashrings.py
+++ b/slack_data/load_data/load_leashrings.py
@@ -67,6 +67,7 @@ def add_leashrings_to_db(leashrings: list[dict], session: SessionDep) -> None:
             price=leashring.get("price"),
             currency=currency,
             notes=leashring.get("notes"),
+            active=leashring.get("active"),
         )
         db_leashring = LeashRing.model_validate(leashring_create)
         db_leashring.brand = session.get(Brand, brand_id)

--- a/slack_data/load_data/load_rollers.py
+++ b/slack_data/load_data/load_rollers.py
@@ -70,6 +70,7 @@ def add_rollers_to_db(rollers: list[dict], session: SessionDep) -> None:
             isa_certified=roller.get("isa_approved", False),
             price=roller.get("price"),
             currency=currency,
+            active=roller.get("active"),
         )
         db_roller = Roller.model_validate(roller_create)
         db_roller.brand = session.get(Brand, brand_id)

--- a/slack_data/load_data/load_starterkits.py
+++ b/slack_data/load_data/load_starterkits.py
@@ -104,6 +104,7 @@ def add_starterkits_to_db(starterkits: list[dict], session: SessionDep) -> None:
             description=sk.get("description"),
             version=sk.get("version"),
             notes=sk.get("notes"),
+            active=sk.get("active"),
         )
 
         db_sk = StarterKit.model_validate(starterkit_create)

--- a/slack_data/load_data/load_treepros.py
+++ b/slack_data/load_data/load_treepros.py
@@ -78,6 +78,7 @@ def add_treepros_to_db(treepros: list[dict], session: SessionDep) -> None:
             description=treepro.get("description"),
             version=treepro.get("version"),
             notes=treepro.get("notes"),
+            active=treepro.get("active"),
         )
 
         db_treepro = TreePro.model_validate(treepro_create)

--- a/slack_data/load_data/load_tricklinekits.py
+++ b/slack_data/load_data/load_tricklinekits.py
@@ -94,6 +94,7 @@ def add_tricklinekits_to_db(tricks: list[dict], session: SessionDep) -> None:
             description=t.get("description"),
             version=t.get("version"),
             notes=t.get("notes"),
+            active=t.get("active"),
         )
 
         db_tk = TricklineKit.model_validate(trick_create)

--- a/slack_data/load_data/load_webbings.py
+++ b/slack_data/load_data/load_webbings.py
@@ -91,6 +91,7 @@ def add_webbings_to_db(webbings: list[dict], session: SessionDep) -> None:
             isa_certified=webbing.get("isa_certified", False),
             price=parse_price(webbing.get("priceMeter")),
             currency=parse_currency(webbing.get("currency")),
+            active=webbing.get("active"),
         )
         db_webbing = Webbing.model_validate(webbing_create)
         db_webbing.brand = session.get(Brand, brand_id)

--- a/slack_data/load_data/load_weblocks.py
+++ b/slack_data/load_data/load_weblocks.py
@@ -78,6 +78,7 @@ def clean_weblock_data(weblock: dict[str, Any]) -> dict[str, Any]:
 
     cleaned_data["date_introduced"] = weblock.get("date_introduced")
     cleaned_data["product_url"] = weblock.get("product_url")
+    cleaned_data["active"] = weblock.get("active")
 
     return cleaned_data
 
@@ -114,7 +115,8 @@ def add_weblocks_to_db(weblocks: list[dict], session: SessionDep) -> None:
             currency=weblock.get("currency"),
             description=weblock.get("description"),
             version=weblock.get("version"),
-            notes=weblock.get("notes")
+            notes=weblock.get("notes"),
+            active=weblock.get("active"),
         )
         db_weblock = Weblock.model_validate(weblock_create)
         db_weblock.brand = session.get(Brand, brand_id)

--- a/slack_data/models/grips.py
+++ b/slack_data/models/grips.py
@@ -35,6 +35,7 @@ class BaseGrip(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 class Grip(BaseGrip, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/slack_data/models/leashrings.py
+++ b/slack_data/models/leashrings.py
@@ -25,6 +25,7 @@ class BaseLeashRing(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 class LeashRing(BaseLeashRing, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/slack_data/models/rollers.py
+++ b/slack_data/models/rollers.py
@@ -52,6 +52,7 @@ class BaseRoller(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 class Roller(BaseRoller, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/slack_data/models/starterkits.py
+++ b/slack_data/models/starterkits.py
@@ -29,6 +29,7 @@ class BaseStarterKit(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 
 class StarterKit(BaseStarterKit, table=True):

--- a/slack_data/models/treepro.py
+++ b/slack_data/models/treepro.py
@@ -28,6 +28,7 @@ class BaseTreePro(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 
 class TreePro(BaseTreePro, table=True):

--- a/slack_data/models/tricklinekits.py
+++ b/slack_data/models/tricklinekits.py
@@ -28,6 +28,7 @@ class BaseTricklineKit(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 
 class TricklineKit(BaseTricklineKit, table=True):

--- a/slack_data/models/webbing.py
+++ b/slack_data/models/webbing.py
@@ -137,6 +137,7 @@ class BaseWebbing(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 class Webbing(BaseWebbing, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/slack_data/models/weblocks.py
+++ b/slack_data/models/weblocks.py
@@ -48,6 +48,7 @@ class BaseWeblock(SQLModel):
     description: str | None = None
     version: str | None = None
     notes: str | None = None
+    active: bool | None = Field(default=None, index=True)
 
 class Weblock(BaseWeblock, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/starterkits.json
+++ b/starterkits.json
@@ -14,7 +14,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "10 m Fit n Slack Set",
@@ -31,7 +32,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "10 m Kids n Slack Set",
@@ -48,7 +50,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "15 m Clip n Slack Set",
@@ -65,7 +68,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "15 Meter Slackline Set – Includes Tree Protection",
@@ -82,7 +86,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Shop NZ"
+        "manufacturer": "Slackline Shop NZ",
+        "active": true
     },
     {
         "name": "15m kit",
@@ -99,7 +104,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Middle Way Slacklines"
+        "manufacturer": "Middle Way Slacklines",
+        "active": true
     },
     {
         "name": "15m kit",
@@ -116,7 +122,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Acrobat Slackline"
+        "manufacturer": "Acrobat Slackline",
+        "active": true
     },
     {
         "name": "20m Slackline Kit: 1 Practice Line",
@@ -133,7 +140,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mitra"
+        "manufacturer": "Slack Mitra",
+        "active": false
     },
     {
         "name": "23m Active Slackline",
@@ -150,7 +158,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Viper Slacklines"
+        "manufacturer": "Viper Slacklines",
+        "active": true
     },
     {
         "name": "25m kit",
@@ -167,7 +176,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Middle Way Slacklines"
+        "manufacturer": "Middle Way Slacklines",
+        "active": true
     },
     {
         "name": "25m kit",
@@ -184,7 +194,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Acrobat Slackline"
+        "manufacturer": "Acrobat Slackline",
+        "active": true
     },
     {
         "name": "Aki Starter Classic Slacklineset",
@@ -201,7 +212,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Aki Slacklines"
+        "manufacturer": "Aki Slacklines",
+        "active": false
     },
     {
         "name": "Aki Starter Comfort Slacklineset",
@@ -218,7 +230,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Aki Slacklines"
+        "manufacturer": "Aki Slacklines",
+        "active": false
     },
     {
         "name": "Allround Slackline | 15m Set",
@@ -235,7 +248,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Base Line Kit",
@@ -252,7 +266,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Industries"
+        "manufacturer": "Slackline Industries",
+        "active": true
     },
     {
         "name": "Basic 6 25 M",
@@ -269,7 +284,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Basic2",
@@ -286,7 +302,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "BC Prim-25 Slackline Kit",
@@ -303,7 +320,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Balance Community: Slackline Outfitters"
+        "manufacturer": "Balance Community: Slackline Outfitters",
+        "active": true
     },
     {
         "name": "Beginner Primitive Slackline Kit",
@@ -320,7 +338,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacklife BC"
+        "manufacturer": "Slacklife BC",
+        "active": true
     },
     {
         "name": "Breathe 20 Slackline Kit",
@@ -337,7 +356,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Balance Community: Slackline Outfitters"
+        "manufacturer": "Balance Community: Slackline Outfitters",
+        "active": false
     },
     {
         "name": "Classic Line Red XL TreeWear",
@@ -354,7 +374,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Gibbon"
+        "manufacturer": "Gibbon",
+        "active": true
     },
     {
         "name": "Dragon 2 25 M",
@@ -371,7 +392,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Dragon 6",
@@ -388,7 +410,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Easy pack",
@@ -405,7 +428,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Easy Slackline"
+        "manufacturer": "Easy Slackline",
+        "active": false
     },
     {
         "name": "ELINE SLACKLINE: LIGHT KIT",
@@ -422,7 +446,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Yoga Slackers"
+        "manufacturer": "Yoga Slackers",
+        "active": true
     },
     {
         "name": "Eline SlacklineE Kit",
@@ -439,7 +464,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Yoga Slackers"
+        "manufacturer": "Yoga Slackers",
+        "active": true
     },
     {
         "name": "EQB BALANCE 20 M",
@@ -456,7 +482,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Equilibrium Slacklines (EQB)"
+        "manufacturer": "Equilibrium Slacklines (EQB)",
+        "active": true
     },
     {
         "name": "EQB STEP 12 M",
@@ -473,7 +500,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Equilibrium Slacklines (EQB)"
+        "manufacturer": "Equilibrium Slacklines (EQB)",
+        "active": true
     },
     {
         "name": "EQB TRICK 20 M",
@@ -490,7 +518,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Equilibrium Slacklines (EQB)"
+        "manufacturer": "Equilibrium Slacklines (EQB)",
+        "active": true
     },
     {
         "name": "EQB Yoga15 M",
@@ -507,7 +536,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Equilibrium Slacklines (EQB)"
+        "manufacturer": "Equilibrium Slacklines (EQB)",
+        "active": true
     },
     {
         "name": "Experience Slackline | 30m Set",
@@ -524,7 +554,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Firestarter 35m",
@@ -541,7 +572,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "SlackGear"
+        "manufacturer": "SlackGear",
+        "active": true
     },
     {
         "name": "FUN Kit - Beginner Slackline Set 20m",
@@ -558,7 +590,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Raed Slacklines"
+        "manufacturer": "Raed Slacklines",
+        "active": true
     },
     {
         "name": "Guide 2 20 M",
@@ -575,7 +608,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Guide 6 20 M",
@@ -592,7 +626,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Kit Cruise 15m",
@@ -609,7 +644,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Easy Slackline"
+        "manufacturer": "Easy Slackline",
+        "active": false
     },
     {
         "name": "Kit Cruise Easy with handlerail",
@@ -626,7 +662,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Easy Slackline"
+        "manufacturer": "Easy Slackline",
+        "active": false
     },
     {
         "name": "KIT EASY 15M",
@@ -643,7 +680,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "KIT IGLOO 25 M",
@@ -660,7 +698,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "KIT INUIT 30 M",
@@ -677,7 +716,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "Kit Primitiv 25",
@@ -694,7 +734,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Easy Slackline"
+        "manufacturer": "Easy Slackline",
+        "active": false
     },
     {
         "name": "Kit Primitive Compact Line",
@@ -711,7 +752,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Bera Adventure"
+        "manufacturer": "Bera Adventure",
+        "active": true
     },
     {
         "name": "KIT SLACK 15M (17M CUMULÉ)",
@@ -728,7 +770,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": false
     },
     {
         "name": "KIT SLACK DE 20M AVEC CLIQUET",
@@ -745,7 +788,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "KIT STREET BALANCE SLACK 10m",
@@ -762,7 +806,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Bera Adventure"
+        "manufacturer": "Bera Adventure",
+        "active": true
     },
     {
         "name": "Landcruising Aloha Rodeolineset",
@@ -779,7 +824,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Aki Slacklines"
+        "manufacturer": "Aki Slacklines",
+        "active": false
     },
     {
         "name": "Minimum Slackline | 12m Set",
@@ -796,7 +842,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Nature 2 15M",
@@ -813,7 +860,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Nature 6 15 M",
@@ -830,7 +878,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "PACK CLICK 25 M",
@@ -847,7 +896,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "PLAY LINE",
@@ -864,7 +914,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Industries"
+        "manufacturer": "Slackline Industries",
+        "active": true
     },
     {
         "name": "Primitive Pack 30m",
@@ -881,7 +932,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Geko Slacklines"
+        "manufacturer": "Geko Slacklines",
+        "active": true
     },
     {
         "name": "Primitive Slackline Kit | Light &amp; Easy Setup",
@@ -898,7 +950,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Sigma Impact Set",
@@ -915,7 +968,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackliner.de"
+        "manufacturer": "Slackliner.de",
+        "active": true
     },
     {
         "name": "Sigma Slackline Set ( 35 mm ), 15m lang",
@@ -932,7 +986,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackliner.de"
+        "manufacturer": "Slackliner.de",
+        "active": true
     },
     {
         "name": "Sigma Slackline Set ( 35 mm breit ) 25m lang",
@@ -949,7 +1004,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackliner.de"
+        "manufacturer": "Slackliner.de",
+        "active": true
     },
     {
         "name": "SLACKLINE KIT - PIRATE 18",
@@ -966,7 +1022,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Inov"
+        "manufacturer": "Slack Inov",
+        "active": false
     },
     {
         "name": "SLACKLINE KIT - PLASMA 30",
@@ -983,7 +1040,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Inov"
+        "manufacturer": "Slack Inov",
+        "active": false
     },
     {
         "name": "Slackline Kit - Training LINE 18",
@@ -1000,7 +1058,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Spider slacklines"
+        "manufacturer": "Spider slacklines",
+        "active": true
     },
     {
         "name": "Slackline YOGA Set",
@@ -1017,7 +1076,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Super Guide 6 30 M",
@@ -1034,7 +1094,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Traveler | leichte Reise-Slackline",
@@ -1051,7 +1112,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Zebra 2 25 M",
@@ -1068,7 +1130,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Zebra 6 25 M",
@@ -1085,6 +1148,7 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     }
 ]

--- a/tests/test_active_field.py
+++ b/tests/test_active_field.py
@@ -1,0 +1,169 @@
+"""
+Tests for the `active` lifecycle field across all 8 gear types.
+
+`active` is the one field every gear model shares that is populated ENTIRELY
+from the seed JSON — there is no default, no derivation, and no other code path
+that can set it. Each loader carries exactly one line for it:
+
+    active=<item>.get("active"),
+
+`.get()` returns None on a missing or misspelled key rather than raising, so
+deleting that line, or renaming the JSON key, makes every item of that gear type
+seed as None. Nothing crashes. The API keeps returning 200. The only visible
+symptom is downstream and far away: the frontend's Legacy badge silently stops
+rendering and the HISTORIC filter silently returns nothing.
+
+That is a change no other test in this suite would catch, which is why the
+loader mapping — not just the model column — is asserted here per gear type.
+
+Three states are meaningful and all three are covered:
+    True  = still sold
+    False = legacy / discontinued
+    None  = unknown (key absent) — a legal value, not an error
+"""
+
+import pytest
+
+from slack_data.load_data.load_grips import add_grips_to_db
+from slack_data.load_data.load_leashrings import add_leashrings_to_db
+from slack_data.load_data.load_rollers import add_rollers_to_db
+from slack_data.load_data.load_starterkits import add_starterkits_to_db, clean_starterkit_data
+from slack_data.load_data.load_treepros import add_treepros_to_db
+from slack_data.load_data.load_tricklinekits import (
+    add_tricklinekits_to_db,
+    clean_tricklinekit_data,
+)
+from slack_data.load_data.load_webbings import add_webbings_to_db
+from slack_data.load_data.load_weblocks import add_weblocks_to_db, clean_weblock_data
+
+
+# Per gear type: the API prefix, a loader callable, and a minimal item in the
+# shape that loader actually reads. These deliberately differ, because the
+# loaders do:
+#   - brand key is `brand` for webbing/weblock, `manufacturer` for the rest
+#   - weblock keeps the nested SlackDB scrape shape (`specifications`)
+#   - add_*_to_db expects ALREADY-CLEANED input; load_*() is what applies
+#     clean_*() first. Where a clean step exists we route through it, since for
+#     weblock the `active` mapping lives in clean_weblock_data() rather than in
+#     add_weblocks_to_db() — testing the pair is what covers the real path.
+def _webbing(active):
+    d = {"brand": "TestBrand", "name": "W1", "materialType": "Polyester"}
+    if active is not None:
+        d["active"] = active
+    return d
+
+
+def _weblock(active):
+    d = {
+        "brand": "TestBrand",
+        "name": "WL1",
+        "specifications": {"Material": "Aluminum", "Compatible webbing width": "25mm"},
+    }
+    if active is not None:
+        d["active"] = active
+    return d
+
+
+def _mfr(name, **extra):
+    def build(active):
+        d = {"manufacturer": "TestBrand", "name": name, **extra}
+        if active is not None:
+            d["active"] = active
+        return d
+    return build
+
+
+def _via(clean, add):
+    """Mirror load_*(): clean each item, then hand the batch to the adder."""
+    def run(items, session):
+        add([clean(i) for i in items], session)
+    return run
+
+
+GEAR_TYPES = [
+    ("webbing",      add_webbings_to_db,   _webbing),
+    ("weblock",      _via(clean_weblock_data, add_weblocks_to_db), _weblock),
+    ("roller",       add_rollers_to_db,    _mfr("R1")),
+    ("leashring",    add_leashrings_to_db, _mfr("LR1")),
+    ("grip",         add_grips_to_db,      _mfr("G1")),
+    ("treepro",      add_treepros_to_db,   _mfr("TP1")),
+    ("starterkit",   _via(clean_starterkit_data, add_starterkits_to_db),
+                     _mfr("SK1", tensioning_type="Double Ratchet")),
+    ("tricklinekit", _via(clean_tricklinekit_data, add_tricklinekits_to_db),
+                     _mfr("TK1", tensioning_type="RAT1")),
+]
+
+IDS = [t[0] for t in GEAR_TYPES]
+
+
+# ---------------------------------------------------------------------------
+# Loader mapping — the line that can vanish silently
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("prefix, loader, build", GEAR_TYPES, ids=IDS)
+@pytest.mark.parametrize("value", [True, False], ids=["active", "legacy"])
+def test_loader_maps_active_from_json(client, session, prefix, loader, build, value):
+    """A JSON `active` of true/false reaches the API response unchanged."""
+    loader([build(value)], session)
+    session.commit()
+
+    items = client.get(f"/{prefix}/").json()
+    assert len(items) == 1, f"{prefix}: expected exactly one seeded item"
+    assert items[0]["active"] is value
+
+
+@pytest.mark.parametrize("prefix, loader, build", GEAR_TYPES, ids=IDS)
+def test_loader_leaves_active_none_when_key_absent(client, session, prefix, loader, build):
+    """A missing `active` key is 'unknown' (None), not an error and not False."""
+    loader([build(None)], session)
+    session.commit()
+
+    items = client.get(f"/{prefix}/").json()
+    assert len(items) == 1
+    assert items[0]["active"] is None
+
+
+@pytest.mark.parametrize("prefix, loader, build", GEAR_TYPES, ids=IDS)
+def test_active_is_exposed_by_the_public_schema(client, session, prefix, loader, build):
+    """
+    `active` must be declared on the *Public response model, not merely stored.
+    A field present on the table but absent from the response schema would be
+    dropped silently on serialisation — the frontend reads this off the API.
+    """
+    loader([build(True)], session)
+    session.commit()
+
+    assert "active" in client.get(f"/{prefix}/").json()[0]
+
+
+# ---------------------------------------------------------------------------
+# Write path — PATCH must be able to flip lifecycle state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("prefix, loader, build", GEAR_TYPES, ids=IDS)
+def test_patch_can_flip_active(client, session, prefix, loader, build):
+    """Retiring or reinstating an item is a PATCH of one field."""
+    loader([build(True)], session)
+    session.commit()
+    item_id = client.get(f"/{prefix}/").json()[0]["id"]
+
+    assert client.patch(f"/{prefix}/{item_id}", json={"active": False}).json()["active"] is False
+    assert client.get(f"/{prefix}/{item_id}").json()["active"] is False
+
+    assert client.patch(f"/{prefix}/{item_id}", json={"active": True}).json()["active"] is True
+
+
+@pytest.mark.parametrize("prefix, loader, build", GEAR_TYPES, ids=IDS)
+def test_patch_of_another_field_leaves_active_alone(client, session, prefix, loader, build):
+    """
+    PATCH uses exclude_unset, so a partial update must not reset `active` to its
+    default. This is the regression that would quietly wipe lifecycle state
+    across the catalogue the first time anything else is edited.
+    """
+    loader([build(False)], session)
+    session.commit()
+    item_id = client.get(f"/{prefix}/").json()[0]["id"]
+
+    client.patch(f"/{prefix}/{item_id}", json={"notes": "unrelated edit"})
+
+    assert client.get(f"/{prefix}/{item_id}").json()["active"] is False

--- a/treepros.json
+++ b/treepros.json
@@ -14,7 +14,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Raed Slacklines"
+        "manufacturer": "Raed Slacklines",
+        "active": false
     },
     {
         "name": "Adjustable Tree Wear",
@@ -31,7 +32,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Bera Adventure"
+        "manufacturer": "Bera Adventure",
+        "active": true
     },
     {
         "name": "Tree-Shirt  L TreePro",
@@ -48,7 +50,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack house"
+        "manufacturer": "Slack house",
+        "active": true
     },
     {
         "name": "TreeHugger Classic",
@@ -65,7 +68,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Balance Community: Slackline Outfitters"
+        "manufacturer": "Balance Community: Slackline Outfitters",
+        "active": true
     },
     {
         "name": "TreeHugger Cosmic",
@@ -82,7 +86,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Balance Community: Slackline Outfitters"
+        "manufacturer": "Balance Community: Slackline Outfitters",
+        "active": false
     },
     {
         "name": "Breathe Tree Pro",
@@ -99,7 +104,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Balance Community: Slackline Outfitters"
+        "manufacturer": "Balance Community: Slackline Outfitters",
+        "active": false
     },
     {
         "name": "Tree-Shirt M TreePro",
@@ -116,7 +122,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack house"
+        "manufacturer": "Slack house",
+        "active": true
     },
     {
         "name": "Treepro XL",
@@ -133,7 +140,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Industries"
+        "manufacturer": "Slackline Industries",
+        "active": false
     },
     {
         "name": "Tree Pro",
@@ -150,7 +158,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Industries"
+        "manufacturer": "Slackline Industries",
+        "active": true
     },
     {
         "name": "Slackline Tree Protection Set",
@@ -167,7 +176,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "TreeProtection Set | V2",
@@ -184,7 +194,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Tree Protection | 3L",
@@ -201,7 +212,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Tree Protection XL",
@@ -218,7 +230,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Spider slacklines"
+        "manufacturer": "Spider slacklines",
+        "active": true
     },
     {
         "name": "Protect Abre Pillow",
@@ -235,7 +248,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack Mountain"
+        "manufacturer": "Slack Mountain",
+        "active": true
     },
     {
         "name": "Tree-Shirt S TreePro",
@@ -252,7 +266,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack house"
+        "manufacturer": "Slack house",
+        "active": true
     },
     {
         "name": "Tree-Guard Set",
@@ -269,7 +284,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "Baumschutz Basic",
@@ -286,7 +302,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Tree Pad",
@@ -303,7 +320,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Equilibrium Slacklines (EQB)"
+        "manufacturer": "Equilibrium Slacklines (EQB)",
+        "active": true
     },
     {
         "name": "Baumschutz Easy",
@@ -320,7 +338,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackstar"
+        "manufacturer": "Slackstar",
+        "active": false
     },
     {
         "name": "Tree Eco",
@@ -337,7 +356,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack.fr"
+        "manufacturer": "Slack.fr",
+        "active": false
     },
     {
         "name": "Tree Protection",
@@ -354,7 +374,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Spider slacklines"
+        "manufacturer": "Spider slacklines",
+        "active": true
     },
     {
         "name": "Treewear XL - Edition",
@@ -371,7 +392,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Gibbon"
+        "manufacturer": "Gibbon",
+        "active": true
     },
     {
         "name": "Treeskin",
@@ -388,6 +410,7 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Elephant"
+        "manufacturer": "Elephant",
+        "active": false
     }
 ]

--- a/tricklinekits.json
+++ b/tricklinekits.json
@@ -14,7 +14,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Middle Way Slacklines"
+        "manufacturer": "Middle Way Slacklines",
+        "active": false
     },
     {
         "name": "Level 1 Kit",
@@ -31,7 +32,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Rigging Ventures"
+        "manufacturer": "Rigging Ventures",
+        "active": false
     },
     {
         "name": "Level 2 Kit",
@@ -48,7 +50,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Rigging Ventures"
+        "manufacturer": "Rigging Ventures",
+        "active": false
     },
     {
         "name": "Level 3 Trickline kit",
@@ -65,7 +68,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Rigging Ventures"
+        "manufacturer": "Rigging Ventures",
+        "active": false
     },
     {
         "name": "Super Jumpline Slackline Set",
@@ -82,7 +86,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slacktivity"
+        "manufacturer": "Slacktivity",
+        "active": true
     },
     {
         "name": "Trickline Kit - Pro Line 25",
@@ -99,7 +104,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Spider slacklines"
+        "manufacturer": "Spider slacklines",
+        "active": true
     },
     {
         "name": "Kit Freestyle 22m - Andy Lewis X13",
@@ -116,7 +122,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slack.fr"
+        "manufacturer": "Slack.fr",
+        "active": false
     },
     {
         "name": "BOSS LINE KIT",
@@ -133,7 +140,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline Industries"
+        "manufacturer": "Slackline Industries",
+        "active": true
     },
     {
         "name": "25 m Air n Jump Set",
@@ -150,7 +158,8 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Slackline tools"
+        "manufacturer": "Slackline tools",
+        "active": false
     },
     {
         "name": "Level Two Kit",
@@ -167,6 +176,7 @@
         "description": null,
         "version": null,
         "notes": null,
-        "manufacturer": "Rigging Ventures"
+        "manufacturer": "Rigging Ventures",
+        "active": false
     }
 ]

--- a/webbings.json
+++ b/webbings.json
@@ -62,7 +62,8 @@
         "width": 25,
         "thickness": 3.5,
         "webbing_construction": "Core/Sheath",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Core 2 LS",
@@ -127,7 +128,8 @@
         "width": 25,
         "thickness": 3.2,
         "webbing_construction": "Core/Sheath",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Core 1",
@@ -192,7 +194,8 @@
         "width": 25,
         "thickness": 3.9,
         "webbing_construction": "Core/Sheath",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "T-Wave",
@@ -265,7 +268,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 3.33,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Sonic 2",
@@ -429,7 +433,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "White Magic",
@@ -501,7 +506,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Unicorn",
@@ -570,7 +576,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.79,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Wizard",
@@ -643,7 +650,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.79,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Aero 1",
@@ -742,7 +750,8 @@
         "width": 25,
         "thickness": 2.5,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Aero 2",
@@ -843,7 +852,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.96,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Feather",
@@ -904,7 +914,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.61,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Feather Pro",
@@ -1005,7 +1016,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.36,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Mantra MK1",
@@ -1101,7 +1113,8 @@
         "breakingStrength": 42,
         "date_introduced": null,
         "product_url": "https://www.balancecommunity.com/products/mantra-mk1",
-        "width": 25
+        "width": 25,
+        "active": false
     },
     {
         "name": "Mantra MK2",
@@ -1197,7 +1210,8 @@
         "breakingStrength": 42,
         "date_introduced": null,
         "product_url": "https://www.balancecommunity.com/products/mantra-mk2",
-        "width": 25
+        "width": 25,
+        "active": false
     },
     {
         "name": "Mantra MK3",
@@ -1280,7 +1294,8 @@
         "product_url": "https://www.balancecommunity.com/products/mantra-mk3",
         "thickness": 4.1,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Mantra MK4 Flight",
@@ -1381,7 +1396,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.46,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "type-18 MK1",
@@ -1450,7 +1466,8 @@
         "date_introduced": null,
         "product_url": null,
         "width": 25,
-        "webbing_construction": "Flat"
+        "webbing_construction": "Flat",
+        "active": false
     },
     {
         "name": "Type 18 MKII",
@@ -1515,7 +1532,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.5,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Lift",
@@ -1616,7 +1634,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.46,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Spider Silk MK2",
@@ -1717,7 +1736,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 9.68,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Maverick",
@@ -1745,7 +1765,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.4,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Moonwalk",
@@ -1786,7 +1807,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 3.2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "McFly",
@@ -1819,7 +1841,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.29,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Bluewing",
@@ -1919,7 +1942,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Passion Red",
@@ -1980,7 +2004,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 3,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "SlackPro 42kN",
@@ -2063,7 +2088,8 @@
         "product_url": "http://www.slackpro.de/en/products/2542slackline.shtml",
         "thickness": 2.7,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Neon ",
@@ -2192,7 +2218,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Sigma X",
@@ -2256,7 +2283,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Sigma Impact",
@@ -2317,7 +2345,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.05,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Sigma LG",
@@ -2366,7 +2395,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.05,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Dragon",
@@ -2407,7 +2437,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 33,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "Sumo",
@@ -2448,7 +2479,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 39,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": false
     },
     {
         "name": "Bounce",
@@ -2485,7 +2517,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 25,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "Flash",
@@ -2524,7 +2557,8 @@
         "width": 25,
         "thickness": 2.5,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Element",
@@ -2561,7 +2595,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 29,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "Skye",
@@ -2630,7 +2665,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 45,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": false
     },
     {
         "name": "Fresh",
@@ -2671,7 +2707,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 42,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "eLine",
@@ -2701,7 +2738,8 @@
         "product_url": "https://yogaslackers.com/shop/slackline/eline-webbing/",
         "width": 25.4,
         "thickness": 2.08,
-        "webbing_construction": "Tubular"
+        "webbing_construction": "Tubular",
+        "active": true
     },
     {
         "name": "Cobalt",
@@ -2738,7 +2776,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Windu",
@@ -2775,7 +2814,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.33,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Snake Tub",
@@ -2808,7 +2848,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.5,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Diablo2",
@@ -2845,7 +2886,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Goku 2",
@@ -2885,7 +2927,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.66,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Artic Fox",
@@ -2918,7 +2961,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Flax",
@@ -2947,7 +2991,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.5,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "morpheus",
@@ -2984,7 +3029,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "spectre",
@@ -3021,7 +3067,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.66,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "rubalise",
@@ -3050,7 +3097,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.39,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "wallaby",
@@ -3079,7 +3127,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Storm",
@@ -3108,7 +3157,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "plum",
@@ -3137,7 +3187,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.67,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Cosmic",
@@ -3217,7 +3268,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.6,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Donkey",
@@ -3253,7 +3305,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.9,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Nova",
@@ -3289,7 +3342,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.7,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Mammut",
@@ -3386,7 +3440,8 @@
         "width": 25.8,
         "thickness": 4.2,
         "webbing_construction": "Core/Sheath",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Rainbow",
@@ -3470,7 +3525,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.65,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Parsec",
@@ -3570,7 +3626,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "MOTM",
@@ -3670,7 +3727,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Helium",
@@ -3774,7 +3832,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.69,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Cumulus",
@@ -3854,7 +3913,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "pinkTube",
@@ -3970,7 +4030,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": true,
         "priceMeter": 1.83,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "redTube",
@@ -4138,7 +4199,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": true,
         "priceMeter": 2.5,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Marathon",
@@ -4302,7 +4364,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.8,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Marathon Play",
@@ -4466,7 +4529,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.9,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Half-Marathon",
@@ -4599,7 +4663,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 2.7,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Raven",
@@ -4684,7 +4749,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.85,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Milky Way",
@@ -4832,7 +4898,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Tender",
@@ -4901,7 +4968,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.1,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Fly",
@@ -4969,7 +5037,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.37,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Zao",
@@ -5038,7 +5107,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.4,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Edge",
@@ -5107,7 +5177,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.48,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Jumbo",
@@ -5176,7 +5247,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.89,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Nylove",
@@ -5245,7 +5317,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.6,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Y2k",
@@ -5269,7 +5342,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.6,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Ribera",
@@ -5282,7 +5356,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Bloodline",
@@ -5300,7 +5375,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Tape",
@@ -5317,7 +5393,8 @@
         "date_introduced": null,
         "product_url": "http://www.singingrock.com/slackline-webbing-yellowblack",
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": true
     },
     {
         "name": "Ninja",
@@ -5337,7 +5414,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 45,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": false
     },
     {
         "name": "Nitro",
@@ -5357,7 +5435,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 55.6,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": false
     },
     {
         "name": "Slim Green",
@@ -5378,7 +5457,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 18,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "Chartreuse",
@@ -5396,7 +5476,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Dibona",
@@ -5414,7 +5495,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Elia",
@@ -5432,7 +5514,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Etna II",
@@ -5450,7 +5533,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Fuji",
@@ -5468,7 +5552,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Krakatoa",
@@ -5481,7 +5566,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Mauna Kea",
@@ -5499,7 +5585,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Pierra Menta",
@@ -5517,7 +5604,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Vercors",
@@ -5535,7 +5623,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Vesuve",
@@ -5553,7 +5642,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Sat'Elite",
@@ -5568,7 +5658,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.72,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Red Zebra",
@@ -5588,7 +5679,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.19,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Slack Swan",
@@ -5606,7 +5698,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Flamme II",
@@ -5624,7 +5717,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Emeraude",
@@ -5639,7 +5733,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Goku",
@@ -5661,7 +5756,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Club S",
@@ -5681,7 +5777,8 @@
         "webbing_construction": "Threaded Tubular",
         "isa_certified": false,
         "priceMeter": 2.06,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Dark Blue",
@@ -5701,7 +5798,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.96,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "MILF",
@@ -5722,7 +5820,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.15,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Neon Light",
@@ -5741,7 +5840,8 @@
         "product_url": null,
         "thickness": 2.4,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "SuperFL Kill Bill",
@@ -5762,7 +5862,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.7,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Supertube Norway",
@@ -5783,7 +5884,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.24,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Jumpline",
@@ -5802,7 +5904,8 @@
         "product_url": null,
         "thickness": 2,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Jumpline Pro Series",
@@ -5823,7 +5926,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.75,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Jumpline AntiPop",
@@ -5844,7 +5948,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.72,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Flash'line",
@@ -5864,7 +5969,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.35,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "EcoLine",
@@ -5884,7 +5990,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.95,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Wing 3.5",
@@ -5902,7 +6009,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Skillshot HS",
@@ -5921,7 +6029,8 @@
         "product_url": null,
         "thickness": 3.1,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Skillshot LS",
@@ -5940,7 +6049,8 @@
         "product_url": null,
         "thickness": 2.5,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Flow Line",
@@ -5958,7 +6068,8 @@
         "date_introduced": null,
         "product_url": "http://www.gibbon-slacklines.com/en/products/longline-modules/flowline/index.html",
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Tube Line",
@@ -5971,7 +6082,8 @@
         "date_introduced": null,
         "product_url": "https://www.fitshop.fr/en/gibbon-tube-line-set-gib-13895",
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": true
     },
     {
         "name": "Verve 35mm",
@@ -5989,7 +6101,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Matrix",
@@ -6010,7 +6123,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 3.95,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Matrix Outer",
@@ -6028,7 +6142,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Wave Tube",
@@ -6049,7 +6164,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.69,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Wave Tape 19",
@@ -6070,7 +6186,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.35,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Wave Tube 19",
@@ -6091,7 +6208,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.35,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Sigma Impact LS",
@@ -6112,7 +6230,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.9,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Strong II",
@@ -6132,7 +6251,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Octopussy MKV",
@@ -6153,7 +6273,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 3.66,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": true
     },
     {
         "name": "Rubber Band MKIII BLU",
@@ -6174,7 +6295,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.47,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": true
     },
     {
         "name": "Rubber Band MKIII SOL",
@@ -6195,7 +6317,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.47,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": true
     },
     {
         "name": "Blue Mile",
@@ -6216,7 +6339,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.5,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": false
     },
     {
         "name": "Sin Más",
@@ -6236,7 +6360,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.95,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Black-White",
@@ -6256,7 +6381,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Slack-Spec Tubelar",
@@ -6271,7 +6397,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.38,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Slack-Spec 11/16\"",
@@ -6286,7 +6413,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.18,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Slack-Spec Threaded Tubular",
@@ -6304,7 +6432,8 @@
         "date_introduced": null,
         "product_url": null,
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Spider Silk 7/8\"",
@@ -6323,7 +6452,8 @@
         "product_url": null,
         "thickness": 2.8,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "RAGEline",
@@ -6345,7 +6475,8 @@
         "date_introduced": null,
         "product_url": "http://www.balancecommunity.com/rageline",
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "CoreTek",
@@ -6366,7 +6497,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Sugoi",
@@ -6387,7 +6519,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Great White",
@@ -6408,7 +6541,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 14,
-        "currency": "ZAR"
+        "currency": "ZAR",
+        "active": true
     },
     {
         "name": "Tantalus",
@@ -6429,7 +6563,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.6,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "Sky Pilot (Green/Orange)",
@@ -6448,7 +6583,8 @@
         "product_url": null,
         "thickness": 3,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "HighTech",
@@ -6467,7 +6603,8 @@
         "product_url": null,
         "thickness": 3,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Type 18 CG4",
@@ -6488,7 +6625,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Rasta Tubelar",
@@ -6504,7 +6642,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.38,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Chi",
@@ -6525,7 +6664,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 6,
-        "currency": "ILS"
+        "currency": "ILS",
+        "active": true
     },
     {
         "name": "Zen",
@@ -6546,7 +6686,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 9,
-        "currency": "ILS"
+        "currency": "ILS",
+        "active": false
     },
     {
         "name": "Flat",
@@ -6567,7 +6708,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.98,
-        "currency": "NZD"
+        "currency": "NZD",
+        "active": true
     },
     {
         "name": "Sky Pilot (Black/White)",
@@ -6587,7 +6729,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.2,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "Lion Line",
@@ -6602,7 +6745,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 8.99,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "Tube #1",
@@ -6617,7 +6761,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.7,
-        "currency": "NZD"
+        "currency": "NZD",
+        "active": true
     },
     {
         "name": "Mirage",
@@ -6638,7 +6783,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.8,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "Alfa",
@@ -6659,7 +6805,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "Mamba",
@@ -6680,7 +6827,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.59,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Flamme III",
@@ -6700,7 +6848,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Abysses",
@@ -6720,7 +6869,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Verve 25mm",
@@ -6741,7 +6891,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.33,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Wave Tube  32",
@@ -6762,7 +6913,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.95,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "#FFF",
@@ -6782,7 +6934,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.89,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Neon Light",
@@ -6801,7 +6954,8 @@
         "product_url": null,
         "thickness": 2.4,
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "Reggae",
@@ -6822,7 +6976,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.24,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "RVD",
@@ -6843,7 +6998,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.24,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Low stretch Webbing",
@@ -6863,7 +7019,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.79,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "SuperMOTM",
@@ -6883,7 +7040,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 3.29,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Plasma",
@@ -6903,7 +7061,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Firefly (phosphorescent)",
@@ -6927,7 +7086,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.79,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "French Line",
@@ -6948,7 +7108,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.34,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Pop-Art",
@@ -6964,7 +7125,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.4,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Project 44",
@@ -6985,7 +7147,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.65,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Aloha (Aka Aki Tidal)",
@@ -7006,7 +7169,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.19,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Panda",
@@ -7031,7 +7195,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.59,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Joker",
@@ -7055,7 +7220,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Y.a.w",
@@ -7075,7 +7241,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.59,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Coelum",
@@ -7096,7 +7263,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.65,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Skyway",
@@ -7117,7 +7285,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.53,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Totally Tubular",
@@ -7132,7 +7301,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.55,
-        "currency": "CAD"
+        "currency": "CAD",
+        "active": false
     },
     {
         "name": "FIREFOX",
@@ -7153,7 +7323,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.5,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Spice",
@@ -7174,7 +7345,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.1,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Orange",
@@ -7194,7 +7366,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 47.53,
-        "currency": "RUB"
+        "currency": "RUB",
+        "active": false
     },
     {
         "name": "S.O.S - Sunset Over Seas",
@@ -7219,7 +7392,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 3.2,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Blue",
@@ -7284,7 +7458,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.2,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Green",
@@ -7349,7 +7524,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.4,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Polar",
@@ -7370,7 +7546,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.89,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Jybn",
@@ -7391,7 +7568,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.8,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "SuperTape 19mm",
@@ -7404,7 +7582,8 @@
         "date_introduced": null,
         "product_url": "https://www.edelrid.de/en/sports/flat-webbings1/flachband-supertape-19mm.html",
         "webbing_construction": "Flat",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "X-Tuble 16mm",
@@ -7417,7 +7596,8 @@
         "date_introduced": null,
         "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-16mm.html",
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": false
     },
     {
         "name": "X-Tube 25mm",
@@ -7435,7 +7615,8 @@
         "date_introduced": null,
         "product_url": "https://www.edelrid.de/en/sports/tubular-webbings/x-tube-25mm.html",
         "webbing_construction": "Tubular",
-        "isa_certified": false
+        "isa_certified": false,
+        "active": true
     },
     {
         "name": "Abysses Bounce",
@@ -7455,7 +7636,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.6,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Photon",
@@ -7475,7 +7657,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.96,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Rubber Band PUR",
@@ -7496,7 +7679,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.47,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": true
     },
     {
         "name": "Levitation",
@@ -7517,7 +7701,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.93,
-        "currency": "PLN"
+        "currency": "PLN",
+        "active": true
     },
     {
         "name": "MOTM light",
@@ -7532,7 +7717,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 1.49,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Ocean",
@@ -7553,7 +7739,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.74,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Skye2",
@@ -7574,7 +7761,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.84,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "LSDTube",
@@ -7594,7 +7782,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.65,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Spider Silk MK3",
@@ -7663,7 +7852,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.2,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Dyneemite",
@@ -7687,7 +7877,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Aurora",
@@ -7707,7 +7898,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.99,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "ReBL",
@@ -7723,7 +7915,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.05,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Zen 2",
@@ -7743,7 +7936,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 6.9,
-        "currency": "ILS"
+        "currency": "ILS",
+        "active": true
     },
     {
         "name": "Lift 2be",
@@ -7808,7 +8002,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.45,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Candy",
@@ -7829,7 +8024,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.61,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Eclipse",
@@ -7850,7 +8046,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 0.69,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Jelly",
@@ -7915,7 +8112,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Blue 20",
@@ -7936,7 +8134,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Green 20",
@@ -8001,7 +8200,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 2.4,
-        "currency": "USD"
+        "currency": "USD",
+        "active": true
     },
     {
         "name": "Green Magic",
@@ -8022,7 +8222,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 6,
-        "currency": "ILS"
+        "currency": "ILS",
+        "active": true
     },
     {
         "name": "Purple Gold",
@@ -8043,7 +8244,8 @@
         "webbing_construction": "Tubular",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Nomad",
@@ -8064,7 +8266,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Sonic Light",
@@ -8085,7 +8288,8 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 2.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Sky Diamond",
@@ -8106,7 +8310,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 4.97,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": true
     },
     {
         "name": "Rodeo",
@@ -8127,7 +8332,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.62,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Heavy",
@@ -8192,7 +8398,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 3.5,
-        "currency": "USD"
+        "currency": "USD",
+        "active": false
     },
     {
         "name": "Neon",
@@ -8213,7 +8420,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 27,
-        "currency": "CZK"
+        "currency": "CZK",
+        "active": true
     },
     {
         "name": "White Magic",
@@ -8234,7 +8442,8 @@
         "webbing_construction": "Flat",
         "isa_certified": false,
         "priceMeter": 1.3,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     },
     {
         "name": "Unicorn",
@@ -8255,6 +8464,7 @@
         "webbing_construction": "Core/Sheath",
         "isa_certified": false,
         "priceMeter": 1.79,
-        "currency": "EUR"
+        "currency": "EUR",
+        "active": false
     }
 ]

--- a/weblocks.json
+++ b/weblocks.json
@@ -46,7 +46,8 @@
         },
         "date_introduced": 1506117600000,
         "name": "Aeris P Weblock",
-        "product_url": "https://petramslacklines.site123.me/shop-1/aeris-p-weblock-2"
+        "product_url": "https://petramslacklines.site123.me/shop-1/aeris-p-weblock-2",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3040",
@@ -95,7 +96,8 @@
         },
         "date_introduced": 1506117600000,
         "name": "Aeris Weblock",
-        "product_url": "https://petramslacklines.site123.me/shop-1/aeris-weblock-2"
+        "product_url": "https://petramslacklines.site123.me/shop-1/aeris-weblock-2",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/533",
@@ -140,7 +142,8 @@
         },
         "date_introduced": null,
         "name": "Alpine WebLock 4.0",
-        "product_url": "https://www.balancecommunity.com/blogs/slack-science/tagged/alpine-weblock-4-0"
+        "product_url": "https://www.balancecommunity.com/blogs/slack-science/tagged/alpine-weblock-4-0",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3089",
@@ -182,7 +185,8 @@
         },
         "date_introduced": 1579816800000,
         "name": "Alpine WebLock 5.0",
-        "product_url": "https://www.balancecommunity.com/products/alpine-weblock-5"
+        "product_url": "https://www.balancecommunity.com/products/alpine-weblock-5",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3255",
@@ -221,7 +225,8 @@
         },
         "date_introduced": null,
         "name": "Alpine WebLock 6.1",
-        "product_url": "https://www.balancecommunity.com/collections/webbing-anchors/products/alpine-weblock-6-0"
+        "product_url": "https://www.balancecommunity.com/collections/webbing-anchors/products/alpine-weblock-6-0",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3256",
@@ -260,7 +265,8 @@
         },
         "date_introduced": null,
         "name": "Alpine WebLock 6.1 20mm",
-        "product_url": "https://www.balancecommunity.com/collections/webbing-anchors/products/alpine-weblock-6-0"
+        "product_url": "https://www.balancecommunity.com/collections/webbing-anchors/products/alpine-weblock-6-0",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/537",
@@ -305,7 +311,8 @@
         },
         "date_introduced": null,
         "name": "BaboonLock",
-        "product_url": "http://www.slackgear.co.za/product/baboonlock/"
+        "product_url": "http://www.slackgear.co.za/product/baboonlock/",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/526",
@@ -336,7 +343,8 @@
         },
         "date_introduced": null,
         "name": "Banana",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/544",
@@ -382,7 +390,8 @@
         },
         "date_introduced": null,
         "name": "BANANA! 2.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3117",
@@ -424,7 +433,8 @@
         },
         "date_introduced": null,
         "name": "BANANA! 3.0 SR",
-        "product_url": "https://slackhouseshop.pl/en/produkt/banana-3-0-sr/"
+        "product_url": "https://slackhouseshop.pl/en/produkt/banana-3-0-sr/",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3118",
@@ -466,7 +476,8 @@
         },
         "date_introduced": null,
         "name": "BANANA! 3.1",
-        "product_url": "https://slackhouseshop.pl/en/produkt/banana-3-1-weblock/"
+        "product_url": "https://slackhouseshop.pl/en/produkt/banana-3-1-weblock/",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/502",
@@ -508,7 +519,8 @@
         },
         "date_introduced": null,
         "name": "Bandit FX",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/500",
@@ -548,7 +560,8 @@
         },
         "date_introduced": null,
         "name": "Bandit SH",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/524",
@@ -585,7 +598,8 @@
         },
         "date_introduced": null,
         "name": "Bandit SH",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/501",
@@ -625,7 +639,8 @@
         },
         "date_introduced": null,
         "name": "Bandit SL",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/525",
@@ -662,7 +677,8 @@
         },
         "date_introduced": null,
         "name": "Bandit SL",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/548",
@@ -709,7 +725,8 @@
         },
         "date_introduced": null,
         "name": "Beast 1.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/556",
@@ -751,7 +768,8 @@
         },
         "date_introduced": null,
         "name": "Campo weblock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/505",
@@ -795,7 +813,8 @@
         },
         "date_introduced": null,
         "name": "Canon FX",
-        "product_url": "https://www.slackshop.cz/en/weblocks/24-eqb-canon-fx.html"
+        "product_url": "https://www.slackshop.cz/en/weblocks/24-eqb-canon-fx.html",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/503",
@@ -834,7 +853,8 @@
         },
         "date_introduced": null,
         "name": "Canon SH",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/504",
@@ -882,7 +902,8 @@
         },
         "date_introduced": null,
         "name": "Canon SL",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/551",
@@ -929,7 +950,8 @@
         },
         "date_introduced": null,
         "name": "Catlock classic",
-        "product_url": "https://catonslack.com/product/35390452-slackline-weblock-catlock-classic"
+        "product_url": "https://catonslack.com/product/35390452-slackline-weblock-catlock-classic",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/553",
@@ -979,7 +1001,8 @@
         },
         "date_introduced": null,
         "name": "Catlock mini",
-        "product_url": "https://catonslack.com/product/34629326-slackline-weblock-catlock-mini"
+        "product_url": "https://catonslack.com/product/34629326-slackline-weblock-catlock-mini",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/552",
@@ -1025,7 +1048,8 @@
         },
         "date_introduced": 1519858800000,
         "name": "Catlock Pro",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/550",
@@ -1070,7 +1094,8 @@
         },
         "date_introduced": null,
         "name": "Catlock SR",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/563",
@@ -1117,7 +1142,8 @@
         },
         "date_introduced": null,
         "name": "Catlock SR PRO",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/523",
@@ -1148,7 +1174,8 @@
         },
         "date_introduced": null,
         "name": "Chili",
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/549",
@@ -1196,7 +1223,8 @@
         },
         "date_introduced": null,
         "name": "CHILI 2.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/543",
@@ -1232,7 +1260,8 @@
         },
         "date_introduced": null,
         "name": "Constat weblock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/512",
@@ -1269,7 +1298,8 @@
         },
         "date_introduced": null,
         "name": "Direct",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/522",
@@ -1311,7 +1341,8 @@
         },
         "date_introduced": null,
         "name": "Dreamcatcher",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/519",
@@ -1342,7 +1373,8 @@
         },
         "date_introduced": null,
         "name": "Easylock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/520",
@@ -1386,7 +1418,8 @@
         },
         "date_introduced": null,
         "name": "Equilocker",
-        "product_url": "http://www.slackliner.de/Verbindungselemente/Linelocker/Equilocker.html"
+        "product_url": "http://www.slackliner.de/Verbindungselemente/Linelocker/Equilocker.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/558",
@@ -1422,7 +1455,8 @@
         },
         "date_introduced": null,
         "name": "Fortis weblock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/542",
@@ -1476,7 +1510,8 @@
         },
         "date_introduced": null,
         "name": "Frog",
-        "product_url": "https://slack-mountain.com/en/webbing-anchor/231-4047-frogx.html"
+        "product_url": "https://slack-mountain.com/en/webbing-anchor/231-4047-frogx.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/528",
@@ -1526,7 +1561,8 @@
         },
         "date_introduced": null,
         "name": "Ginkgo",
-        "product_url": "https://slack-mountain.com/en/tricklines/166-paire-de-ginkgo-745-l-unite.html"
+        "product_url": "https://slack-mountain.com/en/tricklines/166-paire-de-ginkgo-745-l-unite.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3071",
@@ -1565,7 +1601,8 @@
         },
         "date_introduced": null,
         "name": "Ginkgo Mini",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3019",
@@ -1601,7 +1638,8 @@
         },
         "date_introduced": null,
         "name": "Ginkgo Quickpin",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/506",
@@ -1637,7 +1675,8 @@
         },
         "date_introduced": null,
         "name": "Katana",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/507",
@@ -1676,7 +1715,8 @@
         },
         "date_introduced": null,
         "name": "Katana FX",
-        "product_url": "https://www.slackshop.cz/en/weblocks/27-eqb-katana-fx.html"
+        "product_url": "https://www.slackshop.cz/en/weblocks/27-eqb-katana-fx.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3252",
@@ -1714,7 +1754,8 @@
         },
         "date_introduced": null,
         "name": "KingPin",
-        "product_url": "https://slacktivity.com/shop/kingpin-weblock/"
+        "product_url": "https://slacktivity.com/shop/kingpin-weblock/",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/561",
@@ -1765,7 +1806,8 @@
         },
         "date_introduced": null,
         "name": "Lime",
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/540",
@@ -1814,7 +1856,8 @@
         },
         "date_introduced": null,
         "name": "LineLock AL MK4",
-        "product_url": "https://www.linegrip.com/shop/slackpro-linelock-al/"
+        "product_url": "https://www.linegrip.com/shop/slackpro-linelock-al/",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3041",
@@ -1856,7 +1899,8 @@
         },
         "date_introduced": 1506805200000,
         "name": "LineLock mini",
-        "product_url": "https://krok.biz/slackline/layn-lok-mini"
+        "product_url": "https://krok.biz/slackline/layn-lok-mini",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/541",
@@ -1902,7 +1946,8 @@
         },
         "date_introduced": null,
         "name": "LineLock VA MKIII",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3135",
@@ -1941,7 +1986,8 @@
         },
         "date_introduced": null,
         "name": "Linelocker",
-        "product_url": "https://www.slackshop.cz/cs/kotvitka/132-linelocker.html"
+        "product_url": "https://www.slackshop.cz/cs/kotvitka/132-linelocker.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/555",
@@ -1972,7 +2018,8 @@
         },
         "date_introduced": null,
         "name": "LINK",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3024",
@@ -2012,7 +2059,8 @@
         },
         "date_introduced": 1262300400000,
         "name": "Lynx 1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3023",
@@ -2046,7 +2094,8 @@
         },
         "date_introduced": 1293836400000,
         "name": "Lynx 2.1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/514",
@@ -2083,7 +2132,8 @@
         },
         "date_introduced": null,
         "name": "Lynx 3.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/515",
@@ -2125,7 +2175,8 @@
         },
         "date_introduced": null,
         "name": "Lynx 4.0 SH",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/516",
@@ -2169,7 +2220,8 @@
         },
         "date_introduced": null,
         "name": "Lynx 4.0 Vari",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3249",
@@ -2207,7 +2259,8 @@
         },
         "date_introduced": 1626901200000,
         "name": "Lynx 5",
-        "product_url": "https://aki-slacklines.de/en/hardware/weblocks/203/aki-lynx-5-webbing-locker"
+        "product_url": "https://aki-slacklines.de/en/hardware/weblocks/203/aki-lynx-5-webbing-locker",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3065",
@@ -2252,7 +2305,8 @@
         },
         "date_introduced": null,
         "name": "Mint",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3085",
@@ -2295,7 +2349,8 @@
         },
         "date_introduced": null,
         "name": "Mithril - Pull Pin",
-        "product_url": "https://www.slackshop.cz/en/weblocks/145-349-eqb-mithril.html#/164-pin_version-pull_pin"
+        "product_url": "https://www.slackshop.cz/en/weblocks/145-349-eqb-mithril.html#/164-pin_version-pull_pin",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3079",
@@ -2338,7 +2393,8 @@
         },
         "date_introduced": null,
         "name": "Mithril - Quick Pin",
-        "product_url": "https://www.slackshop.cz/en/weblocks/145-350-eqb-mithril.html#/165-pin_version-quick_pin"
+        "product_url": "https://www.slackshop.cz/en/weblocks/145-350-eqb-mithril.html#/165-pin_version-quick_pin",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3081",
@@ -2369,7 +2425,8 @@
         },
         "date_introduced": 1558904400000,
         "name": "MultiLock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3251",
@@ -2412,7 +2469,8 @@
         },
         "date_introduced": null,
         "name": "Orange",
-        "product_url": "https://www.radrigs.co.uk/product-page/orange"
+        "product_url": "https://www.radrigs.co.uk/product-page/orange",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/510",
@@ -2451,7 +2509,8 @@
         },
         "date_introduced": null,
         "name": "Paddle FX",
-        "product_url": "https://www.slackshop.cz/en/weblocks/25-eqb-paddle-fx.html"
+        "product_url": "https://www.slackshop.cz/en/weblocks/25-eqb-paddle-fx.html",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/560",
@@ -2487,7 +2546,8 @@
         },
         "date_introduced": null,
         "name": "Paddle Linelock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/509",
@@ -2529,7 +2589,8 @@
         },
         "date_introduced": null,
         "name": "Paddle SH",
-        "product_url": "http://www.slackshop.cz/en/lockers/83-eqb-paddle.html"
+        "product_url": "http://www.slackshop.cz/en/lockers/83-eqb-paddle.html",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/508",
@@ -2569,7 +2630,8 @@
         },
         "date_introduced": null,
         "name": "Paddle SL",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3133",
@@ -2612,7 +2674,8 @@
         },
         "date_introduced": null,
         "name": "Pirat PP",
-        "product_url": "https://www.slackshop.cz/en/weblocks/155-369-eqb-pirat.html#/164-pin_version-pull_pin"
+        "product_url": "https://www.slackshop.cz/en/weblocks/155-369-eqb-pirat.html#/164-pin_version-pull_pin",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3134",
@@ -2655,7 +2718,8 @@
         },
         "date_introduced": null,
         "name": "Pirat QP",
-        "product_url": "https://www.slackshop.cz/en/weblocks/155-368-eqb-pirat.html#/165-pin_version-quick_pin"
+        "product_url": "https://www.slackshop.cz/en/weblocks/155-368-eqb-pirat.html#/165-pin_version-quick_pin",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/554",
@@ -2706,7 +2770,8 @@
         },
         "date_introduced": null,
         "name": "PRO Weblock",
-        "product_url": "https://raed-slacklines.com/pro-weblock"
+        "product_url": "https://raed-slacklines.com/pro-weblock",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/517",
@@ -2748,7 +2813,8 @@
         },
         "date_introduced": null,
         "name": "Puma 2.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/547",
@@ -2791,7 +2857,8 @@
         },
         "date_introduced": 1475971200000,
         "name": "PureLock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/534",
@@ -2830,7 +2897,8 @@
         },
         "date_introduced": null,
         "name": "RAGElock",
-        "product_url": "http://www.balancecommunity.com/ragelock"
+        "product_url": "http://www.balancecommunity.com/ragelock",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/535",
@@ -2875,7 +2943,8 @@
         },
         "date_introduced": null,
         "name": "RamLock",
-        "product_url": "https://www.slacklinetechnology.com/shop/ramlock-slackline-anchor"
+        "product_url": "https://www.slacklinetechnology.com/shop/ramlock-slackline-anchor",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/527",
@@ -2920,7 +2989,8 @@
         },
         "date_introduced": null,
         "name": "Rhino",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3046",
@@ -2970,7 +3040,8 @@
         },
         "date_introduced": 1512946800000,
         "name": "Rhino Minion",
-        "product_url": "https://slack-mountain.com/fr/bloqueur-longline-highline/190-rhino-minion.html"
+        "product_url": "https://slack-mountain.com/fr/bloqueur-longline-highline/190-rhino-minion.html",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/536",
@@ -3012,7 +3083,8 @@
         },
         "date_introduced": null,
         "name": "RhinoLock",
-        "product_url": "http://www.slackgear.co.za/product/rhinolock/"
+        "product_url": "http://www.slackgear.co.za/product/rhinolock/",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3047",
@@ -3048,7 +3120,8 @@
         },
         "date_introduced": 1513720800000,
         "name": "RODEO weblock",
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3248",
@@ -3086,7 +3159,8 @@
         },
         "date_introduced": 1513720800000,
         "name": "RODEO weblock",
-        "product_url": null
+        "product_url": null,
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3070",
@@ -3126,7 +3200,8 @@
         },
         "date_introduced": null,
         "name": "Rowan 1.0 (31mm)",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3057",
@@ -3163,7 +3238,8 @@
         },
         "date_introduced": 1533189600000,
         "name": "Rowan 1.0 Captive pin",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3058",
@@ -3203,7 +3279,8 @@
         },
         "date_introduced": 1533189600000,
         "name": "Rowan 1.0 Captive Pin Light",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3059",
@@ -3240,7 +3317,8 @@
         },
         "date_introduced": 1533189600000,
         "name": "Rowan 1.1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3060",
@@ -3280,7 +3358,8 @@
         },
         "date_introduced": 1533189600000,
         "name": "Rowan 1.3",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3106",
@@ -3317,7 +3396,8 @@
         },
         "date_introduced": null,
         "name": "Rowan 3.1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3107",
@@ -3354,7 +3434,8 @@
         },
         "date_introduced": null,
         "name": "Rowan 3.1T",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3108",
@@ -3391,7 +3472,8 @@
         },
         "date_introduced": null,
         "name": "Rowan 3.2",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3109",
@@ -3428,7 +3510,8 @@
         },
         "date_introduced": null,
         "name": "Rowan 3.3",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/545",
@@ -3470,7 +3553,8 @@
         },
         "date_introduced": null,
         "name": "SeaHorse DP 1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/546",
@@ -3513,7 +3597,8 @@
         },
         "date_introduced": null,
         "name": "SeaHorse DP 1.5",
-        "product_url": "https://slacktivity.com/shop/slacktivity-seahorse/"
+        "product_url": "https://slacktivity.com/shop/slacktivity-seahorse/",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3154",
@@ -3556,7 +3641,8 @@
         },
         "date_introduced": null,
         "name": "SeaHorse Sling 1",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/511",
@@ -3602,7 +3688,8 @@
         },
         "date_introduced": null,
         "name": "Sherriff",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/562",
@@ -3645,7 +3732,8 @@
         },
         "date_introduced": null,
         "name": "Sherriff FX",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/532",
@@ -3676,7 +3764,8 @@
         },
         "date_introduced": null,
         "name": "SlackDuck",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/531",
@@ -3707,7 +3796,8 @@
         },
         "date_introduced": null,
         "name": "SlackDuck-DP",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/538",
@@ -3751,7 +3841,8 @@
         },
         "date_introduced": null,
         "name": "Slackibloc 3.1",
-        "product_url": "https://slack-inov.com/gb/gear/95-slackiblock-31"
+        "product_url": "https://slack-inov.com/gb/gear/95-slackiblock-31",
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3012",
@@ -3793,7 +3884,8 @@
         },
         "date_introduced": null,
         "name": "Slackibloc 4",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/539",
@@ -3829,7 +3921,8 @@
         },
         "date_introduced": null,
         "name": "Slackibloc Jump 1.2",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3152",
@@ -3865,7 +3958,8 @@
         },
         "date_introduced": null,
         "name": "Slackibloc SR Pull pin",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3153",
@@ -3901,7 +3995,8 @@
         },
         "date_introduced": null,
         "name": "Slackibloc SR Quick Pin",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3069",
@@ -3937,7 +4032,8 @@
         },
         "date_introduced": 1531947600000,
         "name": "Slackijump",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/529",
@@ -3982,7 +4078,8 @@
         },
         "date_introduced": null,
         "name": "SladLock Power",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/557",
@@ -4024,7 +4121,8 @@
         },
         "date_introduced": null,
         "name": "Solveris weblock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3018",
@@ -4069,7 +4167,8 @@
         },
         "date_introduced": null,
         "name": "Spatium weblock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/530",
@@ -4100,7 +4199,8 @@
         },
         "date_introduced": null,
         "name": "Spirit Lock",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/521",
@@ -4136,7 +4236,8 @@
         },
         "date_introduced": null,
         "name": "T-Rig",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3253",
@@ -4174,7 +4275,8 @@
         },
         "date_introduced": null,
         "name": "TiLock 19mm",
-        "product_url": "https://raed-slacklines.com/tilock"
+        "product_url": "https://raed-slacklines.com/tilock",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/3254",
@@ -4212,7 +4314,8 @@
         },
         "date_introduced": null,
         "name": "TiLock 25mm",
-        "product_url": "https://raed-slacklines.com/tilock"
+        "product_url": "https://raed-slacklines.com/tilock",
+        "active": true
     },
     {
         "image_url": "/api/gear/image_thumb/559",
@@ -4243,7 +4346,8 @@
         },
         "date_introduced": null,
         "name": "Xylon",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/518",
@@ -4274,7 +4378,8 @@
         },
         "date_introduced": null,
         "name": "Yang",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3022",
@@ -4313,7 +4418,8 @@
         },
         "date_introduced": 1262300400000,
         "name": "Zilla 1.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/3021",
@@ -4347,7 +4453,8 @@
         },
         "date_introduced": 1293836400000,
         "name": "Zilla 2.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     },
     {
         "image_url": "/api/gear/image_thumb/513",
@@ -4388,6 +4495,7 @@
         },
         "date_introduced": null,
         "name": "Zilla 3.0",
-        "product_url": null
+        "product_url": null,
+        "active": false
     }
 ]


### PR DESCRIPTION
Stacks on #39. Backend only — the UI that consumes this is the next PR.

Records whether an item is still sold. `active: bool | None` on each `Base<X>`, so it flows to `Public`/`Create`/`Update`: `True` = still sold, `False` = legacy/discontinued, `None` = unknown. Indexed, since scoping the listing by it is a primary filter rather than an occasional one.

Populated from a one-off web-verification pass over the whole catalogue — every item checked against its manufacturer or vendor page. Across the 476 items in these seeds that lands at **172 active / 303 legacy.** The proportion is the point: most of what the database holds is gear you can no longer buy, and until now nothing distinguished it from current product.

One item (slackPro "Neon") is deliberately left without a key, so it seeds as `None`. It's removed by the webbing catalogue pass, and inventing a lifecycle value for a row about to disappear would be worse than saying "unknown".

## The JSON changes are strictly additive

Exactly one `"active"` key per item, **nothing else touched.** Verified mechanically: every object was compared to its pre-change self with `active` removed, across all 8 files, and is byte-identical.

The catalogue expansion (+33 webbings, stretch-curve corrections) and the data corrections (roller rename, weblock dedupe) are deliberately **not** here — they stay in their own changes, so this one can be read, reviewed, or reverted as a single concern.

## Tests — `tests/test_active_field.py`, 48 cases, 6 per gear type

The loader mapping is the part worth testing. Each loader carries exactly one line:

```python
active=<item>.get("active"),
```

`.get()` returns `None` on a missing or misspelled key rather than raising. Delete that line and **every item of that type silently seeds as `None`** — nothing crashes, the API still returns 200, and the only symptom is the Legacy badge quietly vanishing and the HISTORIC filter returning nothing. That's a change nothing else in the suite would catch.

Confirmed the tests catch exactly that: removing the line from `load_grips.py` fails 3 of them.

Covered per type:
- true/false round-trip through the API
- absent key → `None` (unknown is legal, not an error)
- `active` declared on the `*Public` schema, so it survives serialisation — the frontend reads this off the API
- PATCH can flip it
- **PATCH of an unrelated field must not reset it** — `exclude_unset` semantics are what would otherwise wipe lifecycle state across the catalogue the first time anything else is edited

Where the loaders differ, the tests follow: weblock keeps its nested scrape shape and maps `active` inside `clean_weblock_data()` rather than the adder, so those route through clean+add exactly as `load_*()` does.

**Backend suite 203/203** (was 155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)