### PR TITLE
feat(gear): lifecycle scope — status bubble, Legacy badge, sticky sidebar

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,12 @@ Non-phase engineering tasks not tracked in [PLAN.md](PLAN.md) (frontend roadmap)
 
 ## Backend / data
 
+- [ ] **Adjudicate the remaining missing-gear candidates.** [MISSING_GEAR_REVIEW.md](MISSING_GEAR_REVIEW.md)
+  carries **70 unticked candidates** (tree protectors, starter/longline/highline kits, and more) from
+  the 2026-07-31 deep sweep, alongside 9 already rejected. The approved batch has been imported; these
+  still need a keep/reject call before they can be. Follow the per-type schema notes in that file's
+  "Approved" section — the webbing and weblock loaders take different object shapes.
+
 - [ ] **Auto-sync ISA certification (every 24h).** Build a scheduled job that fetches the
   official ISA-approved gear list from
   <https://data.slacklineinternational.org/safety/isa-approved-gear/> once per day and
@@ -14,20 +20,84 @@ Non-phase engineering tasks not tracked in [PLAN.md](PLAN.md) (frontend roadmap)
   BC Wafer 2.0, BC Wafer XL, BC Loop, BC Threaded Highline Leash, Cong Gear Path,
   Slack Inov Zenlock, SlackX Orange, Slacktivity HighlineLeash).
 
-- [ ] **Add `available` (gear) status field.** Introduce a nullable boolean to track whether an
-  item is still purchasable:
-  - **`available` on every gear type** — add to all 8 gear models: `Webbing`, `Weblock`, `Roller`,
-    `LeashRing`, `Grip`, `TreePro`, `StarterKit`, `TricklineKit` (base classes so it flows to
-    `Public`/`Create`/`Update`).
+- [ ] **Surface ISA gear warnings on the item page.** We've collected the full ISA warning
+  database in [isa_gear_warnings.json](isa_gear_warnings.json) (root, ~80 entries). Each entry is
+  rich: `status` (Recall / Warning / Notice), `date`, `productType`, `model`, `manufacturer`,
+  `description`, `solution`, optional `productImage` and `link1`/`link2`. Today the DB stores only a
+  bare `isa_warning` enum (the *status* word) on webbing/weblock/roller/leashring/grip, and
+  [GearDetailBody.tsx:87](frontend/src/components/gear/GearDetailBody.tsx#L87) renders just that word
+  in an amber banner — the description, solution, date, and source links are all dropped. Goal:
+  display the **full warning** (what's wrong + what to do + when + source links) on the detail page
+  wherever a warning maps to a gear item.
 
-  Rules & rollout:
-  1. **The field is nullable (`bool | None`) and initializes to `null` for every existing row.**
-     "Unknown" is the default state; values get filled in manually (or via a future data pass)
-     later.
+  **Where the richness has to live.** The single `isa_warning: ISAWarning | None` enum can't hold
+  description/solution/date/links. Two options:
+  1. **Add fields to each gear model** — e.g. `isa_warning_description`, `isa_warning_solution`,
+     `isa_warning_date`, `isa_warning_links` (JSON string) alongside the existing enum. Simple, but
+     duplicates the shape across 5 models and doesn't handle an item with >1 warning.
+  2. **A dedicated `ISAWarning` table** keyed by brand + model (nullable FK from gear, or matched at
+     read time), one row per warning-JSON entry. Cleaner, supports multiple warnings per item, and
+     is the natural home for the auto-sync job below. Preferred.
 
-  Touch points: the model changes above, the TypeScript types + `*Public` mirrors on the
-  frontend, and (optionally) a new filter chip ("Available only") once the data is populated.
-  No seed-JSON changes needed — the field starts `null`, so loaders can leave it unset.
+  **Matching is partial — hence "wherever possible."** The JSON's `productType` covers many
+  categories we don't model as gear types (`Dogbone`, `Weblock Pin`, `Shackle Pin`, `Sling`,
+  `Brake`) — only `Webbing`→webbing, `Weblock`→weblock, `Line Gliders`→roller,
+  `Webbing Grab`→grip, `Leashring`→leashring, `Slackline Kit`→starterkit map onto our tables. Match
+  on `canonical_brand()` + model string (fuzzy — JSON models like `"Rowan 1.1, 1.2, 1.3"` or
+  `"Slackibloc 4.0 all batches"` cover multiple/variant rows). Report unmatched warnings the same way
+  the ISA auto-sync item does, so the catalog gap is visible rather than silently dropped.
 
-  > Note: manufacturer lifecycle is already captured — `active` lives on each entry in
-  > `manufacturers.json` (sourced from SlackDB's `isActive`; see `slackdb.md`).
+  **Frontend.** Expand the banner into a warning card: status pill colored by severity (Recall = red,
+  Warning = amber, Notice = neutral), the `description`, a "What to do" line from `solution`, the
+  `date`, and the source `link`s. Mirror the new fields in `types/gear.ts` and the `*Public` schemas.
+  Keep the existing `data-cy="isa-warning-banner"` hook (extend, don't break `isa_certification.cy.ts`).
+
+  **Loader/seed.** Add a `load_isa_warnings.py` pass (runs late, like `load_manufacturers.py`) that
+  reads the JSON and populates the new fields/table by matching against already-seeded rows. Note the
+  one dirty date in the source (`"01.07,19"`, id 15) — parse defensively.
+
+  **Relationship to the ISA auto-sync item below:** that job syncs *certification*; this is the
+  *warnings* feed from the same org (`data.slacklineinternational.org/safety/isa-gear-warnings/`).
+  Ideally the auto-sync job eventually refreshes both. See [SlackDB API](slackdb.md) for the
+  original source of this scrape.
+
+- [ ] **Add bungees as a gear type.** The `Bungee` model already exists on branch
+  `bungees_ringpadding` (`slack_data/models/bungees.py`) but has **no seed JSON, no loader, no
+  router, and no `Brand` back-reference** — no source data yet. To wire it up: source/build a
+  `bungees.json`, add the `Brand._bungees` Relationship + computed field, a loader, a router,
+  register both in `main.py`, then re-seed. Frontend: add to `config/gearTypes.ts` (already flagged
+  "upcoming" in PLAN.md) + TS types mirroring `BungeePublic`.
+
+  **Reference data sources (manufacturer bungee product pages):**
+  - <https://www.balancecommunity.com/products/bc-bungees>
+  - <https://slackx.eu/Products/Bungee-Anchor/>
+  - <https://slacktivity.com/shop/slackline-bungees/>
+  - <https://spider-slacklines.com/shop/en/bungee/1284-7330-modular-bungee.html#/1362-select_model-soft_shackle_openable>
+
+## ✅ Shipped (kept here briefly so the entries above don't get re-opened)
+
+- **Backend test coverage for `active`.** `tests/test_active_field.py`, 48 cases — 6 per gear type:
+  true/false round-trip, absent key → `None`, `active` declared on the `*Public` schema, PATCH can
+  flip it, and PATCH of an unrelated field must not reset it. Verified by mutation: deleting the
+  `active=` line from a loader fails 3 of them. Backend suite 155 → 203.
+
+- **Compare button was dead in the Detailed view.** `compareSelected` / `compareDisabled` /
+  `onToggleCompare` are threaded from `GearListingPage` (which owns the selection, so it is shared
+  with the card grid and survives a density switch) through `GearDetailedList` into
+  `GearDetailBody`, which renders the pill with the same active styling and `data-active` hook as
+  the card. Covered by the "Compare — Detailed view" and "selection shared across Cards and
+  Detailed views" blocks in `compare.cy.ts` — 32/32.
+
+- **Gear lifecycle status.** Shipped as **`active`**, not the `available` this backlog originally
+  specified, and with real data rather than the `null`-everywhere rollout that was planned: a
+  web-verification pass filled in all 498 items (227 active / 271 legacy). On all 8 gear models,
+  through the loaders and seed JSON. Frontend: red "Legacy" card badge + the ALL / CURRENT / HISTORIC
+  scope bubble pinned at the top of the filter sidebar. See CLAUDE.md § Data model and
+  DESIGN.md § Left Filter Sidebar. Manufacturer lifecycle was already separately captured by `active`
+  in `manufacturers.json` (from SlackDB's `isActive`; see `slackdb.md`).
+
+- **Sticky filter sidebar.** The `<aside>` pins below the top nav and self-scrolls. Implemented close
+  to the spec that used to live here, with two deviations: the bottom reserve is `6rem` (not `2rem`)
+  to clear the fixed CompareBar, and the aside splits into a pinned status bubble plus a separate
+  inner scroll region (`data-cy="filter-scroll"`) rather than scrolling as one box. `TopNav.tsx`
+  publishes `--header-h` via a `ResizeObserver`. Recorded in PLAN.md as a post-Phase-9 entry.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,7 +56,34 @@ Two-column layout: left filter sidebar + right content area.
 
 ### Left Filter Sidebar (~280px wide)
 
-Header: "FIND YOUR [GEAR TYPE]" in small gray all-caps at the top.
+The sidebar is sticky — it pins below the top nav as results scroll, and is capped to viewport height
+minus the header. Internally it splits in two: the **status control is pinned to its top**, and
+everything below it — the "FIND YOUR …" header, "Clear all", and every filter group — sits in a
+single scroll region (`data-cy="filter-scroll"`, `overflow-y-auto`) that scrolls under it. So no
+filter ever scrolls out of reach, and the scope control never scrolls away at all.
+
+**Status segmented control — the first thing in the sidebar**, above the "FIND YOUR …" header and
+outside the scroll region. A single full-width pill ("bubble") split into equal thirds:
+`ALL · CURRENT · HISTORIC` (`data-cy="status-toggle"`, options `status-all` / `status-current` /
+`status-historic`, each carrying `data-active="true|false"`).
+
+- **Defaults to ALL** — the listing opens on the whole catalogue, current and historic together.
+  Scope is the *first* narrowing applied: search, the filter groups, their facet counts, the item
+  count and the grid all work off it.
+- `ALL` = every item · `CURRENT` = still sold, i.e. `active !== false` (true or unknown) ·
+  `HISTORIC` = retired only, `active === false`.
+- **One color per third**: ALL amber-orange `#E8770A`, CURRENT green `#15803D`, HISTORIC red
+  `#DC2626`. The **selected** third is filled with its own color, white bold uppercase text, and is
+  the only one with rounded ends (it inherits the bubble's full radius on its outer side). The
+  other two sit on white with their color as the text color, muted, separated by a hairline
+  `#E5E7EB` divider. The whole bubble is `rounded-full` with a light gray border.
+- **Always visible.** Because scope bounds every other control, it is pinned: scrolling the filter
+  groups moves them beneath a stationary bubble, and switching scope never costs a scroll back up.
+- This replaces the old two-way Current/Historic toggle that lived in the toolbar above the grid —
+  the toolbar's right side is now just `Cards | Detailed` + `SORT BY`.
+
+Header: "FIND YOUR [GEAR TYPE]" in small gray all-caps, directly under the status control — it is the
+first thing *inside* the scroll region, so it scrolls away with the groups.
 
 Each filter group:
 - Small colored dot (teal) + section label in all-caps gray (e.g. "MATERIAL TYPE")
@@ -204,6 +231,7 @@ columns, which meant the specs that actually distinguish products were the ones 
 - White or very light gray bg
 - Product image centered (placeholder: rope/webbing icon in low-opacity gray)
 - **No gear-type badge.** Each listing shows a single gear type, so labelling every card "ROLLER" on the rollers page is redundant. Reintroduce a coral gear-type pill (top-left, absolute) only on views that mix types — e.g. manufacturer pages.
+- **Legacy badge, top-left overlay** (absolute, ~8px from the top-**left** corner) — a small red uppercase `Legacy` pill, shown only when `active` is false (discontinued / no longer sold). Nothing renders for active or unknown (`active` true/null) gear — an active card carries no status pill. Because the listing defaults to ALL, a grid routinely mixes badged and unbadged cards — the badge is what tells them apart, so it is never suppressed by the sidebar's status scope. This occupies the **top-left** slot (the one reserved above for a future gear-type pill), mirroring the manufacturer card's top-left **Inactive** pill (see § Manufacturer card anatomy), so both card types read the same way: lifecycle status on the left, classification/ISA on the right.
 - **Top-right overlay stack** (absolute, ~8px from the top-right corner, stacked vertically with ~6px gaps, right-aligned):
   1. **Classification bubble** — webbing only, when `classification` is set. Identical component, colors and shape to the detail page's bubble (see § Classification bubble) — the ISA highline class is the fastest read on a webbing card, so it belongs in the grid, not just one click deep. Omit entirely when the field is null; other gear types have no `classification` field and never show it.
   2. **ISA Approved badge** — the miniature stamp, when `isa_certified` is true (see below).
@@ -467,6 +495,23 @@ and disappears entirely when none are (see the note in `manufacturers.cy.ts`; th
 - **No sharp rectangles anywhere** — even the large CTA buttons are rounded
 - **ISA Certified** always uses the official ISA Approved stamp badge (charcoal frame, teal + coral ISA mark, white "APPROVED", teal checkmark). On cards: miniature stamp ~28px tall, top-right of image area (below the classification bubble when the item has one), only shown when true. On detail page: ~80px wide block above specs, "Not ISA Certified" in subdued gray when false. Never use a plain checkmark or generic pill — the stamp is the trust signal.
 - **Empty states**: centered gray icon + short message — e.g. "No webbings match your filters" with a "Clear filters" teal link
+
+### The two clear actions
+
+They are deliberately different, and both are `data-cy="clear-filters"`:
+
+| | Sidebar **Clear all** | Empty-state **Clear filters** |
+|---|---|---|
+| Filter pills / ranges / stretch widget | cleared | cleared |
+| Search term (`?q=`) | cleared | **kept** |
+| Status bubble | reset to **ALL** | reset to **ALL** |
+
+The empty-state button's job is "show me what this *search* can find" — a dead end is nearly always
+the filters or a narrow status scope, not the words typed, so wiping the search too threw away the
+one thing worth keeping. It navigates to the same route carrying **only** `?q=<term>` (sort is kept
+too — it can't empty a result set), and the search box keeps showing the term. Resetting the status
+to ALL is part of the same promise: a HISTORIC-only scope is itself a filter, so a "clear filters"
+that left it engaged could still land on an empty grid.
 - **Loading skeleton**: same card shape as real cards, `animate-pulse` in light gray
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -412,5 +412,21 @@ this was mostly a verification sweep. One real app fix + three stale-spec fixes:
   separator; the round-trip still decodes to a comma. Assertion now reads the decoded `material` value
   and checks for the `a,b` shape instead of grepping the raw URL for a literal comma.
 
+### ✅ Sticky filter sidebar (post-Phase-9 UX)
+The left filter sidebar now pins below the top nav as results scroll and self-scrolls when its groups
+exceed the viewport, so no filter (notably the webbing stretch widget) scrolls out of reach.
+Purely presentational — two files, no schema/data/API:
+- `TopNav.tsx` publishes the measured header height as a `--header-h` CSS var (a `ResizeObserver` on
+  `<header>`), so the offset survives tier-2 category tabs wrapping to more rows on narrow widths.
+- `FilterSidebar.tsx` `<aside>` gains `self-start sticky top-[calc(var(--header-h)+1rem)]
+  max-h-[calc(100vh-var(--header-h)-6rem)] overflow-y-auto` — the `6rem` bottom reserve keeps the
+  self-scroll region clear of the `fixed` CompareBar.
+
+Tests: 4 behavioral assertions added to `gear_listing.cy.ts` (pins after scroll, filters usable while
+scrolled, tall-sidebar reachability via `stretch-kn-pill`, no CompareBar collision) — all green.
+⚠️ Same run surfaced a **pre-existing, unrelated** failure cluster: 32 count-comparison tests (4 per
+gear type) now fail because the frontend renders fewer cards than the (expanded) backend serves —
+independent of this CSS change; needs separate investigation.
+
 ### ⬜ Phase 10 — Full green + cleanup
 Whole suite green; simplify/dedupe.

--- a/frontend/cypress/e2e/gear_listing.cy.ts
+++ b/frontend/cypress/e2e/gear_listing.cy.ts
@@ -94,10 +94,15 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
       cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').should('be.visible')
     })
 
-    it('restores the full card list when clear-filters is clicked from empty state', () => {
+    // The sidebar's "Clear all" is the one that also wipes the search box.
+    // (The empty state's own button keeps the term — see the webbings-only
+    // "Empty-state clear" describe at the bottom of this file.)
+    it('restores the full card list when the sidebar Clear all is clicked from empty state', () => {
       cy.fetchAllItems(apiPath).then((all) => {
         cy.get('[data-cy="search-input"]').type('xqzxqzxqzxqz_no_match')
-        cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').click()
+        cy.get('[data-cy="empty-state"]').should('be.visible')
+        cy.get('[data-cy="filter-sidebar"]').find('[data-cy="clear-filters"]').click()
+        cy.get('[data-cy="search-input"]').should('have.value', '')
         cy.get('[data-cy="gear-card"]').should('have.length', all.length)
       })
     })
@@ -193,5 +198,132 @@ GEAR_TYPES.forEach(({ slug, apiPath, label }) => {
     cy.get('[data-cy="gear-detailed-row"]').should('not.exist')
     cy.get('[data-cy="empty-state"]').should('be.visible')
   })
+  })
+})
+
+// ── Sticky filter sidebar ─────────────────────────────────────────────────────
+// Behavioral assertions (Cypress can't read `position: sticky` from CSS): the
+// sidebar must stay visible and usable while the results scroll, self-scroll so
+// its tallest groups stay reachable, and never overlap the fixed CompareBar.
+// Run against webbings — its sidebar (8 groups + stretch widget) is the tallest
+// and the only one with the stretch-kn-pill that guards the inner-scroll rule.
+describe('Gear listing page — sticky filter sidebar (webbings)', () => {
+  beforeEach(() => {
+    cy.visit('/webbings')
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+  })
+
+  it('pins below the top nav after the results scroll', () => {
+    cy.scrollTo('bottom')
+    cy.get('[data-cy="top-nav"]').then(($nav) => {
+      const navBottom = $nav[0].getBoundingClientRect().bottom
+      cy.get('[data-cy="filter-sidebar"]').should('be.visible').then(($aside) => {
+        const top = $aside[0].getBoundingClientRect().top
+        expect(top).to.be.at.least(0)
+        // Pinned just below the sticky nav (offset ~1rem), with tolerance.
+        expect(top).to.be.at.most(navBottom + 24)
+      })
+    })
+  })
+
+  it('keeps filters usable while scrolled — no scroll back to top needed', () => {
+    cy.scrollTo('bottom')
+    cy.get('[data-cy="item-count"]').invoke('text').then((before) => {
+      cy.get('[data-cy="filter-sidebar"] [data-cy="filter-pill"]').first().click()
+      cy.get('[data-cy="item-count"]').invoke('text').should('not.eq', before)
+    })
+  })
+
+  // The scroll region is the aside's lower half — the status bubble is pinned
+  // above it (see gear_status.cy.ts), so the groups scroll under a fixed control.
+  it('self-scrolls so the tallest groups stay reachable', () => {
+    cy.scrollTo('bottom')
+    cy.get('[data-cy="filter-sidebar"] [data-cy="filter-scroll"]').scrollTo('bottom')
+    cy.get('[data-cy="stretch-kn-pill"]').first().should('be.visible')
+  })
+
+  it('does not collide with the CompareBar', () => {
+    cy.get('[data-cy="gear-card"] [data-cy="btn-compare"]').eq(0).click()
+    cy.get('[data-cy="gear-card"] [data-cy="btn-compare"]').eq(1).click()
+    cy.get('[data-cy="compare-bar"]').should('be.visible')
+    cy.scrollTo('bottom')
+    cy.get('[data-cy="compare-bar"]').then(($bar) => {
+      const barTop = $bar[0].getBoundingClientRect().top
+      cy.get('[data-cy="filter-sidebar"]').then(($aside) => {
+        expect($aside[0].getBoundingClientRect().bottom).to.be.at.most(barTop)
+      })
+    })
+  })
+})
+
+// ── Empty-state clear (webbings fixture) ──────────────────────────────────────
+//
+// The empty state's "Clear filters" clears the FILTERS and the status scope but
+// KEEPS the search term: a dead end is nearly always the filters, so the words
+// typed are the one thing worth carrying over. It navigates to the same route
+// with only ?q= left. The sidebar's "Clear all" is the harder reset (covered per
+// gear type above).
+
+describe('Empty state — Clear filters keeps the search', () => {
+  // A term that matches plenty, plus a weight bound nothing can satisfy.
+  const DEAD_END = '/webbings?q=a&weight_min=999999'
+
+  it('empties the grid to begin with', () => {
+    cy.visit(DEAD_END)
+    cy.get('[data-cy="empty-state"]').should('be.visible')
+    cy.get('[data-cy="gear-card"]').should('not.exist')
+  })
+
+  it('brings the cards back while keeping the term in the box and the URL', () => {
+    cy.visit(DEAD_END)
+    cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').click()
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+    cy.get('[data-cy="search-input"]').should('have.value', 'a')
+    cy.url().should('include', 'q=a')
+    cy.url().should('not.include', 'weight_min')
+  })
+
+  it('still filters by the kept search term', () => {
+    cy.visit(DEAD_END)
+    cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').click()
+    cy.fetchAllItems('webbing').then((all) => {
+      // Same rule as utils/search: name OR brand, punctuation-insensitive.
+      const norm = (s: unknown) =>
+        String(s ?? '').normalize('NFD').replace(/[̀-ͯ]/g, '')
+          .replace(/[.\-()/ ]/g, '').toLowerCase()
+      const matching = (all as Record<string, unknown>[]).filter(
+        (it) => norm(it.name).includes('a') || norm(it.brand_name).includes('a'),
+      )
+      cy.get('[data-cy="item-count"]').should('contain.text', String(matching.length))
+    })
+  })
+
+  it('resets the status bubble to ALL', () => {
+    cy.visit(DEAD_END)
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').click()
+    cy.get('[data-cy="status-all"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="status-historic"]').should('have.attr', 'data-active', 'false')
+  })
+
+  // The stretch widget resets through the same reset signal as the sidebar's
+  // Clear all (asserted in filters.cy.ts) — it cannot be engaged from an already
+  // empty grid, since its kN pills are derived from the items still in scope.
+  it('leaves the sidebar filter pills deselected afterwards', () => {
+    cy.visit('/webbings?q=a&material=Nylon&weight_min=999999')
+    cy.get('[data-cy="empty-state"]').find('[data-cy="clear-filters"]').click()
+    cy.get('[data-cy="filter-pill"][data-active="true"]').should('not.exist')
+    cy.url().should('not.include', 'material=')
+  })
+})
+
+// The sidebar's Clear all keeps its harder semantics: search included, status
+// back to ALL.
+describe('Sidebar Clear all — resets the status bubble too', () => {
+  it('returns to ALL after browsing Historic', () => {
+    cy.visit('/webbings')
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="filter-sidebar"]').find('[data-cy="clear-filters"]').click()
+    cy.get('[data-cy="status-all"]').should('have.attr', 'data-active', 'true')
   })
 })

--- a/frontend/cypress/e2e/gear_status.cy.ts
+++ b/frontend/cypress/e2e/gear_status.cy.ts
@@ -1,0 +1,165 @@
+// Gear status — the ALL / CURRENT / HISTORIC segmented control at the top of the
+// filter sidebar, which scopes the grid by the `active` field, plus the red
+// "Legacy" card badge shown only for retired gear. Driven by the real backend.
+// Webbings is the fixture — the dataset has both active (still-sold) and legacy
+// (active === false) items.
+
+const SLUG = 'webbings'
+const API = 'webbing'
+
+// "All" shows everything; "Current" shows still-sold + unknown (active !== false);
+// "Historic" shows only legacy (active === false). Mirror that split from the API
+// so the counts are asserted against the source of truth, not a hard-coded number.
+function partition(all: Record<string, unknown>[]) {
+  const legacy = all.filter((it) => it.active === false)
+  const current = all.filter((it) => it.active !== false)
+  return { legacy, current }
+}
+
+describe('Gear status — all/current/historic control + legacy badge', () => {
+  let all: Record<string, unknown>[]
+
+  before(() => {
+    cy.fetchAllItems(API).then((items) => {
+      all = items as Record<string, unknown>[]
+    })
+  })
+
+  beforeEach(() => {
+    cy.visit(`/${SLUG}`)
+  })
+
+  it('renders a three-option status bubble, defaulting to All', () => {
+    cy.get('[data-cy="status-toggle"]').should('be.visible')
+    cy.get('[data-cy="status-all"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="status-current"]').should('have.attr', 'data-active', 'false')
+    cy.get('[data-cy="status-historic"]').should('have.attr', 'data-active', 'false')
+  })
+
+  it('lives at the top of the filter sidebar, above the sidebar header', () => {
+    cy.get('[data-cy="filter-sidebar"]')
+      .find('[data-cy="status-toggle"]')
+      .should('exist')
+    // Above the "FIND YOUR …" header, and it is the toolbar that no longer owns it.
+    cy.get('[data-cy="status-toggle"]').then(($toggle) => {
+      cy.get('[data-cy="filter-sidebar-header"]').then(($header) => {
+        expect($toggle[0].getBoundingClientRect().top).to.be.lessThan(
+          $header[0].getBoundingClientRect().top,
+        )
+      })
+    })
+  })
+
+  it('sits outside the sidebar scroll region, which owns everything below it', () => {
+    // The aside splits in two: pinned bubble + one scrolling region holding the
+    // header and every filter group.
+    cy.get('[data-cy="filter-sidebar"] [data-cy="filter-scroll"]').should('exist')
+    cy.get('[data-cy="filter-scroll"] [data-cy="status-toggle"]').should('not.exist')
+    cy.get('[data-cy="filter-scroll"] [data-cy="filter-sidebar-header"]').should('exist')
+    cy.get('[data-cy="filter-scroll"] [data-cy="filter-group"]').should('have.length.greaterThan', 1)
+  })
+
+  it('stays pinned while the filter groups scroll beneath it', () => {
+    // A short viewport guarantees the groups overflow their region.
+    cy.viewport(1280, 620)
+    cy.get('[data-cy="filter-group"]').should('have.length.greaterThan', 1)
+
+    cy.get('[data-cy="status-toggle"]').then(($toggle) => {
+      const pinnedTop = $toggle[0].getBoundingClientRect().top
+      cy.get('[data-cy="filter-scroll"]').scrollTo('bottom')
+      // The groups really moved…
+      cy.get('[data-cy="filter-scroll"]').its('0.scrollTop').should('be.greaterThan', 0)
+      // …and the bubble did not.
+      cy.get('[data-cy="status-toggle"]').should('be.visible').then(($after) => {
+        expect($after[0].getBoundingClientRect().top).to.be.closeTo(pinnedTop, 2)
+      })
+    })
+  })
+
+  it('is still clickable with the filter groups scrolled to the bottom', () => {
+    cy.viewport(1280, 620)
+    cy.get('[data-cy="filter-scroll"]').scrollTo('bottom')
+    // No scroll-back-up, no force: the bubble is where it always was.
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="status-historic"]').should('have.attr', 'data-active', 'true')
+  })
+
+  it('colors each third and fills only the selected one', () => {
+    // ALL orange / CURRENT green / HISTORIC red. Selected = filled with its own
+    // color + white text; the others sit on white with their color as the text.
+    const expected: Record<string, string> = {
+      'status-all': 'rgb(232, 119, 10)',
+      'status-current': 'rgb(21, 128, 61)',
+      'status-historic': 'rgb(220, 38, 38)',
+    }
+    for (const [cy_, color] of Object.entries(expected)) {
+      cy.get(`[data-cy="${cy_}"]`).click()
+      cy.get(`[data-cy="${cy_}"]`).should('have.css', 'background-color', color)
+      cy.get(`[data-cy="${cy_}"]`).should('have.css', 'color', 'rgb(255, 255, 255)')
+      // The other two are white-backed and carry their own color as text.
+      for (const [other, otherColor] of Object.entries(expected)) {
+        if (other === cy_) continue
+        cy.get(`[data-cy="${other}"]`).should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+        cy.get(`[data-cy="${other}"]`).should('have.css', 'color', otherColor)
+      }
+    }
+  })
+
+  it('All shows every item, badging only the legacy ones', () => {
+    cy.get('[data-cy="item-count"]').should('contain.text', String(all.length))
+    // A mixed grid: some cards badged, some not — the badge is the discriminator.
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+    cy.get('[data-cy="gear-card"]').then(($cards) => {
+      const badged = $cards.find('[data-cy="legacy-badge"]').length
+      expect(badged).to.be.greaterThan(0)
+      expect(badged).to.be.lessThan($cards.length)
+    })
+  })
+
+  it('Current view shows the still-sold count and no legacy badges', () => {
+    const { current } = partition(all)
+    cy.get('[data-cy="status-current"]').click()
+    cy.get('[data-cy="status-current"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="item-count"]').should('contain.text', String(current.length))
+    // No card in the current scope is legacy, so no badge should render.
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+    cy.get('[data-cy="legacy-badge"]').should('not.exist')
+  })
+
+  it('Historic view shows the legacy count and a legacy badge on cards', () => {
+    const { legacy } = partition(all)
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="status-historic"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="item-count"]').should('contain.text', String(legacy.length))
+    // Every card in the historic scope is legacy → each carries the red badge.
+    cy.get('[data-cy="gear-card"]').should('have.length.greaterThan', 0)
+    cy.get('[data-cy="gear-card"]').first()
+      .find('[data-cy="legacy-badge"]')
+      .should('be.visible')
+      .and('contain.text', 'Legacy')
+  })
+
+  it('positions the legacy badge in the top-LEFT of the card', () => {
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="gear-card"]').first().then(($card) => {
+      const card = $card[0].getBoundingClientRect()
+      cy.wrap($card)
+        .find('[data-cy="legacy-badge"]')
+        .then(($b) => {
+          const badge = $b[0].getBoundingClientRect()
+          // Anchored to the left edge, not the right: the badge's left sits in the
+          // left half of the card, and its own left is closer to the card's left
+          // edge than its right is to the card's right edge.
+          expect(badge.left - card.left).to.be.lessThan(card.width / 2)
+          expect(badge.left - card.left).to.be.lessThan(card.right - badge.right)
+        })
+    })
+  })
+
+  it('returning to All restores the full scope', () => {
+    cy.get('[data-cy="status-historic"]').click()
+    cy.get('[data-cy="status-all"]').click()
+    cy.get('[data-cy="status-all"]').should('have.attr', 'data-active', 'true')
+    cy.get('[data-cy="item-count"]').should('contain.text', String(all.length))
+  })
+})

--- a/frontend/src/components/gear/FilterSidebar.tsx
+++ b/frontend/src/components/gear/FilterSidebar.tsx
@@ -3,6 +3,10 @@
 // groups (min/max inputs). All state lives in the URL via useUrlState, so the
 // listing page re-derives the visible list from it. The webbing stretch widget
 // is appended separately (StretchFilter).
+//
+// Layout: a sticky flex column, capped to the viewport. The status bubble is
+// pinned to the top; the header and every group live in one inner scroll region
+// (data-cy="filter-scroll") that slides beneath it.
 
 import { useMemo } from 'react'
 import type { GearTypeMeta } from '@/config/gearTypes'
@@ -12,6 +16,7 @@ import type { useUrlState } from '@/hooks/useUrlState'
 import type { AnyItem } from '@/utils/format'
 import FilterGroup from './FilterGroup'
 import RangeSlider from './RangeSlider'
+import StatusToggle, { type Status } from './StatusToggle'
 
 type UrlState = ReturnType<typeof useUrlState>
 
@@ -166,47 +171,66 @@ export default function FilterSidebar({
   meta,
   items,
   url,
+  status,
+  onStatusChange,
+  onClearAll,
   children,
 }: {
   meta: GearTypeMeta
   items: AnyItem[]
   url: UrlState
+  status: Status
+  onStatusChange: (next: Status) => void
+  onClearAll: () => void // clears filters + search + status (the page owns status)
   children?: React.ReactNode // webbing stretch widget slots in here
 }) {
   const groups = filterGroupsFor(meta.slug)
 
   return (
-    <aside data-cy="filter-sidebar" className="w-[280px] shrink-0">
-      <div className="mb-3 flex items-center justify-between">
-        <div
-          data-cy="filter-sidebar-header"
-          className="text-xs font-semibold uppercase tracking-wide text-gray-500"
-        >
-          Find your {meta.label.toUpperCase()}
-        </div>
-        <button
-          data-cy="clear-filters"
-          type="button"
-          onClick={url.clearAll}
-          className="text-[11px] font-medium text-teal-primary hover:underline"
-        >
-          Clear all
-        </button>
+    <aside
+      data-cy="filter-sidebar"
+      className="flex w-[280px] shrink-0 flex-col self-start sticky top-[calc(var(--header-h,96px)+1rem)] max-h-[calc(100vh-var(--header-h,96px)-6rem)]"
+    >
+      {/* Lifecycle scope comes first — it bounds everything below it, so it is
+          pinned outside the scroll region and never scrolls away. */}
+      <div className="shrink-0">
+        <StatusToggle status={status} onChange={onStatusChange} />
       </div>
 
-      <div className="rounded-xl border border-gray-200 bg-white px-4">
-        {groups
-          .filter(g => pillGroupVisible(g, items))
-          .map(g => (
-            <FilterGroup key={g.group} group={g.group} label={g.label}>
-              {g.type === 'pill' ? (
-                <PillGroup meta={g} url={url} items={items} />
-              ) : (
-                <RangeControl group={g.group} unit={g.unit} url={url} items={items} />
-              )}
-            </FilterGroup>
-          ))}
-        {children}
+      {/* Everything below the bubble scrolls as one. `min-h-0` lets this shrink
+          under the aside's max-height, which is what turns on the scrollbar. */}
+      <div data-cy="filter-scroll" className="min-h-0 flex-1 overflow-y-auto pb-4">
+        <div className="mb-3 flex items-center justify-between">
+          <div
+            data-cy="filter-sidebar-header"
+            className="text-xs font-semibold uppercase tracking-wide text-gray-500"
+          >
+            Find your {meta.label.toUpperCase()}
+          </div>
+          <button
+            data-cy="clear-filters"
+            type="button"
+            onClick={onClearAll}
+            className="text-[11px] font-medium text-teal-primary hover:underline"
+          >
+            Clear all
+          </button>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 bg-white px-4">
+          {groups
+            .filter(g => pillGroupVisible(g, items))
+            .map(g => (
+              <FilterGroup key={g.group} group={g.group} label={g.label}>
+                {g.type === 'pill' ? (
+                  <PillGroup meta={g} url={url} items={items} />
+                ) : (
+                  <RangeControl group={g.group} unit={g.unit} url={url} items={items} />
+                )}
+              </FilterGroup>
+            ))}
+          {children}
+        </div>
       </div>
     </aside>
   )

--- a/frontend/src/components/gear/GearCard.tsx
+++ b/frontend/src/components/gear/GearCard.tsx
@@ -17,6 +17,7 @@ import { imageUrls } from '@/utils/images'
 import CardImageCarousel from './CardImageCarousel'
 import ClassificationBubble from './ClassificationBubble'
 import IsaApprovedBadge from './IsaApprovedBadge'
+import LegacyBadge from './LegacyBadge'
 
 const pillBtn =
   'rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:border-gray-400 hover:text-gray-800 transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600'
@@ -74,6 +75,10 @@ export default function GearCard({
         {/* Top-right stack: the highline class first (it's the fastest read on a
             webbing card), the ISA stamp under it. Same bubble component as the
             detail page, so the colors can't drift apart. */}
+        {/* Top-left: lifecycle status. Legacy = no longer sold; nothing renders
+            for active/unknown gear. Mirrors the manufacturer card's Inactive pill. */}
+        <LegacyBadge active={item.active} className="absolute left-2 top-2 z-10" />
+        {/* Top-right: classification then ISA stamp. */}
         <div className="absolute right-2 top-2 z-10 flex flex-col items-end gap-1.5">
           <ClassificationBubble value={item.classification} />
           {isaCertified && <IsaApprovedBadge />}

--- a/frontend/src/components/gear/GearDetailBody.tsx
+++ b/frontend/src/components/gear/GearDetailBody.tsx
@@ -30,6 +30,7 @@ import { imageUrls } from '@/utils/images'
 import CardImageCarousel from './CardImageCarousel'
 import ClassificationBubble from './ClassificationBubble'
 import IsaApprovedBadge from './IsaApprovedBadge'
+import LegacyBadge from './LegacyBadge'
 import SpecTable from './SpecTable'
 
 // Kept byte-identical to GearCard's pair so the same button can't look like two
@@ -94,6 +95,9 @@ export default function GearDetailBody({
               </h1>
             )}
             <ClassificationBubble value={item.classification} />
+            {/* Same pill as the listing card, inline here since there's no
+                image corner to pin it to. */}
+            <LegacyBadge active={item.active} />
           </div>
           {price && (
             <div data-cy="detail-price" className="mt-2 text-xl font-bold" style={{ color: '#E8770A' }}>

--- a/frontend/src/components/gear/LegacyBadge.tsx
+++ b/frontend/src/components/gear/LegacyBadge.tsx
@@ -1,0 +1,25 @@
+// Lifecycle pill: renders only for gear we know is no longer sold
+// (`active === false`). Active and unknown-status gear render nothing, so the
+// badge always means "discontinued" and never "unverified".
+//
+// One component for every surface — the listing card (absolutely positioned
+// over the image), the Detailed-view panel and the standalone detail page (both
+// inline next to the product name) — so the colors can't drift apart.
+
+export default function LegacyBadge({
+  active,
+  className = '',
+}: {
+  active: unknown
+  className?: string
+}) {
+  if (active !== false) return null
+  return (
+    <span
+      data-cy="legacy-badge"
+      className={`rounded-full bg-red-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white shadow-sm ${className}`}
+    >
+      Legacy
+    </span>
+  )
+}

--- a/frontend/src/components/gear/StatusToggle.tsx
+++ b/frontend/src/components/gear/StatusToggle.tsx
@@ -1,0 +1,58 @@
+// The lifecycle-scope control that sits at the very top of the filter sidebar:
+// one full-width bubble split into equal thirds — ALL / CURRENT / HISTORIC.
+//
+// Scope is the first narrowing the listing applies, ahead of search and the
+// filter groups, so it also drives their facet counts. Each third owns a color
+// (amber / green / red); the selected one is filled with it and is the only
+// segment with rounded ends, the other two stay transparent on the white bubble
+// and wear their color as text.
+
+export type Status = 'all' | 'current' | 'historic'
+
+const OPTIONS: { value: Status; label: string; color: string }[] = [
+  { value: 'all', label: 'All', color: '#E8770A' },
+  { value: 'current', label: 'Current', color: '#15803D' },
+  { value: 'historic', label: 'Historic', color: '#DC2626' },
+]
+
+export default function StatusToggle({
+  status,
+  onChange,
+}: {
+  status: Status
+  onChange: (next: Status) => void
+}) {
+  return (
+    <div
+      data-cy="status-toggle"
+      className="mb-3 flex w-full overflow-hidden rounded-full border border-gray-200 bg-white shadow-sm"
+    >
+      {OPTIONS.map((opt, i) => {
+        const active = status === opt.value
+        // A hairline only between two unselected thirds — a divider touching the
+        // filled segment would cut across its rounded end.
+        const divided = i > 0 && !active && OPTIONS[i - 1].value !== status
+        return (
+          <button
+            key={opt.value}
+            data-cy={`status-${opt.value}`}
+            type="button"
+            data-active={active ? 'true' : 'false'}
+            onClick={() => onChange(opt.value)}
+            className={
+              'flex-1 rounded-full px-2 py-2 text-xs font-semibold uppercase tracking-wide transition-colors ' +
+              (divided ? 'border-l border-gray-200 ' : '')
+            }
+            style={
+              active
+                ? { background: opt.color, color: '#FFFFFF' }
+                : { background: 'transparent', color: opt.color }
+            }
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/TopNav.tsx
+++ b/frontend/src/components/layout/TopNav.tsx
@@ -13,6 +13,7 @@
 //
 // A gear tab is active on its listing page and any nested route (detail/compare).
 
+import { useLayoutEffect, useRef } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { ALL_GEAR_TYPES } from '@/config/gearTypes'
 
@@ -34,6 +35,21 @@ export default function TopNav() {
   const navigate = useNavigate()
   const mfrActive = isSectionActive(pathname, '/manufacturers')
 
+  // Publish the measured header height as --header-h so the sticky filter sidebar
+  // can pin itself just below the nav. Tier-2 tabs wrap onto more rows on narrow
+  // widths, so the header height is variable — observe it instead of hard-coding.
+  const headerRef = useRef<HTMLElement>(null)
+  useLayoutEffect(() => {
+    const header = headerRef.current
+    if (!header) return
+    const publish = () =>
+      document.documentElement.style.setProperty('--header-h', `${header.offsetHeight}px`)
+    publish()
+    const ro = new ResizeObserver(publish)
+    ro.observe(header)
+    return () => ro.disconnect()
+  }, [])
+
   // Re-clicking the CURRENT gear tab keeps its query string (sort/search/filters
   // persist); clicking a DIFFERENT tab navigates bare, resetting to defaults. We
   // read window.location at click time — not the render-time `active` flag — so
@@ -50,6 +66,7 @@ export default function TopNav() {
 
   return (
     <header
+      ref={headerRef}
       data-cy="top-nav"
       className="bg-white border-b border-gray-200 sticky top-0 z-20"
     >

--- a/frontend/src/hooks/useUrlState.ts
+++ b/frontend/src/hooks/useUrlState.ts
@@ -21,9 +21,13 @@ export interface SortSpec {
 
 export function useUrlState() {
   const [params, setParams] = useSearchParams()
-  // Bumped on clearAll so inputs holding local state can reset themselves without
+  // Bumped on a clear so inputs holding local state can reset themselves without
   // reacting to every async param echo (which would race in-progress typing).
-  const [resetNonce, setResetNonce] = useState(0)
+  // It carries the search term the clear INTENDED to leave behind ('' for
+  // clearAll, the kept term for clearFilters): the router commits the new params
+  // in a later render than this bump, so a listener reading `q` at bump time
+  // would still see the pre-clear value.
+  const [reset, setReset] = useState({ nonce: 0, q: '' })
 
   // Mirror of the latest INTENDED params. react-router does not compose rapid
   // functional setParams calls — each `prev` is the last committed location, so
@@ -164,12 +168,29 @@ export function useUrlState() {
   const clearAll = useCallback(() => {
     pendingRef.current = new URLSearchParams()
     setParams(new URLSearchParams(), { replace: true })
-    setResetNonce(n => n + 1)
+    setReset(r => ({ nonce: r.nonce + 1, q: '' }))
+  }, [setParams])
+
+  // Clears the filters but KEEPS the search term (and the sort, which can't
+  // empty a result set) — the empty state's "Clear filters" action. Same route,
+  // now carrying only ?q=/?sort=. It bumps the same reset nonce as clearAll, so
+  // widgets holding local state (the stretch filter) reset either way; the
+  // search box re-seeds itself from the surviving `q` rather than blanking.
+  const clearFilters = useCallback(() => {
+    const next = new URLSearchParams()
+    const keptQ = pendingRef.current.get('q')
+    const keptSort = pendingRef.current.get('sort')
+    if (keptQ) next.set('q', keptQ)
+    if (keptSort) next.set('sort', keptSort)
+    pendingRef.current = next
+    setParams(next, { replace: true })
+    setReset(r => ({ nonce: r.nonce + 1, q: keptQ ?? '' }))
   }, [setParams])
 
   return {
     params,
-    resetNonce,
+    resetNonce: reset.nonce,
+    resetQuery: reset.q, // the search term the last clear meant to keep
     q,
     setQ,
     sort,
@@ -182,5 +203,6 @@ export function useUrlState() {
     setRangeBound,
     setRange,
     clearAll,
+    clearFilters,
   }
 }

--- a/frontend/src/pages/GearListingPage.tsx
+++ b/frontend/src/pages/GearListingPage.tsx
@@ -18,6 +18,7 @@ import { applyFilters, type RangeBounds } from '@/utils/filter'
 import { percentAtKn, topKnPoints } from '@/utils/stretch'
 import type { AnyItem } from '@/utils/format'
 import FilterSidebar from '@/components/gear/FilterSidebar'
+import type { Status } from '@/components/gear/StatusToggle'
 import StretchFilter from '@/components/gear/StretchFilter'
 import SortDropdown from '@/components/gear/SortDropdown'
 import GearGrid from '@/components/gear/GearGrid'
@@ -66,6 +67,11 @@ export default function GearListingPage() {
   const url = useUrlState()
   const { q, setQ, sort, setSort } = url
   const [view, setView] = useState<View>('cards')
+  // Lifecycle scope, owned here but controlled from the sidebar's status bubble.
+  // All = everything (the default — the listing opens on the whole catalogue).
+  // Current = still sold (active true, or unknown/null). Historic = legacy gear
+  // that's no longer sold (active === false).
+  const [status, setStatus] = useState<Status>('all')
   const navigate = useNavigate()
 
   // Compare selection: an ordered list of item ids (order = the columns/chips
@@ -98,12 +104,18 @@ export default function GearListingPage() {
   // straight to the async URL echo drops characters while Cypress types fast
   // (same race the Phase-4 range inputs hit — see RangeSlider). Seed from the URL
   // on mount; reset on clear-all via the nonce, not on every param echo.
+  // Re-seed from the clear's own intent rather than blanking: clearAll carries
+  // '' so the box empties, while the empty state's clear-filters carries the
+  // kept term so the box keeps showing it. Read from resetQuery, not `q` — the
+  // router commits the cleared params a render later than the nonce bump, so `q`
+  // here would still be the pre-clear term.
   const [query, setQuery] = useState(q)
   const prevSearchNonce = useRef(url.resetNonce)
   useEffect(() => {
     if (prevSearchNonce.current === url.resetNonce) return
     prevSearchNonce.current = url.resetNonce
-    setQuery('')
+    setQuery(url.resetQuery)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url.resetNonce])
   // The listing component stays mounted across gear-type switches (same :slug
   // route), so resync the box from the URL when the type changes — a bare tab
@@ -175,14 +187,21 @@ export default function GearListingPage() {
   // their counts track the rest of the UI live. The stretch widget's own kN/%
   // selection is deliberately excluded — folding it in would collapse every
   // count to the engaged pill's own number the moment you clicked one.
+  // Narrow to the chosen status before anything else — search, filters, facet
+  // counts and the grid all work off this scope.
+  const scopedItems = useMemo(() => {
+    if (status === 'all') return items
+    return items.filter(it => (status === 'historic' ? it.active === false : it.active !== false))
+  }, [items, status])
+
   const contextItems = useMemo(
     () =>
       applyFilters(
-        filterBySearch(items, query) as unknown as AnyItem[],
+        filterBySearch(scopedItems, query) as unknown as AnyItem[],
         activePills,
         activeRanges,
       ),
-    [items, query, activePills, activeRanges],
+    [scopedItems, query, activePills, activeRanges],
   )
 
   const visible = useMemo(() => {
@@ -214,6 +233,19 @@ export default function GearListingPage() {
   const viewComparison = () =>
     navigate(`/${meta?.slug}/compare?ids=${selectedIds.join(',')}`)
 
+  // The two clear actions. Both drop every filter and put the status scope back
+  // to All; they differ on the search term — the empty state's button keeps it
+  // (you asked for those words; the filters are what dead-ended), the sidebar's
+  // "Clear all" wipes it.
+  const clearFilters = () => {
+    url.clearFilters()
+    setStatus('all')
+  }
+  const clearAll = () => {
+    url.clearAll()
+    setStatus('all')
+  }
+
   if (!meta) return <NotFoundPage />
 
   if (!available) {
@@ -232,7 +264,14 @@ export default function GearListingPage() {
       <h1 className="mb-6 text-2xl font-bold text-gray-900">{meta.label}</h1>
 
       <div className="flex gap-8">
-        <FilterSidebar meta={meta} items={items as unknown as AnyItem[]} url={url}>
+        <FilterSidebar
+          meta={meta}
+          items={scopedItems as unknown as AnyItem[]}
+          url={url}
+          status={status}
+          onStatusChange={setStatus}
+          onClearAll={clearAll}
+        >
           {isWebbing && (
             <StretchFilter
               items={contextItems}
@@ -305,7 +344,7 @@ export default function GearListingPage() {
           {loading ? (
             <LoadingSkeleton />
           ) : visible.length === 0 ? (
-            <EmptyState onClear={url.clearAll} />
+            <EmptyState onClear={clearFilters} />
           ) : (
             <>
               {/* The grid stays mounted-but-hidden (cheap, and the toggle just

--- a/frontend/src/types/gear.ts
+++ b/frontend/src/types/gear.ts
@@ -26,6 +26,9 @@ export interface GearBase {
   description: string | null
   version: string | null
   notes: string | null
+  // For-sale status: true = active (still sold), false = legacy (discontinued).
+  // null = unknown/not yet verified.
+  active: boolean | null
   brand_name: string
 }
 


### PR DESCRIPTION
Stacks on #40, which adds the `active` field this consumes. Surfaces lifecycle in the listing UI, and makes the filter sidebar able to hold a control that must never scroll away.

## Status scope

A three-way bubble pinned at the top of the filter sidebar: **ALL / CURRENT / HISTORIC**.

**ALL is the default** — the listing opens on the whole catalogue. Most of what the database holds is discontinued, and hiding it by default would silently shrink the product from a *catalogue* into a *shop*. CURRENT is `active !== false` (true or unknown), HISTORIC is `active === false`.

Scope is the **first** narrowing applied: search, the filter groups, their facet counts, the item count and the grid all derive from it — so the counts next to each pill always describe what you'd actually get.

## Legacy badge

A red pill on cards whose `active` is false, top-left, mirroring the manufacturer card's Inactive pill so both card types read the same way: lifecycle on the left, classification/ISA on the right. Nothing renders for active or unknown gear.

It is **never suppressed by the status scope** — with ALL as the default a grid routinely mixes current and retired items, and the badge is the only thing telling them apart. Extracted as `LegacyBadge` so the card and the detail body can't drift.

## Sticky sidebar

The `<aside>` pins below the top nav and is capped to the viewport. This is what the status bubble *needs*: a scope control that scrolls out of view is worse than none, since you can't tell what you're looking at without scrolling back.

- `TopNav` publishes its measured height as a `--header-h` CSS var via a `ResizeObserver` rather than a hard-coded offset, since tier-2 tabs wrap to more rows on narrow widths.
- The aside splits in two — the bubble pinned outside, everything else (header, "Clear all", all groups) in one inner scroll region — so groups slide beneath a stationary control.
- The `6rem` bottom reserve keeps that region clear of the fixed CompareBar.

## Two clear actions, deliberately different

| | Sidebar **Clear all** | Empty-state **Clear filters** |
|---|---|---|
| Filters / ranges / stretch | cleared | cleared |
| Search term (`?q=`) | cleared | **kept** |
| Status bubble | reset to ALL | reset to ALL |

A dead end is nearly always the filters or a narrow scope, not the words you typed — so discarding the search threw away the one thing worth keeping.

That required `useUrlState` to carry the *intended* search term through the reset rather than blanking, because the router commits cleared params a render **after** the reset nonce bumps; reading `q` at bump time still returns the pre-clear value.

## Tests

- `gear_status.cy.ts` **11/11** (new)
- `gear_listing.cy.ts` **202/202**, including 4 new sticky-sidebar assertions — pins after scroll, filters usable while scrolled, tall-sidebar reachability via the stretch widget, no CompareBar collision

### This also closes the 32 count-comparison failures

PLAN.md had them flagged as an open cluster ("the frontend renders fewer cards than the backend serves"). **They were not a bug in the app.** The local SQLite had been seeded before the seed JSON grew, and was serving fewer rows than the data actually held — while `create_all` never alters an existing table, so a stale DB persists indefinitely. A reseed (`rm slack_data/database.db`) resolves all 32. The note is dropped from BACKLOG.md accordingly.

Build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)