### PR TITLE
feat(deploy): ship the app as a container and as a serverless stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the build context small and deterministic. The frontend is rebuilt inside
+# the image, so local node_modules / dist never ship; the DB is regenerated on
+# boot, so never ship a local one.
+.git
+.gitignore
+**/__pycache__
+**/*.py[cod]
+.pytest_cache
+.venv
+venv
+*.db
+*.egg-info
+slackdata.egg-info
+
+# Frontend: rebuilt in the `web` stage from source.
+frontend/node_modules
+frontend/dist
+
+# Local/dev-only material not needed at runtime.
+scraper
+scripts/.cache
+scratchpad_dl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# SlackData — single-container image.
+#
+# One FastAPI process serves BOTH the JSON API and the built React SPA on the
+# same origin, backed by a SQLite database that seeds itself from the bundled
+# root *.json files on first startup. No external database, no CORS, nothing
+# else to run. Hand this image to a host, point a domain at it, terminate TLS
+# in front of it — that's the whole deployment.
+#
+#   docker build -t slackdata .
+#   docker run --rm -p 8000:8000 slackdata   # → http://localhost:8000
+
+# ---- Stage 1: build the frontend (Vite → static assets) --------------------
+FROM node:22-slim AS web
+WORKDIR /app/frontend
+
+# Install deps against the lockfile first for better layer caching.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Build. frontend/.env.production sets VITE_API_URL="" → same-origin API calls.
+COPY frontend/ ./
+RUN npm run build          # → /app/frontend/dist
+
+# ---- Stage 2: the FastAPI runtime -----------------------------------------
+FROM python:3.12-slim AS runtime
+WORKDIR /app
+
+# slack_data uses absolute imports (`from slack_data....`); PYTHONPATH=/app lets
+# uvicorn import the package straight from the copied source (no pip-install of
+# the app itself, so the loaders' __file__-relative paths to the root *.json
+# resolve correctly at /app/*.json).
+ENV PYTHONPATH=/app \
+    PYTHONUNBUFFERED=1
+
+# fastapi[standard] pulls in uvicorn; mirror the pyproject.toml floors.
+RUN pip install --no-cache-dir "fastapi[standard]>=0.115.12" "sqlmodel>=0.0.24"
+
+# Backend source + the seed data it reads on boot.
+COPY slack_data/ ./slack_data/
+COPY *.json ./
+
+# The built SPA, at the path main.py looks for by default (/app/frontend/dist).
+COPY --from=web /app/frontend/dist ./frontend/dist
+
+EXPOSE 8000
+
+# Single worker on purpose: each worker would otherwise race to seed the same
+# SQLite file on cold start. One process is ample for a read-only browse site;
+# scale later by baking a pre-seeded DB into the image (see GOING_LIVE.md).
+CMD ["uvicorn", "slack_data.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,35 @@
+# SlackData API — AWS Lambda container image (serverless deploy).
+#
+# One Lambda runs the FastAPI API. The gear catalog is baked into a read-only
+# SQLite file AT BUILD TIME from the root *.json, so there is no database to run
+# and nothing to seed on cold start. The website (SPA + images) is NOT in here —
+# it's served separately from S3/CloudFront. See infra/ and GOING_LIVE.md.
+#
+#   docker build -f Dockerfile.lambda -t slackdata-api .
+
+FROM public.ecr.aws/lambda/python:3.12
+
+# Runtime deps only — no uvicorn/CLI needed inside Lambda (Mangum drives the app).
+RUN pip install --no-cache-dir \
+      "fastapi>=0.115.12" \
+      "sqlmodel>=0.0.24" \
+      "mangum>=0.17"
+
+# App source.
+COPY slack_data/ ${LAMBDA_TASK_ROOT}/slack_data/
+
+# Seed data + builder → bake the read-only catalog into the image, then drop the
+# JSON (only the baked catalog.db is read at runtime).
+COPY *.json ${LAMBDA_TASK_ROOT}/
+COPY scripts/build_catalog_db.py ${LAMBDA_TASK_ROOT}/scripts/build_catalog_db.py
+RUN cd ${LAMBDA_TASK_ROOT} \
+    && PYTHONPATH=${LAMBDA_TASK_ROOT} python scripts/build_catalog_db.py ${LAMBDA_TASK_ROOT}/catalog.db \
+    && rm -f ${LAMBDA_TASK_ROOT}/*.json
+
+# CATALOG_DB_PATH → read-only mode (no seeding). API_ROOT_PATH → the API is served
+# under /api behind CloudFront (only affects /docs + openapi.json URLs; CloudFront
+# strips the /api prefix before the request reaches Lambda — see infra/).
+ENV CATALOG_DB_PATH=${LAMBDA_TASK_ROOT}/catalog.db \
+    API_ROOT_PATH=/api
+
+CMD ["slack_data.lambda_handler.handler"]

--- a/GOING_LIVE.md
+++ b/GOING_LIVE.md
@@ -1,0 +1,166 @@
+# GOING_LIVE.md — Hosting SlackData serverlessly on the ISA's AWS
+
+The International Slackline Association (ISA) is hosting SlackData on their AWS. They run everything
+**serverless** (static client-rendered web + Lambda) so it costs ≈$0 when idle — the right call for a
+low-traffic community tool. This document is the plan to get there, and to make sure the two feedback
+features we know are coming drop in **without any re-architecture**.
+
+Feedback features planned (confirmed with the maintainer):
+- **"Suggest a missing item"** — an anonymous public submission form.
+- **"Submit a correction / missing data"** — an anonymous public text form on each gear page.
+- **A single admin login** (the maintainer's email) to review submissions — *no general user accounts*.
+
+---
+
+## 1. The core principle: two data domains, never mixed
+
+Everything about keeping this cheap, serverless, and future-proof comes from one split:
+
+| Domain | Nature | Where it lives | Who writes |
+|--------|--------|----------------|------------|
+| **Catalog** (the ~500 gear rows) | **read-only**, derived from the repo's version-controlled `*.json` | a **pre-built SQLite file baked into the Lambda**, opened read-only | nobody at runtime — updated by editing JSON + redeploying |
+| **Submissions** (suggestions & corrections) | **append-only**, grows over time | **DynamoDB** (on-demand, ≈$0 idle — the ISA's native tool) | the anonymous public, via form POSTs; read by the admin |
+
+The catalog never becomes writable. A "correction" is a *text note to the admin*, not a live edit —
+the admin folds it into the JSON and redeploys. This is why we keep SQLite for the catalog (great at
+the relational filtering the app does) **and** why submissions go to DynamoDB (perfect for flat,
+append-only records) — no DynamoDB rewrite of the catalog, no relational server for submissions.
+
+**Because the two domains are separate, the feedback features are purely additive** (new API routes +
+a DynamoDB table + frontend forms). Nothing built for the read-only launch has to change to add them.
+
+---
+
+## 2. Target architecture (all pay-per-use / free when idle)
+
+```
+                     ┌──────────────── CloudFront (one domain) ────────────────┐
+   browser ────────► │  default behavior   /*     → S3  (React SPA + images)   │
+                     │  path behavior      /api/* → API Gateway → Lambda        │
+                     └──────────────────────────────┬──────────────────────────┘
+                                                     │
+                              ┌──────────────────────┴───────────────────────┐
+                              │  Lambda: FastAPI (via Mangum)                 │
+                              │   ├─ read catalog  → baked read-only SQLite   │
+                              │   └─ write/read submissions → DynamoDB        │
+                              └───────────────────────────────────────────────┘
+```
+
+| Piece | Service | Idle cost |
+|-------|---------|-----------|
+| Website (SPA + 62 MB images) | **S3 + CloudFront** (static, client-rendered) | ≈$0 |
+| Read API | **Lambda** (FastAPI + Mangum) behind **API Gateway** | ≈$0 |
+| Catalog data | **read-only SQLite baked into the Lambda package** | $0 |
+| Submissions | **DynamoDB** (on-demand billing) | ≈$0 |
+| Admin login *(phase 3)* | **Cognito**, one user | ≈$0 |
+
+Putting the API under `/api/*` on the **same CloudFront domain** means the SPA makes **same-origin**
+requests — no CORS in production at all.
+
+---
+
+## 3. What needs to change
+
+### Backend (`slack_data/`)
+1. **Lambda adapter** — add `mangum`; expose `handler = Mangum(app)` (small `lambda_handler.py` or in
+   `main.py`). API Gateway (HTTP API) proxies to it.
+2. **Read-only catalog mode** — [database.py](slack_data/database.py): when `CATALOG_DB_PATH` is set
+   (Lambda), build the engine against the pre-built file opened read-only/immutable
+   (`sqlite:///file:<path>?mode=ro&immutable=1&uri=true`) and **skip** `create_all`. Local dev is
+   unchanged (still seeds `database.db` from JSON).
+3. **Skip seeding on Lambda** — [main.py](slack_data/main.py) `lifespan`: guard the whole seed block so
+   it only runs in local/dev mode; on Lambda the DB is already built.
+4. **Bake the DB at deploy** — a `scripts/build_catalog_db.py` that runs the existing loaders once to
+   produce `database.db` from the JSON, invoked during the image build so the `.db` ships in the
+   package. (Same seeding logic, moved from boot-time to build-time.)
+5. **Submissions feature** (the seam):
+   - `slack_data/models/submissions.py` — Pydantic **request** models (`SuggestionCreate`,
+     `CorrectionCreate`: type, gear ref, message, **optional email**, captcha token). Not SQLModel
+     tables — these go to DynamoDB.
+   - `slack_data/dynamo.py` — thin boto3 wrapper (`put_submission`, `list_submissions`).
+   - `slack_data/api/routers/submissions_router.py` — **public** `POST /suggestions`,
+     `POST /corrections`: validate, verify captcha, write to DynamoDB with `status="new"` + timestamp.
+   - `slack_data/captcha.py` — server-side verify the captcha token (Cloudflare Turnstile / hCaptcha),
+     secret from env.
+   - *(Phase 3, stubbed now)* admin router `GET/PATCH /admin/submissions` guarded by a Cognito JWT.
+6. **Deps** — `pyproject.toml`: add `mangum`, `boto3` (for local/tests; present in the Lambda runtime).
+7. **CORS** — leave the existing dev block as-is (local only). Production is same-origin via CloudFront,
+   so no prod CORS.
+
+### Frontend (`frontend/`)
+8. **API base** — [.env.production](frontend/.env.production): `VITE_API_URL=/api` (same-origin behind
+   CloudFront) instead of `""`.
+9. **Deploy target** — `vite build` → **S3**; served via CloudFront. Images already static.
+10. **Submission UI** (phaseable):
+    - "Suggest a missing item" page/modal → `POST /api/suggestions`.
+    - "Submit a correction" form on the gear detail page → `POST /api/corrections` (auto-attaches gear
+      type + id).
+    - A captcha widget on both.
+    - *(Phase 3)* a Cognito-gated `/admin` route listing submissions.
+
+### Infrastructure (Serverless Framework — the ISA's tooling)
+11. `serverless.ts` + `infrastructure/` defining: Lambda (**container image** — reuses our Dockerfile,
+    dodges the zip size limit), API Gateway HTTP API, S3 (SPA + images), CloudFront (default→S3,
+    `/api/*`→API GW), **DynamoDB** submissions table, IAM (Lambda→DynamoDB + read the captcha secret),
+    SSM/Secrets for the captcha key. Cognito user pool (one admin) added in phase 3.
+12. **Deploy flow**: build catalog DB → build frontend → `sls deploy` → `aws s3 sync` the SPA →
+    CloudFront invalidation. Manual to start; a GitHub Actions workflow later.
+
+### Kept / deferred
+- **Kept:** the [Dockerfile](Dockerfile) — now a **local-dev convenience** and a fallback if a
+  non-serverless host is ever wanted. Not the production artifact.
+- **Deferred:** Cognito admin login + admin triage UI (phase 3); CI/CD; analytics.
+
+---
+
+## 4. Phasing (each phase is additive — nothing earlier is reworked)
+
+| Phase | Ships | New infra | Admin can review via |
+|-------|-------|-----------|----------------------|
+| **1 — Launch** | Public read-only site (browse/filter/search/detail/compare/manufacturers) | S3, CloudFront, Lambda, API Gateway | n/a |
+| **2 — Feedback** | Both submission forms + captcha | DynamoDB table | AWS console / one-line CLI (no login yet) |
+| **3 — Admin polish** | Cognito login (your email) + admin triage page | Cognito user pool | the admin UI |
+
+Phase 2 is the highest-value step for the stated goal ("go live to get feedback") and needs **no**
+login — you read submissions straight from DynamoDB until phase 3 justifies a UI.
+
+---
+
+## 5. Domain
+
+- **Now (free, instant):** a **subdomain of the ISA's domain** (e.g. `slackdata.slackline.international`)
+  pointed at CloudFront. Zero cost, no purchase, perfect for the feedback phase.
+- **Standalone brand (optional, ~$10/yr):** **`slackdata.org`** — `.org` fits a community/nonprofit
+  project. Low-regret to reserve; ask the ISA to **cover and own** it so it lives with the project.
+- **Skip `slackdata.com`** ($460) until the project has real traction.
+
+---
+
+## 6. Design-in-now details (cheap now, painful to retrofit)
+
+- **Spam:** the public POST endpoints will attract bots. Build the forms with a **captcha** (Cloudflare
+  Turnstile / hCaptcha), **API Gateway throttling**, and a hidden **honeypot** field from day one.
+- **Submitter email:** an **optional** field on both forms (leave blank to stay anonymous; provide it to
+  let the admin follow up). Stored on the submission record.
+- **Image rights & disclaimer** *(before public launch)*: many gear images are scraped — confirm rights
+  or swap them, especially under the ISA's name. Surface a "verify specs with the manufacturer" safety
+  disclaimer (the data already models ISA warnings). Add a `LICENSE` (project is described as open
+  source but has none).
+
+---
+
+## 7. Open items to confirm with the ISA
+
+- [ ] Which they prefer: we `sls deploy` into their account (they grant an IAM role / GitHub OIDC), or
+      they run the deploy from our config.
+- [ ] Subdomain to use, and whether they'll cover/own `slackdata.org`.
+- [ ] New Cognito user pool vs. their existing one (only matters at phase 3).
+- [ ] Captcha provider preference (Turnstile is free and simple).
+
+---
+
+### One-line summary
+Static SPA on S3/CloudFront + FastAPI on Lambda with a **read-only baked SQLite** for the catalog and
+**DynamoDB** for append-only submissions. ≈$0 idle, the ISA's native stack, no catalog rewrite — and
+because the read (catalog) and write (submissions) domains are cleanly split, the suggest/correction
+features and single-admin login bolt on later without touching anything shipped at launch.

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,8 @@
+# Production build config.
+#
+# Empty VITE_API_URL makes the API client issue same-origin relative requests
+# (e.g. `/webbing/?limit=100`). In the hosted build the FastAPI container serves
+# BOTH this SPA and the API, so there is no separate API host and no CORS.
+# (See frontend/src/api/client.ts — `?? 'http://localhost:8000'` only kicks in
+# when the var is undefined, so an empty string is preserved.)
+VITE_API_URL=

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,66 @@
+# Deploying SlackData (serverless, Phase 1 — public read-only)
+
+Architecture recap (see [../GOING_LIVE.md](../GOING_LIVE.md) for the full plan):
+
+- **API** — FastAPI as a container-image **Lambda** behind an **HTTP API**. The gear catalog is
+  baked into a **read-only SQLite** file inside the image at build time, so there's no database to
+  run and nothing to seed on cold start.
+- **Website** — the React build + images on **S3**, served through **CloudFront**.
+- **One CloudFront domain** fronts both: `/*` → S3 (SPA), `/api/*` → the API (a CloudFront Function
+  strips `/api` so FastAPI keeps its unprefixed routes). Same-origin ⇒ **no CORS**.
+
+Everything is pay-per-use / ≈$0 idle. No RDS, no container left running.
+
+## Prerequisites
+
+- AWS credentials for the target account (the ISA's), with permission to deploy the stack.
+- Docker (Serverless builds the Lambda image locally and pushes to ECR).
+- Node + `npx serverless`, and Python + this repo's deps for the frontend/catalog builds.
+
+## Deploy
+
+```bash
+# 1. API + AWS resources (Lambda, HTTP API, S3, CloudFront). Builds & pushes the
+#    image defined by ../Dockerfile.lambda, which bakes the read-only catalog.
+cd infra
+npx serverless deploy --stage prod            # add --region <r> to override
+
+# 2. Frontend → S3, pointed at the same-origin API under /api.
+cd ../frontend
+VITE_API_URL=/api npm run build
+aws s3 sync dist/ "s3://$(cd ../infra && npx serverless info --stage prod --verbose \
+  | awk '/WebBucketName/{print $2}')" --delete
+
+# 3. Invalidate CloudFront so the new build shows up immediately.
+aws cloudfront create-invalidation --paths '/*' \
+  --distribution-id "$(cd ../infra && npx serverless info --stage prod --verbose \
+  | awk '/CdnDistributionId/{print $2}')"
+```
+
+The CloudFront domain is printed as the `CdnDomain` output; open it to see the live site. Point the
+real domain/subdomain at that distribution once DNS + an ACM cert (in **us-east-1**) are ready — see
+the `TODO(isa)` markers in [serverless.yml](serverless.yml).
+
+## Updating the gear data
+
+The catalog is baked into the image, so a data change = edit the root `*.json` → **redeploy step 1**
+(rebuilds the image, re-bakes the catalog). No database migration, nothing stateful to touch.
+
+## Local check before deploying
+
+```bash
+# Build the Lambda image and invoke it like API Gateway would (uses the AWS RIE
+# built into the base image):
+docker build -f ../Dockerfile.lambda -t slackdata-api ..
+docker run --rm -p 9000:8080 slackdata-api &
+curl -s "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{
+  "version":"2.0","routeKey":"GET /webbing/","rawPath":"/webbing/",
+  "rawQueryString":"limit=1","requestContext":{"http":{"method":"GET","path":"/webbing/"}}}'
+```
+
+## Not in Phase 1 (added later, additively)
+
+- **Submissions** (suggest-an-item / correction forms) → a DynamoDB table + `POST` routes.
+- **Admin login** to triage submissions → a single-user Cognito pool + a gated admin page.
+
+Neither requires changing anything above — the read-only catalog and this deploy stay as-is.

--- a/infra/cloudfront-strip-api.js
+++ b/infra/cloudfront-strip-api.js
@@ -1,0 +1,17 @@
+// CloudFront Function (viewer-request) — strips the "/api" prefix so the API
+// Gateway / Lambda behind the "/api/*" cache behavior sees the bare FastAPI
+// route (e.g. browser calls /api/webbing → Lambda receives /webbing). This lets
+// the SPA and the API share ONE CloudFront domain (same-origin, zero CORS) while
+// the app code keeps its unprefixed routes. FastAPI's API_ROOT_PATH=/api keeps
+// the /docs + openapi.json URLs correct.
+//
+// Deployed as an AWS::CloudFront::Function; the code is also inlined in
+// infra/serverless.yml. Keep the two in sync.
+function handler(event) {
+    var request = event.request;
+    request.uri = request.uri.replace(/^\/api/, '');
+    if (request.uri === '') {
+        request.uri = '/';
+    }
+    return request;
+}

--- a/infra/serverless.yml
+++ b/infra/serverless.yml
@@ -1,0 +1,144 @@
+# SlackData — serverless deploy (Serverless Framework), Phase 1: public read-only.
+#
+# Deploys the FastAPI catalog API as a container-image Lambda behind an HTTP API.
+# The website (S3 + CloudFront) is defined in the `resources` block below; the
+# CloudFront distribution fronts BOTH the SPA (default) and the API (/api/*), so
+# the browser only ever talks to one origin (no CORS).
+#
+#   cd infra && npx serverless deploy --stage prod
+#
+# The frontend is built + synced separately (see infra/README.md) — Serverless
+# manages the API + AWS resources, not the SPA upload.
+#
+# NOTE: items marked TODO(isa) need the ISA account's specifics (region, custom
+# domain, ACM certificate). The API + S3 + CloudFront default setup deploys as-is.
+
+service: slackdata
+
+provider:
+  name: aws
+  region: ${opt:region, 'eu-central-1'}          # TODO(isa): confirm region
+  stage: ${opt:stage, 'prod'}
+  architecture: x86_64                             # match your build host; arm64 is cheaper
+  ecr:
+    images:
+      api:
+        path: ..                                   # build context = repo root
+        file: Dockerfile.lambda
+
+functions:
+  api:
+    image:
+      name: api
+    memorySize: 512
+    timeout: 29                                    # API Gateway hard max
+    events:
+      - httpApi: '*'                               # proxy every method/path to FastAPI
+
+resources:
+  Resources:
+
+    # ---- Website bucket (private; served only through CloudFront) ------------
+    WebBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:service}-web-${self:provider.stage}   # TODO(isa): globally-unique name
+
+    WebBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref WebBucket
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: cloudfront.amazonaws.com
+              Action: s3:GetObject
+              Resource: !Sub '${WebBucket.Arn}/*'
+              Condition:
+                StringEquals:
+                  AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${Cdn}'
+
+    Oac:
+      Type: AWS::CloudFront::OriginAccessControl
+      Properties:
+        OriginAccessControlConfig:
+          Name: ${self:service}-oac-${self:provider.stage}
+          OriginAccessControlOriginType: s3
+          SigningBehavior: always
+          SigningProtocol: sigv4
+
+    # ---- Strip "/api" before requests reach the API origin ------------------
+    StripApiFunction:
+      Type: AWS::CloudFront::Function
+      Properties:
+        Name: ${self:service}-strip-api-${self:provider.stage}
+        AutoPublish: true
+        FunctionConfig:
+          Comment: Strip the /api prefix for the API cache behavior
+          Runtime: cloudfront-js-1.0
+        FunctionCode: |
+          function handler(event) {
+              var request = event.request;
+              request.uri = request.uri.replace(/^\/api/, '');
+              if (request.uri === '') {
+                  request.uri = '/';
+              }
+              return request;
+          }
+
+    # ---- CloudFront: one domain fronting the SPA (default) + the API (/api/*)-
+    Cdn:
+      Type: AWS::CloudFront::Distribution
+      Properties:
+        DistributionConfig:
+          Enabled: true
+          DefaultRootObject: index.html
+          # TODO(isa): custom domain + cert
+          # Aliases: [slackdata.slackline.international]
+          # ViewerCertificate:
+          #   AcmCertificateArn: <us-east-1 ACM cert ARN>
+          #   SslSupportMethod: sni-only
+          Origins:
+            - Id: web-s3
+              DomainName: !GetAtt WebBucket.RegionalDomainName
+              OriginAccessControlId: !Ref Oac
+              S3OriginConfig:
+                OriginAccessIdentity: ''
+            - Id: api-httpapi
+              DomainName: !Sub '${HttpApi}.execute-api.${AWS::Region}.amazonaws.com'
+              CustomOriginConfig:
+                OriginProtocolPolicy: https-only
+                OriginSSLProtocols: [TLSv1.2]
+          DefaultCacheBehavior:
+            TargetOriginId: web-s3
+            ViewerProtocolPolicy: redirect-to-https
+            # AWS managed "CachingOptimized" policy id
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          CacheBehaviors:
+            - PathPattern: /api/*
+              TargetOriginId: api-httpapi
+              ViewerProtocolPolicy: redirect-to-https
+              AllowedMethods: [GET, HEAD, OPTIONS, PUT, PATCH, POST, DELETE]
+              # AWS managed "CachingDisabled" + "AllViewerExceptHostHeader"
+              CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+              OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
+              FunctionAssociations:
+                - EventType: viewer-request
+                  FunctionARN: !GetAtt StripApiFunction.FunctionMetadata.FunctionARN
+          # SPA deep links: serve index.html for client-routed paths.
+          CustomErrorResponses:
+            - ErrorCode: 403
+              ResponseCode: 200
+              ResponsePagePath: /index.html
+            - ErrorCode: 404
+              ResponseCode: 200
+              ResponsePagePath: /index.html
+
+  Outputs:
+    WebBucketName:
+      Value: !Ref WebBucket
+    CdnDomain:
+      Value: !GetAtt Cdn.DomainName
+    CdnDistributionId:
+      Value: !Ref Cdn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi[standard]>=0.115.12",
     "sqlmodel>=0.0.24",
+    "mangum>=0.17",
 ]
 
 [project.optional-dependencies]

--- a/scripts/build_catalog_db.py
+++ b/scripts/build_catalog_db.py
@@ -1,0 +1,34 @@
+"""Bake the read-only catalog SQLite that ships inside the Lambda package.
+
+Runs the same load sequence the local server runs on first boot
+(``slack_data.seed.seed_catalog``), but as a one-off build step, producing a
+self-contained ``database.db`` the hosted app then opens read-only. Re-run
+whenever the root ``*.json`` seed data changes.
+
+Usage:
+    python scripts/build_catalog_db.py [output_path]   # default: database.db
+"""
+
+import sys
+from pathlib import Path
+
+from sqlmodel import Session, SQLModel, create_engine
+
+# Importing seed pulls in every table model + loader, so SQLModel.metadata is
+# complete before create_all().
+from slack_data.seed import seed_catalog
+
+
+def build(out_path: str) -> None:
+    Path(out_path).unlink(missing_ok=True)
+    engine = create_engine(
+        f"sqlite:///{out_path}", connect_args={"check_same_thread": False}
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        seed_catalog(session)
+    print(f"Built catalog DB -> {out_path}")
+
+
+if __name__ == "__main__":
+    build(sys.argv[1] if len(sys.argv) > 1 else "database.db")

--- a/slack_data/database.py
+++ b/slack_data/database.py
@@ -1,13 +1,35 @@
+import os
 from typing import Annotated, Optional
 from fastapi import Depends
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine
 
+# Local/dev default: a writable SQLite file in the CWD, seeded from the root
+# *.json files on first boot.
 sqlite_file_name = "database.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"
 connect_args = {"check_same_thread": False}
 
+# Hosted (Lambda) mode: CATALOG_DB_PATH points at a pre-built catalog SQLite that
+# ships inside the deployment package. When set, the app opens it strictly
+# read-only and never creates tables or seeds — the catalog is baked at build
+# time (see scripts/build_catalog_db.py). `immutable=1` tells SQLite the file
+# cannot change, so it needs no journal/lock files and works on Lambda's
+# read-only filesystem.
+CATALOG_DB_PATH = os.getenv("CATALOG_DB_PATH")
+READ_ONLY = bool(CATALOG_DB_PATH)
+
+# Verbose SQL logging is handy locally but noisy (and leaks data) in a hosted log
+# stream, so it's off by default. Set SQL_ECHO=true to re-enable for debugging.
+SQL_ECHO = os.getenv("SQL_ECHO", "false").lower() in ("1", "true", "yes")
+
 DATABASE_ENGINE: Optional[Engine] = None
+
+
+def _engine_url() -> str:
+    if CATALOG_DB_PATH:
+        return f"sqlite:///file:{CATALOG_DB_PATH}?mode=ro&immutable=1&uri=true"
+    return sqlite_url
 
 
 def create_db_and_tables():
@@ -15,9 +37,10 @@ def create_db_and_tables():
     if DATABASE_ENGINE is not None:
         raise RuntimeError("`create_db_and_tables` called, but database already created.")
     DATABASE_ENGINE = create_engine(
-        sqlite_url, connect_args=connect_args, echo=True
+        _engine_url(), connect_args=connect_args, echo=SQL_ECHO
     )
-    SQLModel.metadata.create_all(DATABASE_ENGINE)
+    if not READ_ONLY:
+        SQLModel.metadata.create_all(DATABASE_ENGINE)
 
 
 def get_session():

--- a/slack_data/lambda_handler.py
+++ b/slack_data/lambda_handler.py
@@ -1,0 +1,19 @@
+"""AWS Lambda entrypoint.
+
+The Lambda image's CMD is ``slack_data.lambda_handler.handler``. Mangum adapts
+the FastAPI ASGI app to the API Gateway (HTTP API) event/response model.
+
+Mangum runs the ASGI *lifespan* around every invocation, but our lifespan calls
+``create_db_and_tables()`` — which is single-shot and raises if the engine
+already exists. So we initialise the read-only engine ONCE here at cold start and
+run Mangum with ``lifespan="off"``. (There is nothing to start up per request:
+the catalog is a pre-built read-only SQLite baked into the image.)
+"""
+
+from mangum import Mangum
+
+from slack_data.database import create_db_and_tables
+from slack_data.main import app
+
+create_db_and_tables()
+handler = Mangum(app, lifespan="off")

--- a/slack_data/main.py
+++ b/slack_data/main.py
@@ -1,20 +1,13 @@
+import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlmodel import select
+from fastapi.responses import FileResponse
 
-from slack_data.database import get_session, create_db_and_tables
-
-from slack_data.load_data.load_grips import load_grips
-from slack_data.load_data.load_leashrings import load_leashrings
-from slack_data.load_data.load_manufacturers import load_manufacturers
-from slack_data.load_data.load_rollers import load_rollers
-from slack_data.load_data.load_starterkits import load_starterkits
-from slack_data.load_data.load_treepros import load_treepros
-from slack_data.load_data.load_tricklinekits import load_tricklinekits
-from slack_data.load_data.load_webbings import load_webbings
-from slack_data.load_data.load_weblocks import load_weblocks
+from slack_data.database import get_session, create_db_and_tables, READ_ONLY
+from slack_data.seed import seed_catalog
 
 from slack_data.api.routers.brand_router import brand_router
 from slack_data.api.routers.grip_router import grip_router
@@ -26,73 +19,38 @@ from slack_data.api.routers.tricklinekit_router import tricklinekit_router
 from slack_data.api.routers.webbing_router import webbing_router
 from slack_data.api.routers.weblock_router import weblock_router
 
-from slack_data.models.brands import Brand
-from slack_data.models.grips import Grip
-from slack_data.models.leashrings import LeashRing
-from slack_data.models.rollers import Roller
-from slack_data.models.starterkits import StarterKit
-from slack_data.models.treepro import TreePro
-from slack_data.models.tricklinekits import TricklineKit
-from slack_data.models.webbing import Webbing
-from slack_data.models.weblocks import Weblock
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Local/dev: create a writable SQLite in the CWD and seed it from the root
+    # *.json files on first boot. Hosted (read-only) mode ships a pre-built
+    # catalog baked into the deployment package, so there is nothing to create
+    # or seed here — see slack_data.database and scripts/build_catalog_db.py.
     create_db_and_tables()
-    with next(get_session()) as session:
-        existing_webbings = session.exec(select(Webbing)).first()
-        if existing_webbings is None: # Only load from `webbings.json` if the database is empty
-            print("Loading webbing data into the database...")
-            load_webbings(session=session)
-        existing_weblocks = session.exec(select(Weblock)).first()
-        if existing_weblocks is None: # Only load from `webbings.json` if the database is empty
-            print("Loading weblocks data into the database...")
-            load_weblocks(session=session)
-        existing_rollers = session.exec(select(Roller)).first()
-        if existing_rollers is None: # Only load from `rollers.json` if the database is empty
-            print("Loading roller data into the database...")
-            load_rollers(session=session)
-        existing_leashrings = session.exec(select(LeashRing)).first()
-        if existing_leashrings is None: # Only load from `leashrings.json` if the database is empty
-            print("Loading leash ring data into the database...")
-            load_leashrings(session=session)
-        existing_grips = session.exec(select(Grip)).first()
-        if existing_grips is None: # Only load from `grips.json` if the database is empty
-            print("Loading grip data into the database...")
-            load_grips(session=session)
-        existing_treepros = session.exec(select(TreePro)).first()
-        if existing_treepros is None: # Only load from `treepros.json` if the database is empty
-            print("Loading treepro data into the database...")
-            load_treepros(session=session)
-        existing_starterkits = session.exec(select(StarterKit)).first()
-        if existing_starterkits is None: # Only load from `starterkits.json` if the database is empty
-            print("Loading starter kit data into the database...")
-            load_starterkits(session=session)
-        existing_tricklinekits = session.exec(select(TricklineKit)).first()
-        if existing_tricklinekits is None: # Only load from `tricklinekits.json` if the database is empty
-            print("Loading trickline kit data into the database...")
-            load_tricklinekits(session=session)
-        # MUST come last: Brand rows are created by the gear loaders above (via
-        # get_brand(), name-only), and this pass backfills their metadata. Gated on
-        # "no brand has a country yet" rather than on an empty table, because the
-        # table is never empty by this point.
-        needs_enrichment = session.exec(
-            select(Brand).where(Brand.country.is_not(None))
-        ).first() is None
-        if needs_enrichment:
-            print("Enriching brands from manufacturers.json...")
-            load_manufacturers(session=session)
+    if not READ_ONLY:
+        with next(get_session()) as session:
+            seed_catalog(session)
     yield
 
-app = FastAPI(lifespan=lifespan)
+
+# root_path lets the API sit under a path prefix (e.g. "/api" behind CloudFront)
+# without changing any route — it only fixes the URLs in /docs and openapi.json.
+app = FastAPI(lifespan=lifespan, root_path=os.getenv("API_ROOT_PATH", ""))
 
 # Allow the local Vite dev server (and preview) to call the API from the browser.
+# 5174 is the conventional second port: Vite falls back to it when 5173 is taken,
+# which is what a git worktree running its own dev server alongside the primary
+# one gets. Without it that server returns no data at all and the app looks
+# broken for a reason unrelated to the code under test.
+# Hosted builds don't depend on any of this — the container serves the SPA and
+# the API from a single origin, so there is no cross-origin request to allow.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:5173",
         "http://127.0.0.1:5173",
+        "http://localhost:5174",
+        "http://127.0.0.1:5174",
     ],
     allow_credentials=True,
     allow_methods=["*"],
@@ -109,8 +67,28 @@ app.include_router(tricklinekit_router)
 app.include_router(webbing_router)
 app.include_router(weblock_router)
 
-@app.get("/")
-def root():
-    return {"message": "Welcome to SlackData"}
+# Serve the built React SPA (frontend/dist) from the same origin as the API, so
+# the whole app can ship as a single container with no CORS. This is only wired
+# up when a production build is present — the hosted serverless deploy serves the
+# SPA from S3/CloudFront instead (no dist in the Lambda image), and backend-only
+# runs (plus the pytest app in tests/conftest.py) skip it entirely.
+_DIST_DEFAULT = Path(__file__).resolve().parent.parent / "frontend" / "dist"
+FRONTEND_DIST = Path(os.getenv("FRONTEND_DIST", str(_DIST_DEFAULT))).resolve()
 
+if FRONTEND_DIST.is_dir():
+    _INDEX_HTML = FRONTEND_DIST / "index.html"
 
+    @app.get("/{full_path:path}", include_in_schema=False)
+    def serve_spa(full_path: str):
+        # A request for a real built asset (JS/CSS/images/icons/flags) → serve the
+        # file; anything else → index.html so client-side routes survive a refresh.
+        # The API routers are registered above and take precedence over this
+        # catch-all, so JSON endpoints are never shadowed.
+        candidate = (FRONTEND_DIST / full_path).resolve()
+        if candidate.is_file() and FRONTEND_DIST in candidate.parents:
+            return FileResponse(candidate)
+        return FileResponse(_INDEX_HTML)
+else:
+    @app.get("/")
+    def root():
+        return {"message": "Welcome to SlackData"}

--- a/slack_data/seed.py
+++ b/slack_data/seed.py
@@ -1,0 +1,83 @@
+"""Catalog seeding — populate the SQLite catalog from the root *.json files.
+
+This is the single source of the load sequence, used two ways:
+
+- **Local/dev:** called from ``main.py``'s lifespan on first boot, against a
+  writable ``database.db``.
+- **Hosted build:** called by ``scripts/build_catalog_db.py`` to bake the
+  read-only catalog that ships inside the Lambda package.
+
+Importing this module also imports every table model + loader, so
+``SQLModel.metadata`` is complete (used by the build script's ``create_all``).
+"""
+
+from sqlmodel import Session, select
+
+from slack_data.load_data.load_grips import load_grips
+from slack_data.load_data.load_leashrings import load_leashrings
+from slack_data.load_data.load_manufacturers import load_manufacturers
+from slack_data.load_data.load_rollers import load_rollers
+from slack_data.load_data.load_starterkits import load_starterkits
+from slack_data.load_data.load_treepros import load_treepros
+from slack_data.load_data.load_tricklinekits import load_tricklinekits
+from slack_data.load_data.load_webbings import load_webbings
+from slack_data.load_data.load_weblocks import load_weblocks
+
+from slack_data.models.brands import Brand
+from slack_data.models.grips import Grip
+from slack_data.models.leashrings import LeashRing
+from slack_data.models.rollers import Roller
+from slack_data.models.starterkits import StarterKit
+from slack_data.models.treepro import TreePro
+from slack_data.models.tricklinekits import TricklineKit
+from slack_data.models.webbing import Webbing
+from slack_data.models.weblocks import Weblock
+
+
+def seed_catalog(session: Session) -> None:
+    """Load every gear type into ``session``'s database, then enrich brands.
+
+    Each gear type is skipped if its table already holds rows, so this is safe
+    to call against an already-seeded database (a no-op)."""
+    existing_webbings = session.exec(select(Webbing)).first()
+    if existing_webbings is None: # Only load from `webbings.json` if the database is empty
+        print("Loading webbing data into the database...")
+        load_webbings(session=session)
+    existing_weblocks = session.exec(select(Weblock)).first()
+    if existing_weblocks is None: # Only load from `webbings.json` if the database is empty
+        print("Loading weblocks data into the database...")
+        load_weblocks(session=session)
+    existing_rollers = session.exec(select(Roller)).first()
+    if existing_rollers is None: # Only load from `rollers.json` if the database is empty
+        print("Loading roller data into the database...")
+        load_rollers(session=session)
+    existing_leashrings = session.exec(select(LeashRing)).first()
+    if existing_leashrings is None: # Only load from `leashrings.json` if the database is empty
+        print("Loading leash ring data into the database...")
+        load_leashrings(session=session)
+    existing_grips = session.exec(select(Grip)).first()
+    if existing_grips is None: # Only load from `grips.json` if the database is empty
+        print("Loading grip data into the database...")
+        load_grips(session=session)
+    existing_treepros = session.exec(select(TreePro)).first()
+    if existing_treepros is None: # Only load from `treepros.json` if the database is empty
+        print("Loading treepro data into the database...")
+        load_treepros(session=session)
+    existing_starterkits = session.exec(select(StarterKit)).first()
+    if existing_starterkits is None: # Only load from `starterkits.json` if the database is empty
+        print("Loading starter kit data into the database...")
+        load_starterkits(session=session)
+    existing_tricklinekits = session.exec(select(TricklineKit)).first()
+    if existing_tricklinekits is None: # Only load from `tricklinekits.json` if the database is empty
+        print("Loading trickline kit data into the database...")
+        load_tricklinekits(session=session)
+    # MUST come last: Brand rows are created by the gear loaders above (via
+    # get_brand(), name-only), and this pass backfills their metadata. Gated on
+    # "no brand has a country yet" rather than on an empty table, because the
+    # table is never empty by this point.
+    needs_enrichment = session.exec(
+        select(Brand).where(Brand.country.is_not(None))
+    ).first() is None
+    if needs_enrichment:
+        print("Enriching brands from manufacturers.json...")
+        load_manufacturers(session=session)


### PR DESCRIPTION
Packages the app for hosting. Nothing here changes gear data or the UI.

## Backend restructure

- Lifespan seeding moves out of `main.py` into `slack_data/seed.py` (`seed_catalog`), so the same logic serves dev boot and the catalog pre-build.
- `database.py` gains a `READ_ONLY` mode: hosted deploys ship a pre-built SQLite catalog (`scripts/build_catalog_db.py`) instead of seeding from the root JSON at boot.
- `main.py` serves the built SPA from the API origin when `frontend/dist` is present, so the container is single-origin with no CORS. Backend-only runs and the pytest app skip it.
- `root_path` via `API_ROOT_PATH` lets the API sit behind a `/api` prefix without touching any route.
- CORS additionally allows :5174 (the port a second worktree's Vite dev server lands on).

## Packaging

`Dockerfile` (single self-contained container), `Dockerfile.lambda` + `slack_data/lambda_handler.py` (mangum), `infra/` (serverless.yml, CloudFront api-prefix-strip function, README), `frontend/.env.production`, and `GOING_LIVE.md` describing the deploy.

Adds `mangum>=0.17` to dependencies.

Not yet deployed or smoke-tested end to end; review as the plan rather than as a proven rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)